### PR TITLE
feature/103

### DIFF
--- a/assets/airports/airportLoadList.js
+++ b/assets/airports/airportLoadList.js
@@ -247,6 +247,11 @@ window.AIRPORT_LOAD_LIST = (function() { // eslint-disable-line wrap-iife
             name: 'Doha Hamad International Airport'
         },
         {
+            icao: 'rjaa',
+            level: 'hard',
+            name: 'Tokyo Narita International Airport'
+        },
+        {
             icao: 'rjtt',
             level: 'hard',
             name: 'Tokyo Haneda International Airport'

--- a/assets/airports/rjaa.json
+++ b/assets/airports/rjaa.json
@@ -1,0 +1,897 @@
+{
+    "radio": {
+        "twr": "Narita Tower",
+        "app": "Tokyo Approach",
+        "dep": "Tokyo Departure"
+    },
+    "icao": "RJAA",
+    "iata": "NRT",
+    "magnetic_north": 0,
+    "ctr_radius": 80,
+    "ctr_ceiling": 27000,
+    "initial_alt": 3000,
+    "position": ["N35d45m55.00", "E140d23m08.00"],
+    "rr_radius_nm": 5.0,
+    "rr_center": ["N35d45m55.00", "E140d23m08.00"],
+    "has_terrain": false,
+    "wind": {
+        "angle": 250,
+        "speed": 0
+    },
+    "airspace": [
+        {
+            "floor": 			0,
+            "ceiling": 		    27000,
+            "airspace_class":	"E",
+            "poly":
+            [
+                ["N35d51m58.00", "E139d49m52.00"],
+                ["N36d12m12.00", "E139d58m06.00"],
+                ["N36d12m17.00", "E140d08m32.00"],
+                ["N36d06m23.00", "E140d18m45.00"],
+                ["N36d06m26.00", "E140d29m05.00"],
+                ["N35d58m00.00", "E140d32m48.00"],
+                ["N35d42m38.00", "E140d54m07.00"],
+                ["N35d36m23.00", "E140d50m04.00"],
+                ["N35d09m27.00", "E140d32m47.00"],
+                ["N35d04m49.00", "E139d56m19.00"]
+            ]
+        }
+    ],
+    "fixes": {
+        "A4L11":    ["N35d59m15.60", "E140d12m49.10"],
+        "A4L12":    ["N36d02m32.60", "E140d16m46.80"],
+        "A4L13":    ["N36d02m36.70", "E140d25m59.70"],
+        "A4L14":    ["N35d59m37.80", "E140d32m05.00"],
+        "A4R21":    ["N35d55m29.40", "E140d17m29.20"],
+        "A4R22":    ["N35d57m34.50", "E140d21m50.10"],
+        "A4R23":    ["N35d56m38.80", "E140d26m14.70"],
+        "A4R24":    ["N35d52m15.20", "E140d26m45.60"],
+        "A6L21":    ["N35d31m37.90", "E140d34m41.90"],
+        "A6L22":    ["N35d26m24.60", "E140d38m26.30"],
+        "A6R11":    ["N35d30m56.90", "E140d33m16.20"],
+        "A6R12":    ["N35d25m43.50", "E140d37m00.70"],
+        "A6R13":    ["N35d26m54.90", "E140d24m52.60"],
+        "A6R14":    ["N35d33m24.70", "E140d20m11.90"],
+        "AA433":    ["N35d44m38.50", "E140d17m00.80"],
+        "AA631":    ["N35d36m19.90", "E140d44m31.90"],
+        "AA632":    ["N35d44m46.70", "E140d38m28.90"],
+        "ABBOT":    ["N35d49m23.00", "E141d05m12.00"],
+        "ARIES":    ["N35d56m07.40", "E140d15m05.90"],
+        "AKAGI":    ["N36d23m47.00", "E139d41m94.00"],
+        "ARWEN":    ["N36d15m47.00", "E139d50m73.00"],
+        "ASPEN":    ["N35d34m51.00", "E140d30m28.10"],
+        "ASTRA":    ["N35d52m07.10", "E140d18m00.20"],
+        "ATAGO":    ["N35d47m00.90", "E140d15m46.80"],
+        "BEACH":    ["N35d24m08.50", "E139d54m12.40"],
+        "BEAMS":    ["N35d35m33.00", "E140d31m53.10"],
+        "BINKS":    ["N35d11m16.30", "E140d43m56.70"],
+        "BOXER":    ["N35d52m13.00", "E140d19m51.60"],
+        "CETUS":    ["N35d36m09.80", "E140d48m13.20"],
+        "CLUST":    ["N35d51m50.90", "E140d44m41.40"],
+        "CREEK":    ["N35d56m72.00", "E140d16m59.00"],
+        "CUPID":    ["N35d29m30.30", "E141d05m57.30"],
+        "DAITO":    ["N35d21m53.60", "E140d30m39.00"],
+        "DANTE":    ["N36d07m28.00", "E140d28m37.00"],
+        "ELGAR":    ["N35d31m29.20", "E140d45m27.40"],
+        "GEMIN":    ["N35d57m38.60", "E140d24m50.70"],
+        "GIINA":    ["N35d31m34.00", "E140d32m99.00"],
+        "GIMLI":    ["N35d44m57.60", "E140d29m34.40"],
+        "GOTEN":    ["N35d13m42.00", "E138d43m37.00"],
+        "HKE":      ["N35d48m51.00", "E140d22m18.00"],
+        "HME":      ["N35d33m44.00", "E139d45m40.00"],
+        "INUBO":    ["N35d43m35.30", "E140d47m57.90"],
+        "JELLY":    ["N35d41m32.60", "E140d44m19.70"],
+        "JYOSO":    ["N36d16m46.40", "E139d51m09.50"],
+        "KUJYU":    ["N35d21m04.00", "E140d27m19.80"],
+        "LAKES":    ["N35d57m85.00", "E140d30m02.00"],
+        "MELON":    ["N35d50m57.10", "E140d51m51.20"],
+        "MERCY":    ["N35d03m24.80", "E140d31m20.90"],
+        "METIS":    ["N35d59m76.00", "E140d14m38.00"],
+        "NORMA":    ["N35d59m00.80", "E140d32m54.00"],
+        "NRE":      ["N35d46m56.00", "E140d21m45.00"],
+        "PAPAS":    ["N35d22m41.50", "E140d56m58.60"],
+        "PEGAS":    ["N35d51m26.30", "E140d33m02.10"],
+        "PHLOX":    ["N35d45m56.60", "E140d22m46.10"],
+        "ROUGE":    ["N35d17m35.90", "E140d44m43.70"],
+        "ROUSY":    ["N35d22m40.00", "E140d56m67.00"],
+        "SAMMY":    ["N35d35m26.70", "E140d20m42.00"],
+        "SEDNA":    ["N35d42m48.80", "E140d49m10.40"],
+        "SOHSA":    ["N35d40m31.70", "E140d37m47.70"],
+        "SUNNS":    ["N34d48m27.00", "E141d44m28.00"],
+        "SWAMP":    ["N36d19m24.00", "E140d32m28.00"],
+        "SZE":      ["N34d47m49.00", "E138d11m36.00"],
+        "TEMIS":    ["N35d32m03.00", "E140d34m41.00"],
+        "TETRA":    ["N35d46m44.00", "E140d15m93.00"],
+        "TOADS":    ["N36d02m49.30", "E140d10m13.50"],
+        "TWINS":    ["N35d49m55.80", "E140d37m34.00"],
+        "TYLER":    ["N35d26m50.50", "E140d38m07.80"],
+        "WEBBS":    ["N35d48m33.00", "E140d47m52.00"] 
+    },
+
+    "runways": [
+        {
+            "name": ["16L", "34R"],
+            "name_offset": [[0, 0], [0, 0]],
+            "end": [["N35d48m18.72", "E140d22m41.19"], ["N35d47m08.82", "E140d23m31.72"]],
+            "length": 4.000,
+            "ils": [true, true]
+        },
+        {
+            "name": ["16R", "34L"],
+            "name_offset": [[0, 0], [0, 0]],
+            "end": [["N35d46m27.80", "E140d22m05.85"], ["N35d44m35.96", "E140d23m26.66"]],
+            "length": 2.500,
+            "ils": [true, true]
+        }
+    ],
+    "sids": {
+        "TETRA6": {
+            "icao": "TETRA6",
+            "name": "Tetra Six",
+            "rwy": {
+                "16L": ["BEAMS", "A6L21", "AA631", "AA632", "PHLOX", ["TETRA", "A120+"]],
+                "16R": ["ASPEN", "A6R11", "AA631", "AA632", "PHLOX", ["TETRA", "A120+"]],
+                "34L": [["ARIES", "A40+"], "A4L11", "A4L12", ["A4L13", "A70"], "A4L14", "PEGAS", "PHLOX", ["TETRA", "A120+"]],
+                "34R": ["BOXER", "A4R21", "A4R22", ["A4R23", "A70"], "A4R24", "PHLOX", ["TETRA", "A120+"]]
+            },
+            "draw": [
+                ["BEAMS", "A6L21", "AA631", "AA632", "PHLOX", "TETRA"],
+                ["ASPEN", "A6R11", "AA631"],
+                ["ARIES", "A4L11", "A4L12", "A4L13", "A4L13", "A4L14", "PEGAS", "PHLOX"],
+                ["BOXER", "A4R21", "A4R22", "A4R23", "A4R24", "PHLOX"],
+                ["TETRA"]
+            ]
+        },
+        "BEACH1": {
+            "icao": "BEACH1",
+            "name": "Beach 1",
+            "rwy": {
+                "16L": ["BEAMS", "A6L22", ["KUJYU", "A110+"], ["BEACH", "A200+"]],
+                "16R": ["ASPEN", "A6R12", ["KUJYU", "A110+"], ["BEACH", "A200+"]],
+                "34L": [["ARIES", "A40+"], "A4L11", "A4L12", ["A4L13", "A70"], "A4L14", "PEGAS", "GIMLI", ["SAMMY", "A110+"], ["BEACH", "A200+"]],
+                "34R": ["BOXER", "A4R21", "A4R22", ["A4R23", "A70"], "A4R24", ["SAMMY", "A110+"], ["BEACH", "A200+"]]
+            },
+            "draw": [
+                ["BEAMS", "A6L22", "KUJYU", "BEACH"],
+                ["ASPEN", "A6R12", "KUJYU"],
+                ["A4L14", "PEGAS", "GIMLI", "SAMMY", "BEACH"],
+                ["A4R24", "SAMMY"],
+                ["BEACH"]
+            ]
+        },
+        "JYOSO7": {
+            "icao": "JYOSO7",
+            "name": "Jyoso Seven",
+            "rwy": {
+                "16L": ["BEAMS", "A6L21", "AA631", "AA632", "PHLOX", "ATAGO", "TOADS", ["JYOSO", "A70"]],
+                "16R": ["ASPEN", "A6R11", "A6R13", "A6R14", "ATAGO", "TOADS", ["JYOSO", "A70"]],
+                "34L": [["ARIES", "A40+"], "TOADS", ["JYOSO", "A70"]],
+                "34R": ["BOXER", "A4R21", "A4R22", "A4R23", "A4R24", "PHLOX", "ATAGO", "TOADS", ["JYOSO", "A70"]]
+            },
+            "draw": [
+                ["PHLOX", "ATAGO", "TOADS", "JYOSO"],
+                ["A6R11", "A6R13", "A6R14", "ATAGO"],
+                ["ARIES", "TOADS"],
+                ["JYOSO"]
+            ]
+        },
+        "PAPAS5": {
+            "icao": "PAPAS5",
+            "name": "Papas Five",
+            "rwy": {
+                "16L": ["BEAMS", "A6L21", ["PAPAS", "A70+"]],
+                "16R": ["ASPEN", "A6R12", ["PAPAS", "A70+"]],
+                "34L": [["ARIES", "A40+"], "A4L11", "A4L12", ["A4L13", "A70"], "A4L14", "JELLY", ["PAPAS", "A70+"]],
+                "34R": ["BOXER", "A4R21", "A4R22", "A4R23", "SOHSA", ["PAPAS", "A70+"]]
+            },
+            "draw": [
+                ["A6L21", "PAPAS"],
+                ["A6R12", "PAPAS"],
+                ["A4L14", "JELLY", "PAPAS"],
+                ["A4R23", "SOHSA", "PAPAS"]
+            ]
+        },
+        "CUPID3": {
+            "icao": "CUPID3",
+            "name": "Cupid Three",
+            "rwy": {
+                "16L": ["BEAMS", "A6L21", "CUPID"],
+                "16R": ["ASPEN", "A6R12", "CUPID"],
+                "34L": [["ARIES", "A40+"], "A4L11", "A4L12", ["A4L13", "A70"], "A4L14", "JELLY", "CUPID"],
+                "34R": ["BOXER", "A4R21", "A4R22", ["A4R23", "A70"], "SOHSA", "CUPID"]
+            },
+            "draw": [
+                ["A6L21", "CUPID"],
+                ["A6R12", "CUPID"],
+                ["JELLY", "CUPID"],
+                ["SOHSA", "CUPID"]
+            ]
+        },
+        "DAITO2": {
+            "icao": "DAITO2",
+            "name": "Daito Two",
+            "rwy": {
+                "16L": ["BEAMS", "A6L22", "DAITO", "MERCY"],
+                "16R": ["ASPEN", "A6R12", "DAITO", "MERCY"],
+                "34L": ["ASTRA", "AA433", "DAITO", "MERCY"],
+                "34R": ["BOXER", "AA433", "DAITO", "MERCY"]
+            },
+            "draw": [
+                ["A6L22", "DAITO", "MERCY"],
+                ["A6R12", "DAITO"],
+                ["ASTRA", "AA433", "DAITO"],
+                ["BOXER", "AA433"],
+                ["MERCY"]
+            ]
+        },
+        "SAKURA4": {
+            "icao": "SAKURA4",
+            "name": "Sakura Four",
+            "transitions": {
+                "GOTEN": [["HME", "A200+"], ["GOTEN", "A240+"]],
+                "SHIZUOKA": [["HME", "A200+"], "SZE"]
+            },
+            "rwy": {
+                "16L": ["NRE", ["TETRA", "A120+"]],
+                "16R": ["NRE", ["TETRA", "A120+"]],
+                "34L": ["HKE", "NRE", ["TETRA", "A120+"]],
+                "34R": ["HKE", "NRE", ["TETRA", "A120+"]]
+            },
+            "draw": [
+                ["NRE", "TETRA"],
+                ["HKE", "NRE", "TETRA"],
+                ["TETRA", "HME"],
+                ["HME", "GOTEN*"],
+                ["HME", "SZE*"]
+            ]
+        },
+        "AKAGI2": {
+            "icao": "AKAGI2",
+            "name": "Akagi Two",
+            "rwy": {
+                "16L": [["ARWEN", "A70"], "AKAGI"],
+                "16R": [["ARWEN", "A70"], "AKAGI"],
+                "34L": [["ARIES", "A40+"], "TOADS", ["ARWEN", "A70"], "AKAGI"],
+                "34R": [["CREEK", "A40+"], "METIS", ["ARWEN", "A70"], "AKAGI"]
+            },
+            "draw": [
+                ["ARWEN", "AKAGI"],
+                ["ARIES", "TOADS", "ARWEN"],
+                ["CREEK", "METIS", "ARWEN"],
+                ["AKAGI"]
+            ]
+        },
+        "ROUSY2": {
+            "icao": "ROUSY2",
+            "name": "Rousy Two",
+            "transitions": {
+                "SUNNS": [["SUNNS", "A190+"]]
+            },
+            "rwy": {
+                "16L": [["ROUSY", "A70+"]],
+                "16R": [["ROUSY", "A70+"]],
+                "34L": [["NRE", "A28+"], ["ROUSY", "A70+"]],
+                "34R": [["HKE", "A28+"], ["ROUSY", "A70+"]]
+            },
+            "draw": [
+                ["NRE", "HKE", "ROUSY", "SUNNS*"]
+            ]
+        }
+    },
+
+    "stars": {
+        "NORMA": {
+            "icao": "NORMA",
+            "name": "Norma",
+            "transitions": {
+                "MELON": ["MELON"]
+            },
+            "body": ["CLUST", "NORMA"],
+            "draw": [
+                ["MELON", "CLUST", "NORMA"]
+            ]
+        },
+        "GEMIN": {
+            "icao": "GEMIN",
+            "name": "Gemin",
+            "transitions": {
+                "BINKS": ["BINKS"]
+            },
+            "body": ["CETUS", "INUBO", "TWINS", "GEMIN"],
+            "draw": [
+                ["BINKS", "CETUS", "INUBO", "TWINS", "GEMIN"]
+            ]
+        },
+        "ABBOT_SOUTH_A": {
+            "icao": "ABBOT SOUTH A",
+            "name": "Abbot South Alfa",
+            "transitions": {
+                "ABBOT": ["ABBOT"]
+            },
+            "body": ["WEBBS", ["GIINA", "A40"]],
+            "draw": [
+                ["ABBOT", "WEBBS", "GIINA"]
+            ]
+        },
+        "ABBOT_SOUTH_B": {
+            "icao": "ABBOT SOUTH B",
+            "name": "Abbot South Bravo",
+            "transitions": {
+                "ABBOT": ["ABBOT"]
+            },
+            "body": ["WEBBS", ["TEMIS", "A50"]],
+            "draw": [
+                ["ABBOT", "WEBBS", "TEMIS"]
+            ]
+        },
+        "BINKS_SOUTH_A": {
+            "icao": "BINKS SOUTH A",
+            "name": "Binks South Alfa",
+            "transitions": {
+                "BINKS": ["BINKS"]
+            },
+            "body": [["GIINA", "A40"]],
+            "draw": [
+                ["BINKS", "GIINA"]
+            ]
+        },
+        "BINKS_SOUTH_B": {
+            "icao": "BINKS SOUTH B",
+            "name": "Binks South Bravo",
+            "transitions": {
+                "BINKS": ["BINKS"]
+            },
+            "body": [["TEMIS", "A50"]],
+            "draw": [
+                ["BINKS", "BINKS"]
+            ]
+        },
+        "SWAMP_SOUTH_A": {
+            "icao": "SWAMP SOUTH A",
+            "name": "Swamp South Alfa",
+            "transitions": {
+                "SWAMP": ["SWAMP"]
+            },
+            "body": [["DANTE", "A110"], ["WEBBS", "A90"], ["GIINA", "A40"]],
+            "draw": [   
+                ["SWAMP", "DANTE", "WEBBS", "GIINA"]
+            ]
+        },
+        "SWAMP_SOUTH_B": {
+            "icao": "SWAMP SOUTH B",
+            "name": "Swamp South Bravo",
+            "transitions": {
+                "SWAMP": ["SWAMP"]
+            },
+            "body": [["DANTE", "A110"], ["WEBBS", "A90"], ["TEMIS", "A50"]],
+            "draw": [
+                ["SWAMP", "DANTE", "WEBBS", "TEMIS"]
+            ]
+        },
+        "ABBOT_NORTH": {
+            "icao": "ABBOT NORTH",
+            "name": "Abbot North",
+            "transitions": {
+                "ABBOT": ["ABBOT"]
+            },
+            "body": ["WEBBS", ["LAKES", "A60"]],
+            "draw": [
+                ["ABBOT", "WEBBS", "LAKES"]
+            ]
+        },
+        "SWAMP_NORTH": {
+            "icao": "SWAMP NORTH",
+            "name": "Swamp North",
+            "transitions": {
+                "SWAMP": ["SWAMP"]
+            },
+            "body": [["DANTE", "A110"], ["WEBBS", "A90"], ["LAKES", "A60"]],
+            "draw": [
+                ["SWAMP", "DANTE", "WEBBS", "LAKES"]
+            ]
+        },
+        "LAKES": {
+            "icao": "LAKES",
+            "name": "Lakes",
+            "transitions": {
+                "BINKS": ["BINKS"]
+            },
+            "body": ["WEBBS", ["LAKES", "A60"]],
+            "draw": [
+                ["BINKS", "WEBBS", "LAKES"]
+            ]
+        },
+        "ELGAR": {
+            "icao": "ELGAR",
+            "name": "Elgar",
+            "transitions": {
+                "MELON": ["MELON"]
+            },
+            "body": ["SEDNA", "ELGAR"],
+            "draw": [
+                ["MELON", "SEDNA", "ELGAR"]
+            ]
+        },
+        "TYLER": {
+            "icao": "TYLER",
+            "name": "Tyler",
+            "transitions": {
+                "BINKS": ["BINKS"]
+            },
+            "body": ["ROUGE", "TYLER"],
+            "draw": [
+                ["BINKS", "ROUGE", "TYLER"]
+            ]
+        }
+    },
+
+    "departures": {
+        "airlines": [
+            ["afl",  1],
+            ["amx",  1],
+            ["aca",  3],
+            ["cca",  7],
+            ["afr",  2],
+            ["aic",  1],
+            ["aza",  2],
+            ["ana", 54],
+            ["aal",  3],
+            ["aua",  1],
+            ["baw",  1],
+            ["cpa",  3],
+            ["ces",  3],
+            ["csn",  7],
+            ["dal", 17],
+            ["uae",  2],
+            ["etd",  1],
+            ["eva",  2],
+            ["gia",  2],
+            ["hal",  1],
+            ["ibe",  1],
+            ["jal", 34],
+            ["jjp", 12],
+            ["klm",  2],
+            ["kal",  5],
+            ["dlh",  3],
+            ["mas",  5],
+            ["qfa",  1],
+            ["qtr",  1],
+            ["sbi",  2],
+            ["sas",  2],
+            ["sco",  3],
+            ["sia",  2],
+            ["sjo",  4],
+            ["swr",  2],
+            ["thy",  1],
+            ["ual", 10],
+            ["fdx",  4],
+            ["nca", 16],
+            ["sqc",  2],
+            ["ups",  4]
+        ],
+        "destinations": [
+            "TETRA6",
+            "BEACH1",
+            "JYOSO7",
+            "PAPAS5",
+            "CUPID3",
+            "DAITO2",
+            "SAKURA4",
+            "AKAGI2",
+            "ROUSY2"
+        ],
+        "type": "random",
+        "offset": 0,
+        "frequency": 67
+    },
+    "arrivals": [
+        {
+            "type": 		"cyclic",
+            "route":        "MELON.NORMA.RJAA",
+            "frequency":    6,
+            "altitude":     14000,
+            "speed":		240,
+            "offset":		2,
+            "airlines": [
+                    ["amx",  1],
+                    ["aca",  3],
+                    ["ana", 54],
+                    ["aal",  3],
+                    ["dal", 17],
+                    ["hal",  1],
+                    ["jal", 34],
+                    ["sia",  2],
+                    ["ual", 10],
+                    ["fdx",  4],
+                    ["nca", 16],
+                    ["ups",  4],
+                    ["apj",  4],
+                    ["vnl",  6]
+                ]
+        },
+        {
+            "type": 		"cyclic",
+            "route":        "MELON.ELGAR.RJAA",
+            "frequency":    4,
+            "altitude":     14000,
+            "speed":		240,
+            "offset":		2,
+            "airlines": [
+                    ["amx",  1],
+                    ["aca",  3],
+                    ["ana", 54],
+                    ["aal",  3],
+                    ["dal", 17],
+                    ["hal",  1],
+                    ["jal", 34],
+                    ["sia",  2],
+                    ["ual", 10],
+                    ["fdx",  4],
+                    ["nca", 16],
+                    ["ups",  4],
+                    ["apj",  4],
+                    ["vnl",  6]
+                ]
+        },
+        {
+            "type": 		"cyclic",
+            "route":        "BINKS.GEMIN.RJAA",
+            "frequency":    7,
+            "altitude":     14000,
+            "speed":		230,
+            "offset":		2,
+            "airlines": [
+                    ["amx",  1],
+                    ["aza",  2],
+                    ["ana", 54],
+                    ["dal", 17],
+                    ["hal",  1],
+                    ["jal", 34],
+                    ["qfa",  1],
+                    ["sjo",  4],
+                    ["ual", 10],
+                    ["fdx",  4],
+                    ["nca", 16],
+                    ["ups",  4],
+                    ["aic",  1],
+                    ["uae",  2],
+                    ["etd",  1],
+                    ["eva",  2],
+                    ["gia",  2],
+                    ["kal",  5],
+                    ["mas",  5],
+                    ["qtr",  1],
+                    ["sco",  3],
+                    ["sia",  2],
+                    ["apj",  4],
+                    ["vnl",  6]
+                ]
+        },
+        {
+            "type": 		"cyclic",
+            "route":        "BINKS.BINKS_SOUTH_A.RJAA",
+            "frequency":    3,
+            "altitude":     14000,
+            "speed":		230,
+            "offset":		2,
+            "airlines": [
+                    ["amx",  1],
+                    ["aza",  2],
+                    ["ana", 54],
+                    ["dal", 17],
+                    ["hal",  1],
+                    ["jal", 34],
+                    ["qfa",  1],
+                    ["sjo",  4],
+                    ["ual", 10],
+                    ["fdx",  4],
+                    ["nca", 16],
+                    ["ups",  4],
+                    ["aic",  1],
+                    ["uae",  2],
+                    ["etd",  1],
+                    ["eva",  2],
+                    ["gia",  2],
+                    ["kal",  5],
+                    ["mas",  5],
+                    ["qtr",  1],
+                    ["sco",  3],
+                    ["sia",  2],
+                    ["apj",  4],
+                    ["vnl",  6]
+                ]
+        },
+        {
+            "type": 		"cyclic",
+            "route":        "BINKS.BINKS_SOUTH_B.RJAA",
+            "frequency":    3,
+            "altitude":     14000,
+            "speed":		230,
+            "offset":		2,
+            "airlines": [
+                    ["amx",  1],
+                    ["aza",  2],
+                    ["ana", 54],
+                    ["dal", 17],
+                    ["hal",  1],
+                    ["jal", 34],
+                    ["qfa",  1],
+                    ["sjo",  4],
+                    ["ual", 10],
+                    ["fdx",  4],
+                    ["nca", 16],
+                    ["ups",  4],
+                    ["aic",  1],
+                    ["uae",  2],
+                    ["etd",  1],
+                    ["eva",  2],
+                    ["gia",  2],
+                    ["kal",  5],
+                    ["mas",  5],
+                    ["qtr",  1],
+                    ["sco",  3],
+                    ["sia",  2],
+                    ["apj",  4],
+                    ["vnl",  6]
+                ]
+        },
+        {
+            "type": 		"cyclic",
+            "route":        "BINKS.LAKES.RJAA",
+            "frequency":    3,
+            "altitude":     14000,
+            "speed":		230,
+            "offset":		2,
+            "airlines": [
+                    ["amx",  1],
+                    ["aza",  2],
+                    ["ana", 54],
+                    ["dal", 17],
+                    ["hal",  1],
+                    ["jal", 34],
+                    ["qfa",  1],
+                    ["sjo",  4],
+                    ["ual", 10],
+                    ["fdx",  4],
+                    ["nca", 16],
+                    ["ups",  4],
+                    ["aic",  1],
+                    ["uae",  2],
+                    ["etd",  1],
+                    ["eva",  2],
+                    ["gia",  2],
+                    ["kal",  5],
+                    ["mas",  5],
+                    ["qtr",  1],
+                    ["sco",  3],
+                    ["sia",  2],
+                    ["apj",  4],
+                    ["vnl",  6]
+                ]
+        },
+        {
+            "type": 		"cyclic",
+            "route":        "BINKS.TYLER.RJAA",
+            "frequency":    3,
+            "altitude":     14000,
+            "speed":		230,
+            "offset":		2,
+            "airlines": [
+                    ["amx",  1],
+                    ["aza",  2],
+                    ["ana", 54],
+                    ["dal", 17],
+                    ["hal",  1],
+                    ["jal", 34],
+                    ["qfa",  1],
+                    ["sjo",  4],
+                    ["ual", 10],
+                    ["fdx",  4],
+                    ["nca", 16],
+                    ["ups",  4],
+                    ["aic",  1],
+                    ["uae",  2],
+                    ["etd",  1],
+                    ["eva",  2],
+                    ["gia",  2],
+                    ["kal",  5],
+                    ["mas",  5],
+                    ["qtr",  1],
+                    ["sco",  3],
+                    ["sia",  2],
+                    ["apj",  4],
+                    ["vnl",  6]
+                ]
+        },
+        {
+            "type": 		"cyclic",
+            "route":        "ABBOT.ABBOT_SOUTH_A.RJAA",
+            "frequency":    5,
+            "altitude":     10000,
+            "speed":		250,
+            "offset":		2,
+            "airlines": [
+                    ["amx",  1],
+                    ["aca",  3],
+                    ["ana", 54],
+                    ["aal",  3],
+                    ["dal", 17],
+                    ["hal",  1],
+                    ["jal", 34],
+                    ["sia",  2],
+                    ["ual", 10],
+                    ["fdx",  4],
+                    ["nca", 16],
+                    ["ups",  4],
+                    ["apj",  4],
+                    ["vnl",  6]
+                ]
+        },
+        {
+            "type": 		"cyclic",
+            "route":        "ABBOT.ABBOT_SOUTH_B.RJAA",
+            "frequency":    3,
+            "altitude":     10000,
+            "speed":		250,
+            "offset":		2,
+            "airlines": [
+                    ["amx",  1],
+                    ["aca",  3],
+                    ["ana", 54],
+                    ["aal",  3],
+                    ["dal", 17],
+                    ["hal",  1],
+                    ["jal", 34],
+                    ["sia",  2],
+                    ["ual", 10],
+                    ["fdx",  4],
+                    ["nca", 16],
+                    ["ups",  4],
+                    ["apj",  4],
+                    ["vnl",  6]
+                ]
+        },
+        {
+            "type": 		"cyclic",
+            "route":        "ABBOT.ABBOT_NORTH.RJAA",
+            "frequency":    6,
+            "altitude":     10000,
+            "speed":		250,
+            "offset":		2,
+            "airlines": [
+                    ["amx",  1],
+                    ["aca",  3],
+                    ["ana", 54],
+                    ["aal",  3],
+                    ["dal", 17],
+                    ["hal",  1],
+                    ["jal", 34],
+                    ["sia",  2],
+                    ["ual", 10],
+                    ["fdx",  4],
+                    ["nca", 16],
+                    ["ups",  4],
+                    ["apj",  4],
+                    ["vnl",  6]
+                ]
+        },
+        {
+            "type": 		"cyclic",
+            "route":        "SWAMP.SWAMP_SOUTH_B.RJAA",
+            "frequency":    9,
+            "altitude":     12000,
+            "speed":		250,
+            "offset":		2,
+            "airlines": [
+                    ["afl",  1],
+                    ["aca",  3],
+                    ["cca",  7],
+                    ["afr",  2],
+                    ["ana", 54],
+                    ["aal",  3],
+                    ["aua",  1],
+                    ["baw",  1],
+                    ["cpa",  3],
+                    ["ces",  3],
+                    ["csn",  7],
+                    ["dal", 17],
+                    ["ibe",  1],
+                    ["jal", 34],
+                    ["jjp", 12],
+                    ["klm",  2],
+                    ["dlh",  3],
+                    ["sbi",  2],
+                    ["sas",  2],
+                    ["sjo",  4],
+                    ["swr",  2],
+                    ["thy",  1],
+                    ["ual", 10],
+                    ["fdx",  4],
+                    ["nca", 16],
+                    ["sqc",  2],
+                    ["ups",  4],
+                    ["apj",  4],
+                    ["vnl",  6]
+                ]
+        },
+        {
+            "type": 		"cyclic",
+            "route":        "SWAMP.SWAMP_SOUTH_A.RJAA",
+            "frequency":    8,
+            "altitude":     12000,
+            "speed":		250,
+            "offset":		2,
+            "airlines": [
+                    ["afl",  1],
+                    ["aca",  3],
+                    ["cca",  7],
+                    ["afr",  2],
+                    ["ana", 54],
+                    ["aal",  3],
+                    ["aua",  1],
+                    ["baw",  1],
+                    ["cpa",  3],
+                    ["ces",  3],
+                    ["csn",  7],
+                    ["dal", 17],
+                    ["ibe",  1],
+                    ["jal", 34],
+                    ["jjp", 12],
+                    ["klm",  2],
+                    ["dlh",  3],
+                    ["sbi",  2],
+                    ["sas",  2],
+                    ["sjo",  4],
+                    ["swr",  2],
+                    ["thy",  1],
+                    ["ual", 10],
+                    ["fdx",  4],
+                    ["nca", 16],
+                    ["sqc",  2],
+                    ["ups",  4],
+                    ["apj",  4],
+                    ["vnl",  6]
+                ]
+        },
+        {
+            "type": 		"cyclic",
+            "route":        "SWAMP.SWAMP_NORTH.RJAA",
+            "frequency":    6,
+            "altitude":     12000,
+            "speed":		250,
+            "offset":		2,
+            "airlines": [
+                    ["afl",  1],
+                    ["aca",  3],
+                    ["cca",  7],
+                    ["afr",  2],
+                    ["ana", 54],
+                    ["aal",  3],
+                    ["aua",  1],
+                    ["baw",  1],
+                    ["cpa",  3],
+                    ["ces",  3],
+                    ["csn",  7],
+                    ["dal", 17],
+                    ["ibe",  1],
+                    ["jal", 34],
+                    ["jjp", 12],
+                    ["klm",  2],
+                    ["dlh",  3],
+                    ["sbi",  2],
+                    ["sas",  2],
+                    ["sjo",  4],
+                    ["swr",  2],
+                    ["thy",  1],
+                    ["ual", 10],
+                    ["fdx",  4],
+                    ["nca", 16],
+                    ["sqc",  2],
+                    ["ups",  4],
+                    ["apj",  4],
+                    ["vnl",  6]
+                ]
+        }
+    ]
+}


### PR DESCRIPTION
Narita International Airport (成田国際空港 Narita Kokusai Kūkō) (IATA: NRT, ICAO: RJAA), also known as Tokyo Narita Airport, formerly and originally known as New Tokyo International Airport (新東京国際空港 Shin Tōkyō Kokusai Kūkō), is an international airport serving the Greater Tokyo Area of Japan. It is located approximately 60 kilometres (37 mi) east of central Tokyo in Chiba Prefecture, straddling the border between the city of Narita and the adjacent town of Shibayama.

Narita is the predominant international airport in Japan, handling around 50% of the country's international passenger traffic and 60% of its international air cargo traffic. As of 2013, Narita was the second-busiest passenger airport in Japan (after Haneda Airport in Tokyo), and was the tenth-busiest air freight hub in the world. Its 4,000-metre (13,123 ft) main runway shares the record for longest runway in Japan with the second runway at Kansai International Airport in Osaka.

Narita serves as the main international hub of Japan Airlines, All Nippon Airways and Nippon Cargo Airlines, and as a hub for low-cost carriers Jetstar Japan, Peach and Vanilla Air. It also serves as an Asian hub for Delta Air Lines and United Airlines.

From [Wikipedia](https://en.wikipedia.org/wiki/Narita_International_Airport)

Also known as zlsa/atc#597

Featured in #103 