### PR TITLE
feature/108

### DIFF
--- a/assets/airports/airportLoadList.js
+++ b/assets/airports/airportLoadList.js
@@ -42,6 +42,11 @@ window.AIRPORT_LOAD_LIST = (function() { // eslint-disable-line wrap-iife
      */
     return [
         {
+            icao: 'cyow',
+            level: 'easy',
+            name: 'Ottawa Macdonald-Cartier International Airport'
+        },
+        {
             icao: 'ebbr',
             level: 'easy',
             name: 'Brussels-National &#9983'

--- a/assets/airports/cyow.json
+++ b/assets/airports/cyow.json
@@ -1,0 +1,106 @@
+{
+    "radio": {
+        "twr": "xx xx",
+        "app": "xx xx",
+        "dep": "xx xx"
+    },
+    "icao": "CYOW",
+    "iata": "YOW",
+    "magnetic_north": -90000,
+    "ctr_radius": 80,
+    "ctr_ceiling": 7000,
+    "initial_alt": 3000,
+    "position": ["xx"],
+    "rr_radius_nm": 5.0,
+    "rr_center": ["xx"],
+    "has_terrain": false,
+    "wind": {
+		"angle": 204,
+        "speed": 9
+    },
+    "airspace": [{
+        "floor": 0,
+        "ceiling": 20000,
+        "airspace_class": "C",
+        "poly": [
+
+        ]
+    }],
+    "fixes": {
+
+	},
+    "runways": [{
+        "name": ["xx", "xx"],
+        "name_offset": [
+            [0, 0], [0, 0]
+        ],
+        "end": [
+            ["xx", "xx", "ft"],
+            ["xx", "xx", "ft"]
+        ],
+        "length": 4.000,
+        "ils": [true, true]
+    }, {
+        "name": ["xx", "xx"],
+        "name_offset": [
+            [0, 0], [0, 0]
+        ],
+        "end": [
+            ["xx", "xx", "ft"],
+            ["xx", "xx", "ft"]
+        ],
+        "length": 3.500,
+        "ils": [true, true]
+    }],
+    "sids": {
+        "xx": {
+            "icao": "xx",
+            "name": "xx x",
+            "rwy": {
+
+            },
+            "draw": [
+
+            ]
+        }
+    },
+    "departures": {
+        "airlines": [
+
+        ],
+        "destinations": [
+
+        ],
+        "type": "cyclic",
+        "offset": 0,
+        "frequency": 9.5
+    },
+    "stars": {
+        "xx": {
+            "icao": "xx",
+            "name": "xx",
+            "entryPoints": {
+                "xx": [
+					"xx"
+				]
+            },
+            "body": [
+
+            ],
+            "draw": [
+
+            ]
+        }
+    },
+	"arrivals": [{
+		"type":		 "cyclic",
+		"route":	 "xx.xx.xxxx",
+		"frequency": 2,
+		"altitude":	 20000,
+		"speed":	 430,
+		"offset":	 2,
+		"airlines": [
+
+		]
+    }
+]}


### PR DESCRIPTION
Ottawa/Macdonald–Cartier International Airport or Macdonald–Cartier International Airport (L'aéroport international Macdonald-Cartier in French), (IATA: YOW, ICAO: CYOW) in Ottawa, Ontario, Canada is an international airport named after the Canadian statesmen and one of the "founding fathers of Canada", Sir John A. Macdonald and Sir George-Étienne Cartier. Located in the south end of the city, 5.5 nautical miles (10.2 km; 6.3 mi) south of downtown Ottawa, it is Canada's sixth busiest airport and Ontario's second busiest airport by airline passenger traffic and Canada's eighth busiest by aircraft movements, with 4,616,448 passengers and 154,637 aircraft movements in 2014. The airport is an Air Canada focus city and the home base for First Air. The airport is classified as an airport of entry by Nav Canada and is staffed by the Canada Border Services Agency. The airport is one of eight Canadian airports that have United States border preclearance facilities. The airport used to be a military base known as CFB Ottawa South/CFB Uplands. Although it is no longer a Canadian Forces Base it is still home to the Royal Canadian Air Force's 412 Transport Squadron.

From [Wikipedia](https://en.wikipedia.org/wiki/Ottawa_Macdonald–Cartier_International_Airport)

Also known as zlsa/atc#728
Requested by @scott-j-smith in zlsa/atc#688

Featured in #108 