### PR TITLE
bugfix/207

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@
 
 
 ### Bugfixes
-- Adds a default center position when calculating `panX` and `panY` after double click on an aircraft strip [#207](https://github.com/openscope/openscope/issues/207)
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 
 ### Bugfixes
+- Adds a default center position when calculating `panX` and `panY` after double click on an aircraft strip [#207](https://github.com/openscope/openscope/issues/207)
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 
 ### Bugfixes
+- Adds a default position value to `SpawnPatternModel` so aircraft have, at least, a `[0, 0]` starting position [#207](https://github.com/openscope/openscope/issues/207)
 
 
 

--- a/src/assets/scripts/client/aircraft/AircraftStripView.js
+++ b/src/assets/scripts/client/aircraft/AircraftStripView.js
@@ -454,8 +454,20 @@ export default class AircraftStripView {
      * @param  event {jquery event}
      */
     onDoubleClickHandler = (event) => {
-        prop.canvas.panX = 0 - round(window.uiController.km_to_px(event.data.position[0]));
-        prop.canvas.panY = round(window.uiController.km_to_px(event.data.position[1]));
+        // this provides a way to default the position to the airport center in some cases, an aircraft
+        // may not have a position set which causes the calculations below to fail.
+        // this is only an issue for departing aircraft that have not yet taxied.
+        let aircraftPositionOnCanvas = [0, 0];
+
+        if (event.data.position.length === 2) {
+            aircraftPositionOnCanvas = [
+                event.data.position[0],
+                event.data.position[1]
+            ];
+        }
+
+        prop.canvas.panX = 0 - round(window.uiController.km_to_px(aircraftPositionOnCanvas[0]));
+        prop.canvas.panY = round(window.uiController.km_to_px(aircraftPositionOnCanvas[1]));
         prop.canvas.dirty = true;
     };
 }

--- a/src/assets/scripts/client/aircraft/AircraftStripView.js
+++ b/src/assets/scripts/client/aircraft/AircraftStripView.js
@@ -454,20 +454,8 @@ export default class AircraftStripView {
      * @param  event {jquery event}
      */
     onDoubleClickHandler = (event) => {
-        // this provides a way to default the position to the airport center in some cases, an aircraft
-        // may not have a position set which causes the calculations below to fail.
-        // this is only an issue for departing aircraft that have not yet taxied.
-        let aircraftPositionOnCanvas = [0, 0];
-
-        if (event.data.position.length === 2) {
-            aircraftPositionOnCanvas = [
-                event.data.position[0],
-                event.data.position[1]
-            ];
-        }
-
-        prop.canvas.panX = 0 - round(window.uiController.km_to_px(aircraftPositionOnCanvas[0]));
-        prop.canvas.panY = round(window.uiController.km_to_px(aircraftPositionOnCanvas[1]));
+        prop.canvas.panX = 0 - round(window.uiController.km_to_px(event.data.position[0]));
+        prop.canvas.panY = round(window.uiController.km_to_px(event.data.position[1]));
         prop.canvas.dirty = true;
     };
 }

--- a/src/assets/scripts/client/trafficGenerator/SpawnPatternModel.js
+++ b/src/assets/scripts/client/trafficGenerator/SpawnPatternModel.js
@@ -224,11 +224,17 @@ export default class SpawnPatternModel extends BaseModel {
         /**
          * Initial position of a spawning aircraft
          *
+         * Defaults to [0, 0] which equates the the airport midfield and should
+         * only apply to departing aircraft.
+         *
+         * An arriving aircraft should be assigned a position along an arrival
+         * route, in which case this default will not be used.
+         *
          * @property position
          * @type {array}
-         * @default []
+         * @default [0, 0]
          */
-        this.position = [];
+        this.position = [0, 0];
 
         // SPAWN PATTERN PROPERTIES
 
@@ -463,7 +469,7 @@ export default class SpawnPatternModel extends BaseModel {
         this._maximumAltitude = -1;
         this.speed = 0;
         this.heading = -1;
-        this.position = [];
+        this.position = [0, 0];
 
         this.cycleStartTime = -1;
         this.rate = -1;

--- a/test/trafficGenerator/SpawnPatternModel.spec.js
+++ b/test/trafficGenerator/SpawnPatternModel.spec.js
@@ -48,7 +48,13 @@ ava('does not throw when called with valid parameters', (t) => {
     t.notThrows(() => new SpawnPatternModel(DEPARTURE_PATTERN_MOCK, navigationLibraryFixture, airportControllerFixture));
 });
 
-ava('altitude returns a random altitude rounded to the nearest 1,000ft', (t) => {
+ava('#position defaults to [0, 0]', (t) => {
+    const model = new SpawnPatternModel(DEPARTURE_PATTERN_MOCK, navigationLibraryFixture, airportControllerFixture);
+
+    t.true(_isEqual(model.position, [0, 0]));
+});
+
+ava('#altitude returns a random altitude rounded to the nearest 1,000ft', (t) => {
     const model = new SpawnPatternModel(ARRIVAL_PATTERN_MOCK, navigationLibraryFixture, airportControllerFixture);
     const result = model.altitude;
     const expectedResult = _round(result, -3);
@@ -184,7 +190,7 @@ ava('._calculatePositionAndHeadingForArrival() returns early when spawnPattern.c
     model._calculatePositionAndHeadingForArrival(DEPARTURE_PATTERN_MOCK, navigationLibraryFixture);
 
     t.true(model.heading === -1);
-    t.true(_isEmpty(model.position));
+    t.true(_isEqual(model.position, [0, 0]));
 });
 
 ava('._calculatePositionAndHeadingForArrival() calculates aircraft heading and position when provided a route', (t) => {


### PR DESCRIPTION
fixes #207 

Adds a default center position when calculating `panX` and `panY` after double click on an aircraft strip