### PR TITLE
bugfix/148

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@
 - Updates airline json files to include `icao` key. Updates `AirlineCollection` and `AirlineModel` to handle variable casing of `icao`  [#195](https://github.com/openscope/openscope/issues/195)
 - Adds a default position value to `SpawnPatternModel` so aircraft have, at least, a `[0, 0]` starting position [#207](https://github.com/openscope/openscope/issues/207)
 - Ensures data block colored bars are all the same width (3px), regardless of callsign length [#210](https://github.com/openscope/openscope/issues/210)
-
+- Fixes internal fms error that was breaking the game when issuing holds over present position [#148](https://github.com/openscope/openscope/issues/148)
 
 
 

--- a/src/assets/scripts/client/aircraft/AircraftCommander.js
+++ b/src/assets/scripts/client/aircraft/AircraftCommander.js
@@ -581,32 +581,24 @@ export default class AircraftCommander {
             holdFixLocation = aircraft.position; // make a/c hold over their present position
             inboundHdg = aircraft.heading;
 
-            // TODO: these aren't `Waypoints` and they should be
+            const holdingWaypointModel = new Waypoint({
+                navmode: WAYPOINT_NAV_MODE.HOLD,
+                speed: aircraft.fms.currentWaypoint.speed,
+                altitude: aircraft.fms.altitudeForCurrentWaypoint(),
+                fix: null,
+                hold: {
+                    fixName: '[custom]',
+                    fixPos: holdFixLocation,
+                    dirTurns: dirTurns,
+                    legLength: legLength,
+                    inboundHdg: inboundHdg,
+                    timer: null
+                }
+            });
+
             aircraft.fms.insertLegHere({
                 type: 'fix',
-                waypoints: [
-                    { // document the present position as the 'fix' we're holding over
-                        navmode: WAYPOINT_NAV_MODE.FIX,
-                        fix: '[custom]',
-                        location: holdFixLocation,
-                        altitude: aircraft.fms.altitudeForCurrentWaypoint(),
-                        speed: aircraft.fms.currentWaypoint.speed
-                    },
-                    { // Force the initial turn to outbound heading when entering the hold
-                        navmode: WAYPOINT_NAV_MODE.HOLD,
-                        speed: aircraft.fms.currentWaypoint.speed,
-                        altitude: aircraft.fms.altitudeForCurrentWaypoint(),
-                        fix: null,
-                        hold: {
-                            fixName: holdFix,
-                            fixPos: holdFixLocation,
-                            dirTurns: dirTurns,
-                            legLength: legLength,
-                            inboundHdg: inboundHdg,
-                            timer: null
-                        }
-                    }
-                ]
+                waypoints: [holdingWaypointModel]
             });
         }
 


### PR DESCRIPTION
Ensure hold command generates Waypoint instance, and not just an object. This fixes an error when trying to call a method of the Waypoint model, which obviously doesn't exist if it's not an instance of that class!

Holds work properly now.

Resolves #148.