### PR TITLE
bugfix/211

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
 - Updates airline json files to include `icao` key. Updates `AirlineCollection` and `AirlineModel` to handle variable casing of `icao`  [#195](https://github.com/openscope/openscope/issues/195)
 - Adds a default position value to `SpawnPatternModel` so aircraft have, at least, a `[0, 0]` starting position [#207](https://github.com/openscope/openscope/issues/207)
 - Ensures data block colored bars are all the same width (3px), regardless of callsign length [#210](https://github.com/openscope/openscope/issues/210)
-
+- Adds missing `return` in `.generateFlightNumberWithAirlineModel()` that was needed to properly recurse back through the method in the case of a duplicate flight number. [#210](https://github.com/openscope/openscope/issues/210)
 
 
 

--- a/src/assets/scripts/client/airline/AirlineController.js
+++ b/src/assets/scripts/client/airline/AirlineController.js
@@ -69,7 +69,7 @@ export default class AirlineController {
 
         if (this._isActiveFlightNumber(flightNumber)) {
             // `flightNumber` already exists, recurse back through this method and generate a new flight number
-            this.generateFlightNumberWithAirlineModel(airlineModel);
+            return this.generateFlightNumberWithAirlineModel(airlineModel);
         }
 
         airlineModel.addFlightNumberToInUse(flightNumber);

--- a/test/airline/AirlineController.spec.js
+++ b/test/airline/AirlineController.spec.js
@@ -31,11 +31,29 @@ ava('.generateFlightNumberWithAirlineModel() calls airlineModel.generateFlightNu
 
     const generateFlightNumberStub = sinon.stub(airlineModel, 'generateFlightNumber');
     generateFlightNumberStub.onFirstCall().returns('42');
-    generateFlightNumberStub.onSecondCall().returns('3')
+    generateFlightNumberStub.onSecondCall().returns('3');
 
     controller.generateFlightNumberWithAirlineModel(airlineModel);
 
     t.true(generateFlightNumberStub.calledTwice);
+
+    generateFlightNumberStub.restore();
+});
+
+ava('.generateFlightNumberWithAirlineModel() does not set a duplicate flightNumber to the list', (t) => {
+    const controller = new AirlineController(AIRLINE_DEFINITION_LIST_FOR_FIXTURE);
+    const airlineModel = controller.airlineCollection._items[0];
+    airlineModel.activeFlightNumbers = ['42'];
+
+    const generateFlightNumberStub = sinon.stub(airlineModel, 'generateFlightNumber');
+    generateFlightNumberStub.onFirstCall().returns('42');
+    generateFlightNumberStub.onSecondCall().returns('3');
+
+    controller.generateFlightNumberWithAirlineModel(airlineModel);
+
+    t.true(controller.flightNumbers.length === 2);
+    t.true(controller.flightNumbers.indexOf('42') !== -1);
+    t.true(controller.flightNumbers.indexOf('3') !== -1);
 
     generateFlightNumberStub.restore();
 });


### PR DESCRIPTION
fixes #211 

Adds missing return in .generateFlightNumberWithAirlineModel() that was needed to properly recurse back through the method in the case of a duplicate flight number