### PR TITLE
bugfix/259

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 ### Bugfixes
 - Standardized indentation in all json files [#256](https://github.com/openscope/openscope/issues/256)
-
+    - followed up and corrected 2 mistakenly cleared out aircraft files [#259](https://github.com/openscope/openscope/issues/259)
 
 
 

--- a/assets/aircraft/a332.json
+++ b/assets/aircraft/a332.json
@@ -1,1 +1,37 @@
-l
+{
+    "name": "Airbus A330-200",
+    "icao": "A332",
+    "engines": {
+        "number": 2,
+        "type": "J"
+    },
+    "weightclass": "H",
+    "category": {
+        "srs": 3,
+        "lahso": 8,
+        "recat": "B"
+    },
+    "ceiling": 41000,
+    "rate": {
+        "climb":      3500,
+        "descent":    2000,
+        "accelerate": 6,
+        "decelerate": 3.5
+    },
+    "runway": {
+        "takeoff": 2.600,
+        "landing": 1.600
+    },
+    "speed":{
+        "min":     125,
+        "landing": 130,
+        "cruise":  465,
+        "cruiseM": null,
+        "max":     475,
+        "maxM":    0.80
+    },
+    "capability": {
+        "ils": true,
+        "fix": true
+    }
+}

--- a/assets/aircraft/a343.json
+++ b/assets/aircraft/a343.json
@@ -1,1 +1,37 @@
-l
+{
+    "name": "Airbus A340-300",
+    "icao": "A343",
+    "engines": {
+        "number": 4,
+        "type": "J"
+    },
+    "weightclass": "H",
+    "category": {
+        "srs": 3,
+        "lahso": 9,
+        "recat": "B"
+    },
+    "ceiling": 41000,
+    "rate": {
+        "climb":      3500,
+        "descent":    2000,
+        "accelerate": 4,
+        "decelerate": 3
+    },
+    "runway": {
+        "takeoff": 3.000,
+        "landing": 1.800
+    },
+    "speed":{
+        "min":     145,
+        "landing": 150,
+        "cruise":  475,
+        "cruiseM": null,
+        "max":     494,
+        "maxM":    0.84
+    },
+    "capability": {
+        "ils": true,
+        "fix": true
+    }
+}


### PR DESCRIPTION
Restore content for mistakenly cleared out aircraft files. This will fix the failing build on `develop`.

Resolves #259.