### PR TITLE
bugfix/165

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@
 ### Bugfixes
 - Standardized indentation in all json files [#256](https://github.com/openscope/openscope/issues/256)
     - followed up and corrected 2 mistakenly cleared out aircraft files [#259](https://github.com/openscope/openscope/issues/259)
-
+- Fixes the flash of NaN for displayed Speed [#165](https://github.com/openscope/openscope/issues/165)
+- Removes the option for non simpe speed calculation since it was higely inaccurate.[#271](https://github.com/openscope/openscope/issues/271)
 
 
 

--- a/src/assets/scripts/client/constants/gameOptionConstants.js
+++ b/src/assets/scripts/client/constants/gameOptionConstants.js
@@ -45,17 +45,6 @@ export const GAME_OPTION_VALUES = [
         ]
     },
     {
-        name: GAME_OPTION_NAMES.SIMPLIFY_SPEEDS,
-        defaultValue: 'yes',
-        description: 'Use simplified airspeeds',
-        help: 'Controls use of a simplified calculation which results in aircraft always moving across the ground at the speed assigned.  In reality aircraft will move faster as they increase altitude.',
-        type: 'select',
-        data: [
-            ['Yes', 'yes'],
-            ['No', 'no']
-        ]
-    },
-    {
         name: GAME_OPTION_NAMES.SOFT_CEILING,
         defaultValue: 'no',
         description: 'Allow departures via climb',


### PR DESCRIPTION
Resolves #165.

Removes the options and sets the default value to always use the simple ground speed. Since the other calculations were vastly incorrect and dependent on the frame rate of the game.