### PR TITLE
feature/263

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 ### Bugfixes
 - Standardized indentation in all json files [#256](https://github.com/openscope/openscope/issues/256)
     - followed up and corrected 2 mistakenly cleared out aircraft files [#259](https://github.com/openscope/openscope/issues/259)
-
+- Fixs firefox compatibility issue [#263](https://github.com/openscope/openscope/issues/259)
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 ### Bugfixes
 - Standardized indentation in all json files [#256](https://github.com/openscope/openscope/issues/256)
     - followed up and corrected 2 mistakenly cleared out aircraft files [#259](https://github.com/openscope/openscope/issues/259)
-- Fixs firefox compatibility issue by changeing ajax to getJSON  [#263](https://github.com/openscope/openscope/issues/259)
+- Fixes firefox compatibility issue by changeing ajax to getJSON  [#263](https://github.com/openscope/openscope/issues/259)
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 ### Bugfixes
 - Standardized indentation in all json files [#256](https://github.com/openscope/openscope/issues/256)
     - followed up and corrected 2 mistakenly cleared out aircraft files [#259](https://github.com/openscope/openscope/issues/259)
-- Fixs firefox compatibility issue [#263](https://github.com/openscope/openscope/issues/259)
+- Fixs firefox compatibility issue by changeing ajax to getJSON  [#263](https://github.com/openscope/openscope/issues/259)
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 ### Bugfixes
 - Standardized indentation in all json files [#256](https://github.com/openscope/openscope/issues/256)
     - followed up and corrected 2 mistakenly cleared out aircraft files [#259](https://github.com/openscope/openscope/issues/259)
-- Fixes firefox compatibility issue by changeing ajax to getJSON  [#263](https://github.com/openscope/openscope/issues/259)
+- Fixes Firefox compatibility issue by changing ajax to getJSON  [#263](https://github.com/openscope/openscope/issues/259)
 
 
 

--- a/src/assets/scripts/client/App.js
+++ b/src/assets/scripts/client/App.js
@@ -119,11 +119,6 @@ export default class App {
             $.ajax('assets/aircraft/aircraft.json')
         )
             .done((airportResponse, airlineResponse, aircraftResponse) => {
-                console.log('airlineResponse');
-                console.log(airlineResponse);
-                console.log('airlineResponse.airlines');
-                console.log(airlineResponse.airlines);
-
                 this.setupChildren(
                     airportLoadList,
                     airportResponse[0],

--- a/src/assets/scripts/client/App.js
+++ b/src/assets/scripts/client/App.js
@@ -115,10 +115,7 @@ export default class App {
         // FIXME: this is wrong. move this and make it less bad!
         $.when(
             $.ajax(`assets/airports/${initialAirportToLoad}.json`),
-            $.ajax({
-                url: 'assets/airlines/airlines.json',
-                dataType: 'json'
-            }),
+            $.ajax('assets/airlines/airlines.json'),
             $.ajax('assets/aircraft/aircraft.json')
         )
             .done((airportResponse, airlineResponse, aircraftResponse) => {

--- a/src/assets/scripts/client/App.js
+++ b/src/assets/scripts/client/App.js
@@ -115,9 +115,10 @@ export default class App {
         // FIXME: this is wrong. move this and make it less bad!
         console.log('when');
         $.when(
-            $.ajax(`assets/airports/${initialAirportToLoad.toLowerCase()}.json`),
+
             $.ajax('assets/airlines/airlines.json'),
-            $.ajax('assets/aircraft/aircraft.json')
+            $.ajax('assets/aircraft/aircraft.json'),
+            $.ajax(`assets/airports/${initialAirportToLoad.toLowerCase()}.json`)
         )
             .done((airportResponse, airlineResponse, aircraftResponse) => {
                 console.log(airlineResponse);

--- a/src/assets/scripts/client/App.js
+++ b/src/assets/scripts/client/App.js
@@ -121,8 +121,8 @@ export default class App {
             .done((airportResponse, airlineResponse, aircraftResponse) => {
                 console.log('airlineResponse');
                 console.log(airlineResponse);
-                console.log('airlineResponse[0].airlines');
-                console.log(airlineResponse[0].airlines);
+                console.log('airlineResponse.airlines');
+                console.log(airlineResponse.airlines);
 
                 this.setupChildren(
                     airportLoadList,

--- a/src/assets/scripts/client/App.js
+++ b/src/assets/scripts/client/App.js
@@ -117,8 +117,10 @@ export default class App {
             $.ajax(`assets/airports/${initialAirportToLoad.toLowerCase()}.json`),
             $.ajax('assets/airlines/airlines.json'),
             $.ajax('assets/aircraft/aircraft.json')
+            console.log('when');
         )
             .done((airportResponse, airlineResponse, aircraftResponse) => {
+                console.log('done ');
                 this.setupChildren(
                     airportLoadList,
                     airportResponse[0],
@@ -126,6 +128,7 @@ export default class App {
                     aircraftResponse[0].aircraft
                 );
                 this.enable();
+                console.log('done / enable ');
             })
             .fail((jqXHR, textStatus, errorThrown) => {
                 console.error(textStatus);

--- a/src/assets/scripts/client/App.js
+++ b/src/assets/scripts/client/App.js
@@ -119,6 +119,10 @@ export default class App {
             $.ajax('assets/aircraft/aircraft.json')
         )
             .done((airportResponse, airlineResponse, aircraftResponse) => {
+                console.log('done');
+                console.log(airlineResponse);
+                console.log(airlineResponse[0].airlines);
+
                 this.setupChildren(
                     airportLoadList,
                     airportResponse[0],

--- a/src/assets/scripts/client/App.js
+++ b/src/assets/scripts/client/App.js
@@ -161,7 +161,7 @@ export default class App {
         this.gameController = new GameController(this.getDeltaTime);
         // FIXME: Temporary
         window.gameController = this.gameController;
-
+        console.log(initialAirportData);
         this.navigationLibrary = new NavigationLibrary(initialAirportData);
         this.airportController = new AirportController(initialAirportData, airportLoadList, this.updateRun, this.onAirportChange, this.navigationLibrary);
         // FIXME: Temporary

--- a/src/assets/scripts/client/App.js
+++ b/src/assets/scripts/client/App.js
@@ -178,7 +178,6 @@ export default class App {
 
         this.canvasController = new CanvasController(this.$element, this.navigationLibrary);
         console.log('canvas loaded');
-        console.log(canvasController);
         this.tutorialView = new TutorialView(this.$element);
         this.uiController = new UiController(this.$element);
         this.aircraftCommander = new AircraftCommander(this.airportController, this.navigationLibrary, this.gameController, this.uiController);

--- a/src/assets/scripts/client/App.js
+++ b/src/assets/scripts/client/App.js
@@ -151,6 +151,7 @@ export default class App {
      * @param aircraftTypeDefinitionList {array}  List of all Aircraft definitions
      */
     setupChildren(airportLoadList, initialAirportData, airlineList, aircraftTypeDefinitionList) {
+        console.log('star of setupChildren');
         // FIXME: this entire method needs to be re-written. this is a temporary implemenation used to
         // get things working in a more cohesive manner. soon, all this instantiation should happen
         // in a different class and the window methods should disappear.

--- a/src/assets/scripts/client/App.js
+++ b/src/assets/scripts/client/App.js
@@ -115,13 +115,12 @@ export default class App {
         // FIXME: this is wrong. move this and make it less bad!
         console.log('when');
         $.when(
-
+            $.ajax(`assets/airports/${initialAirportToLoad.toLowerCase()}.json`),
             $.ajax('assets/airlines/airlines.json'),
-            $.ajax('assets/aircraft/aircraft.json'),
-            $.ajax(`assets/airports/${initialAirportToLoad.toLowerCase()}.json`)
+            $.ajax('assets/aircraft/aircraft.json')
         )
             .done((airportResponse, airlineResponse, aircraftResponse) => {
-                console.log(airlineResponse);
+                console.log('done');
                 this.setupChildren(
                     airportLoadList,
                     airportResponse[0],

--- a/src/assets/scripts/client/App.js
+++ b/src/assets/scripts/client/App.js
@@ -114,7 +114,7 @@ export default class App {
         // This is provides a way to get async data from several sources in the app before anything else runs
         // FIXME: this is wrong. move this and make it less bad!
         $.when(
-            $.getJSON(`assets/airports/${initialAirportToLoad}.json`),
+            $.getJSON(`assets/airports/${initialAirportToLoad.toLowerCase()}.json`),
             $.getJSON('assets/airlines/airlines.json'),
             $.getJSON('assets/aircraft/aircraft.json')
         )

--- a/src/assets/scripts/client/App.js
+++ b/src/assets/scripts/client/App.js
@@ -114,21 +114,17 @@ export default class App {
         // This is provides a way to get async data from several sources in the app before anything else runs
         // FIXME: this is wrong. move this and make it less bad!
         console.log('when');
-        /*
-        const getAirportToLoadData = $.ajax({
-            url:`assets/airports/${initialAirportToLoad.toLowerCase()}.json`,
-            async: false
-        });
-        const getAirlinesData = $.ajax({
-            url:'assets/airlines/airlines.json',
-            async: false
-        });
-                */
         $.when(
-            $.ajax(`assets/airports/${initialAirportToLoad.toLowerCase()}.json`),
-            $.ajax('assets/airlines/airlines.json'),
             $.ajax({
-                url:'assets/aircraft/aircraft.json',
+                url: `assets/airports/${initialAirportToLoad.toLowerCase()}.json`,
+                async: false
+            }),
+            $.ajax({
+                url: 'assets/airlines/airlines.json',
+                async: false
+            }),
+            $.ajax({
+                url: 'assets/aircraft/aircraft.json',
                 async: false
             })
         )

--- a/src/assets/scripts/client/App.js
+++ b/src/assets/scripts/client/App.js
@@ -178,7 +178,7 @@ export default class App {
 
         this.spawnPatternCollection = new SpawnPatternCollection(initialAirportData, this.navigationLibrary, this.airportController);
         this.spawnScheduler = new SpawnScheduler(this.spawnPatternCollection, this.aircraftController, this.gameController);
-
+        console.log(this.$element);
         this.canvasController = new CanvasController(this.$element, this.navigationLibrary);
         console.log('canvas loaded');
         this.tutorialView = new TutorialView(this.$element);

--- a/src/assets/scripts/client/App.js
+++ b/src/assets/scripts/client/App.js
@@ -202,7 +202,7 @@ export default class App {
         window.tutorialView = this.tutorialView;
         window.inputController = this.inputController;
         window.uiController = this.uiController;
-        // window.canvasController = this.canvasController;
+        window.canvasController = this.canvasController;
 
         log(`Version ${this.prop.version_string}`);
 

--- a/src/assets/scripts/client/App.js
+++ b/src/assets/scripts/client/App.js
@@ -113,11 +113,11 @@ export default class App {
     initiateDataLoad(airportLoadList, initialAirportToLoad) {
         // This is provides a way to get async data from several sources in the app before anything else runs
         // FIXME: this is wrong. move this and make it less bad!
+        console.log('when');
         $.when(
             $.ajax(`assets/airports/${initialAirportToLoad.toLowerCase()}.json`),
             $.ajax('assets/airlines/airlines.json'),
             $.ajax('assets/aircraft/aircraft.json')
-            console.log('when');
         )
             .done((airportResponse, airlineResponse, aircraftResponse) => {
                 console.log('done ');
@@ -128,7 +128,7 @@ export default class App {
                     aircraftResponse[0].aircraft
                 );
                 this.enable();
-                console.log('done / enable ');
+                console.log('done  enable ');
             })
             .fail((jqXHR, textStatus, errorThrown) => {
                 console.error(textStatus);

--- a/src/assets/scripts/client/App.js
+++ b/src/assets/scripts/client/App.js
@@ -114,9 +114,9 @@ export default class App {
         // This is provides a way to get async data from several sources in the app before anything else runs
         // FIXME: this is wrong. move this and make it less bad!
         $.when(
-            $.ajax(`assets/airports/${initialAirportToLoad}.json`),
-            $.ajax('assets/airlines/airlines.json'),
-            $.ajax('assets/aircraft/aircraft.json')
+            $.getJSON(`assets/airports/${initialAirportToLoad}.json`),
+            $.getJSON('assets/airlines/airlines.json'),
+            $.getJSON('assets/aircraft/aircraft.json')
         )
             .done((airportResponse, airlineResponse, aircraftResponse) => {
                 this.setupChildren(

--- a/src/assets/scripts/client/App.js
+++ b/src/assets/scripts/client/App.js
@@ -176,6 +176,8 @@ export default class App {
         this.spawnScheduler = new SpawnScheduler(this.spawnPatternCollection, this.aircraftController, this.gameController);
 
         this.canvasController = new CanvasController(this.$element, this.navigationLibrary);
+        console.log('canvas loaded');
+        console.log(canvasController);
         this.tutorialView = new TutorialView(this.$element);
         this.uiController = new UiController(this.$element);
         this.aircraftCommander = new AircraftCommander(this.airportController, this.navigationLibrary, this.gameController, this.uiController);
@@ -202,7 +204,7 @@ export default class App {
         window.tutorialView = this.tutorialView;
         window.inputController = this.inputController;
         window.uiController = this.uiController;
-        window.canvasController = this.canvasController;
+        // window.canvasController = this.canvasController;
 
         log(`Version ${this.prop.version_string}`);
 

--- a/src/assets/scripts/client/App.js
+++ b/src/assets/scripts/client/App.js
@@ -170,12 +170,13 @@ export default class App {
         this.airportController = new AirportController(initialAirportData, airportLoadList, this.updateRun, this.onAirportChange, this.navigationLibrary);
         // FIXME: Temporary
         window.airportController = this.airportController;
-
+        console.log('airlineList');
+        console.log(airlineList);
         this.airlineController = new AirlineController(airlineList);
         this.aircraftController = new AircraftController(aircraftTypeDefinitionList, this.airlineController, this.navigationLibrary);
         // FIXME: Temporary
         window.aircraftController = this.aircraftController;
-
+        console.log(this.airlineController);
         this.spawnPatternCollection = new SpawnPatternCollection(initialAirportData, this.navigationLibrary, this.airportController);
         this.spawnScheduler = new SpawnScheduler(this.spawnPatternCollection, this.aircraftController, this.gameController);
         console.log(this.$element);

--- a/src/assets/scripts/client/App.js
+++ b/src/assets/scripts/client/App.js
@@ -120,7 +120,7 @@ export default class App {
             $.ajax('assets/aircraft/aircraft.json')
         )
             .done((airportResponse, airlineResponse, aircraftResponse) => {
-                console.log('done ');
+                console.log(airlineResponse);
                 this.setupChildren(
                     airportLoadList,
                     airportResponse[0],

--- a/src/assets/scripts/client/App.js
+++ b/src/assets/scripts/client/App.js
@@ -114,10 +114,23 @@ export default class App {
         // This is provides a way to get async data from several sources in the app before anything else runs
         // FIXME: this is wrong. move this and make it less bad!
         console.log('when');
+        /*
+        const getAirportToLoadData = $.ajax({
+            url:`assets/airports/${initialAirportToLoad.toLowerCase()}.json`,
+            async: false
+        });
+        const getAirlinesData = $.ajax({
+            url:'assets/airlines/airlines.json',
+            async: false
+        });
+                */
         $.when(
             $.ajax(`assets/airports/${initialAirportToLoad.toLowerCase()}.json`),
             $.ajax('assets/airlines/airlines.json'),
-            $.ajax('assets/aircraft/aircraft.json')
+            $.ajax({
+                url:'assets/aircraft/aircraft.json',
+                async: false
+            })
         )
             .done((airportResponse, airlineResponse, aircraftResponse) => {
                 console.log('done');

--- a/src/assets/scripts/client/App.js
+++ b/src/assets/scripts/client/App.js
@@ -154,7 +154,7 @@ export default class App {
      * @param aircraftTypeDefinitionList {array}  List of all Aircraft definitions
      */
     setupChildren(airportLoadList, initialAirportData, airlineList, aircraftTypeDefinitionList) {
-        console.log('star of setupChildren');
+        console.log('start of setupChildren');
         // FIXME: this entire method needs to be re-written. this is a temporary implemenation used to
         // get things working in a more cohesive manner. soon, all this instantiation should happen
         // in a different class and the window methods should disappear.

--- a/src/assets/scripts/client/App.js
+++ b/src/assets/scripts/client/App.js
@@ -119,8 +119,9 @@ export default class App {
             $.ajax('assets/aircraft/aircraft.json')
         )
             .done((airportResponse, airlineResponse, aircraftResponse) => {
-                console.log('done');
+                console.log('airlineResponse');
                 console.log(airlineResponse);
+                console.log('airlineResponse[0].airlines');
                 console.log(airlineResponse[0].airlines);
 
                 this.setupChildren(
@@ -165,7 +166,7 @@ export default class App {
         this.gameController = new GameController(this.getDeltaTime);
         // FIXME: Temporary
         window.gameController = this.gameController;
-        console.log(initialAirportData);
+
         this.navigationLibrary = new NavigationLibrary(initialAirportData);
         this.airportController = new AirportController(initialAirportData, airportLoadList, this.updateRun, this.onAirportChange, this.navigationLibrary);
         // FIXME: Temporary

--- a/src/assets/scripts/client/App.js
+++ b/src/assets/scripts/client/App.js
@@ -113,14 +113,12 @@ export default class App {
     initiateDataLoad(airportLoadList, initialAirportToLoad) {
         // This is provides a way to get async data from several sources in the app before anything else runs
         // FIXME: this is wrong. move this and make it less bad!
-        console.log('when');
         $.when(
-            $.ajax(`assets/airports/${initialAirportToLoad.toLowerCase()}.json`),
+            $.ajax(`assets/airports/${initialAirportToLoad}.json`),
             $.ajax('assets/airlines/airlines.json'),
             $.ajax('assets/aircraft/aircraft.json')
         )
             .done((airportResponse, airlineResponse, aircraftResponse) => {
-                console.log('done');
                 this.setupChildren(
                     airportLoadList,
                     airportResponse[0],
@@ -128,7 +126,6 @@ export default class App {
                     aircraftResponse[0].aircraft
                 );
                 this.enable();
-                console.log('done  enable ');
             })
             .fail((jqXHR, textStatus, errorThrown) => {
                 console.error(textStatus);

--- a/src/assets/scripts/client/App.js
+++ b/src/assets/scripts/client/App.js
@@ -115,18 +115,9 @@ export default class App {
         // FIXME: this is wrong. move this and make it less bad!
         console.log('when');
         $.when(
-            $.ajax({
-                url: `assets/airports/${initialAirportToLoad.toLowerCase()}.json`,
-                async: false
-            }),
-            $.ajax({
-                url: 'assets/airlines/airlines.json',
-                async: false
-            }),
-            $.ajax({
-                url: 'assets/aircraft/aircraft.json',
-                async: false
-            })
+            $.ajax(`assets/airports/${initialAirportToLoad.toLowerCase()}.json`),
+            $.ajax('assets/airlines/airlines.json'),
+            $.ajax('assets/aircraft/aircraft.json')
         )
             .done((airportResponse, airlineResponse, aircraftResponse) => {
                 console.log('done');
@@ -163,7 +154,6 @@ export default class App {
      * @param aircraftTypeDefinitionList {array}  List of all Aircraft definitions
      */
     setupChildren(airportLoadList, initialAirportData, airlineList, aircraftTypeDefinitionList) {
-        console.log('start of setupChildren');
         // FIXME: this entire method needs to be re-written. this is a temporary implemenation used to
         // get things working in a more cohesive manner. soon, all this instantiation should happen
         // in a different class and the window methods should disappear.
@@ -179,18 +169,15 @@ export default class App {
         this.airportController = new AirportController(initialAirportData, airportLoadList, this.updateRun, this.onAirportChange, this.navigationLibrary);
         // FIXME: Temporary
         window.airportController = this.airportController;
-        console.log('airlineList');
-        console.log(airlineList);
+
         this.airlineController = new AirlineController(airlineList);
         this.aircraftController = new AircraftController(aircraftTypeDefinitionList, this.airlineController, this.navigationLibrary);
         // FIXME: Temporary
         window.aircraftController = this.aircraftController;
-        console.log(this.airlineController);
+
         this.spawnPatternCollection = new SpawnPatternCollection(initialAirportData, this.navigationLibrary, this.airportController);
         this.spawnScheduler = new SpawnScheduler(this.spawnPatternCollection, this.aircraftController, this.gameController);
-        console.log(this.$element);
         this.canvasController = new CanvasController(this.$element, this.navigationLibrary);
-        console.log('canvas loaded');
         this.tutorialView = new TutorialView(this.$element);
         this.uiController = new UiController(this.$element);
         this.aircraftCommander = new AircraftCommander(this.airportController, this.navigationLibrary, this.gameController, this.uiController);

--- a/src/assets/scripts/client/App.js
+++ b/src/assets/scripts/client/App.js
@@ -115,7 +115,10 @@ export default class App {
         // FIXME: this is wrong. move this and make it less bad!
         $.when(
             $.ajax(`assets/airports/${initialAirportToLoad}.json`),
-            $.ajax('assets/airlines/airlines.json'),
+            $.ajax({
+                url: 'assets/airlines/airlines.json',
+                dataType: 'json'
+            }),
             $.ajax('assets/aircraft/aircraft.json')
         )
             .done((airportResponse, airlineResponse, aircraftResponse) => {

--- a/src/assets/scripts/client/airport/AirportController.js
+++ b/src/assets/scripts/client/airport/AirportController.js
@@ -38,8 +38,6 @@ export default class AirportController {
         this._airportListToLoad = airportLoadList;
         // eslint-disable-next-line no-undef
         prop.airport = airport;
-        console.log('initialAirportData in AirportController Constructor');
-        console.log(initialAirportData);
         return this.init()
                    .ready(initialAirportData);
     }

--- a/src/assets/scripts/client/airport/AirportController.js
+++ b/src/assets/scripts/client/airport/AirportController.js
@@ -87,6 +87,7 @@ export default class AirportController {
         let airportName = DEFAULT_AIRPORT_ICAO;
         console.log('initialAirportData in AirportController Ready');
         console.log(initialAirportData);
+        console.log(initialAirportData.icao);
 
         if (_has(localStorage, STORAGE_KEY.ATC_LAST_AIRPORT) ||
             _has(this.airport.airports, _lowerCase(localStorage[STORAGE_KEY.ATC_LAST_AIRPORT]))
@@ -94,9 +95,10 @@ export default class AirportController {
             airportName = _lowerCase(localStorage[STORAGE_KEY.ATC_LAST_AIRPORT]);
         }
 
-        if (airportName != initialAirportData.icao.toLowerCase()) {
+        /*if (airportName !== initialAirportData.icao) {
             this.airport_set(airportName);
         }
+        */
 
         this.airport_set(airportName, initialAirportData);
 

--- a/src/assets/scripts/client/airport/AirportController.js
+++ b/src/assets/scripts/client/airport/AirportController.js
@@ -94,7 +94,7 @@ export default class AirportController {
         console.log(initialAirportData);
         console.log(airportName);
 
-        if (airportName !== initialAirportData.icao.toLowerCase()) {
+        if (airportName !== initialAirportData.icao) {
             this.airport_set(airportName);
         }
 

--- a/src/assets/scripts/client/airport/AirportController.js
+++ b/src/assets/scripts/client/airport/AirportController.js
@@ -92,17 +92,18 @@ export default class AirportController {
         initialAirportData = JSON.parse(initialAirportData);
         console.log(initialAirportData);
         console.log(typeof initialAirportData);
+        console.log(initialAirportData.icao);
         if (_has(localStorage, STORAGE_KEY.ATC_LAST_AIRPORT) ||
             _has(this.airport.airports, _lowerCase(localStorage[STORAGE_KEY.ATC_LAST_AIRPORT]))
         ) {
             airportName = _lowerCase(localStorage[STORAGE_KEY.ATC_LAST_AIRPORT]);
         }
 
-        /*
-        if (airportName !== initialAirportData.icao) {
+
+        if (airportName !== initialAirportData.icao.toLowerCase()) {
             this.airport_set(airportName);
         }
-        */
+
 
         this.airport_set(airportName, initialAirportData);
 

--- a/src/assets/scripts/client/airport/AirportController.js
+++ b/src/assets/scripts/client/airport/AirportController.js
@@ -94,7 +94,7 @@ export default class AirportController {
             airportName = _lowerCase(localStorage[STORAGE_KEY.ATC_LAST_AIRPORT]);
         }
 
-        if (airportName !== initialAirportData.icao.toLowerCase()) {
+        if (airportName != initialAirportData.icao.toLowerCase()) {
             this.airport_set(airportName);
         }
 

--- a/src/assets/scripts/client/airport/AirportController.js
+++ b/src/assets/scripts/client/airport/AirportController.js
@@ -91,7 +91,10 @@ export default class AirportController {
             airportName = _lowerCase(localStorage[STORAGE_KEY.ATC_LAST_AIRPORT]);
         }
 
-        if (airportName) {
+        console.log(initialAirportData);
+        console.log(airportName);
+
+        if (airportName !== initialAirportData.icao.toLowerCase()) {
             this.airport_set(airportName);
         }
 

--- a/src/assets/scripts/client/airport/AirportController.js
+++ b/src/assets/scripts/client/airport/AirportController.js
@@ -91,7 +91,7 @@ export default class AirportController {
             airportName = _lowerCase(localStorage[STORAGE_KEY.ATC_LAST_AIRPORT]);
         }
 
-        if (airportName !== initialAirportData.icao.toLowerCase()) {
+        if (airportName) {
             this.airport_set(airportName);
         }
 

--- a/src/assets/scripts/client/airport/AirportController.js
+++ b/src/assets/scripts/client/airport/AirportController.js
@@ -89,7 +89,8 @@ export default class AirportController {
         console.log(initialAirportData);
         const airportDataType = typeof initialAirportData;
         console.log(airportDataType);
-
+        initialAirportData = JSON.parse(initialAirportData);
+        console.log(typeof initialAirportData);
         if (_has(localStorage, STORAGE_KEY.ATC_LAST_AIRPORT) ||
             _has(this.airport.airports, _lowerCase(localStorage[STORAGE_KEY.ATC_LAST_AIRPORT]))
         ) {

--- a/src/assets/scripts/client/airport/AirportController.js
+++ b/src/assets/scripts/client/airport/AirportController.js
@@ -87,7 +87,8 @@ export default class AirportController {
         let airportName = DEFAULT_AIRPORT_ICAO;
         console.log('initialAirportData in AirportController Ready');
         console.log(initialAirportData);
-        console.log(initialAirportData.icao);
+        const airportDataType = typeof initialAirportData;
+        console.log(airportDataType);
 
         if (_has(localStorage, STORAGE_KEY.ATC_LAST_AIRPORT) ||
             _has(this.airport.airports, _lowerCase(localStorage[STORAGE_KEY.ATC_LAST_AIRPORT]))
@@ -95,7 +96,8 @@ export default class AirportController {
             airportName = _lowerCase(localStorage[STORAGE_KEY.ATC_LAST_AIRPORT]);
         }
 
-        /*if (airportName !== initialAirportData.icao) {
+        /*
+        if (airportName !== initialAirportData.icao) {
             this.airport_set(airportName);
         }
         */

--- a/src/assets/scripts/client/airport/AirportController.js
+++ b/src/assets/scripts/client/airport/AirportController.js
@@ -91,10 +91,7 @@ export default class AirportController {
             airportName = _lowerCase(localStorage[STORAGE_KEY.ATC_LAST_AIRPORT]);
         }
 
-        console.log(initialAirportData);
-        console.log(airportName);
-
-        if (airportName !== initialAirportData.icao) {
+        if (airportName !== initialAirportData.icao.toLowerCase()) {
             this.airport_set(airportName);
         }
 

--- a/src/assets/scripts/client/airport/AirportController.js
+++ b/src/assets/scripts/client/airport/AirportController.js
@@ -85,25 +85,16 @@ export default class AirportController {
      */
     ready(initialAirportData) {
         let airportName = DEFAULT_AIRPORT_ICAO;
-        console.log('initialAirportData in AirportController Ready');
-        console.log(initialAirportData);
-        const airportDataType = typeof initialAirportData;
-        console.log(airportDataType);
-        //initialAirportData = JSON.parse(initialAirportData);
-        console.log(initialAirportData);
-        console.log(typeof initialAirportData);
-        console.log(initialAirportData.icao);
+
         if (_has(localStorage, STORAGE_KEY.ATC_LAST_AIRPORT) ||
             _has(this.airport.airports, _lowerCase(localStorage[STORAGE_KEY.ATC_LAST_AIRPORT]))
         ) {
             airportName = _lowerCase(localStorage[STORAGE_KEY.ATC_LAST_AIRPORT]);
         }
 
-
         if (airportName !== initialAirportData.icao.toLowerCase()) {
             this.airport_set(airportName);
         }
-
 
         this.airport_set(airportName, initialAirportData);
 

--- a/src/assets/scripts/client/airport/AirportController.js
+++ b/src/assets/scripts/client/airport/AirportController.js
@@ -38,7 +38,8 @@ export default class AirportController {
         this._airportListToLoad = airportLoadList;
         // eslint-disable-next-line no-undef
         prop.airport = airport;
-
+        console.log('initialAirportData in AirportController Constructor');
+        console.log(initialAirportData);
         return this.init()
                    .ready(initialAirportData);
     }
@@ -84,6 +85,8 @@ export default class AirportController {
      */
     ready(initialAirportData) {
         let airportName = DEFAULT_AIRPORT_ICAO;
+        console.log('initialAirportData in AirportController Ready');
+        console.log(initialAirportData);
 
         if (_has(localStorage, STORAGE_KEY.ATC_LAST_AIRPORT) ||
             _has(this.airport.airports, _lowerCase(localStorage[STORAGE_KEY.ATC_LAST_AIRPORT]))

--- a/src/assets/scripts/client/airport/AirportController.js
+++ b/src/assets/scripts/client/airport/AirportController.js
@@ -90,6 +90,7 @@ export default class AirportController {
         const airportDataType = typeof initialAirportData;
         console.log(airportDataType);
         initialAirportData = JSON.parse(initialAirportData);
+        console.log(initialAirportData);
         console.log(typeof initialAirportData);
         if (_has(localStorage, STORAGE_KEY.ATC_LAST_AIRPORT) ||
             _has(this.airport.airports, _lowerCase(localStorage[STORAGE_KEY.ATC_LAST_AIRPORT]))

--- a/src/assets/scripts/client/airport/AirportController.js
+++ b/src/assets/scripts/client/airport/AirportController.js
@@ -89,7 +89,7 @@ export default class AirportController {
         console.log(initialAirportData);
         const airportDataType = typeof initialAirportData;
         console.log(airportDataType);
-        initialAirportData = JSON.parse(initialAirportData);
+        //initialAirportData = JSON.parse(initialAirportData);
         console.log(initialAirportData);
         console.log(typeof initialAirportData);
         console.log(initialAirportData.icao);

--- a/src/assets/scripts/client/airport/AirportModel.js
+++ b/src/assets/scripts/client/airport/AirportModel.js
@@ -516,6 +516,7 @@ export default class AirportModel {
                 // eslint-disable-next-line no-undef
                 log('Parsing terrain');
                 this.parseTerrain(data);
+                log('Parsing terrain complete');
             } catch (e) {
                 throw new Error(e.message);
             }

--- a/src/assets/scripts/client/airport/AirportModel.js
+++ b/src/assets/scripts/client/airport/AirportModel.js
@@ -514,9 +514,7 @@ export default class AirportModel {
         .done((data) => {
             try {
                 // eslint-disable-next-line no-undef
-                log('Parsing terrain');
                 this.parseTerrain(data);
-                log('Parsing terrain complete');
             } catch (e) {
                 throw new Error(e.message);
             }

--- a/src/assets/scripts/client/canvas/CanvasController.js
+++ b/src/assets/scripts/client/canvas/CanvasController.js
@@ -369,10 +369,8 @@ export default class ConvasController {
      * @param name {string}
      */
     canvas_add(name) {
-        console.log('console canvas_add start')
         $(SELECTORS.DOM_SELECTORS.CANVASES).append(`<canvas id='${name}-canvas'></canvas>`);
         this.canvas.contexts[name] = $(`#${name}-canvas`).get(0).getContext('2d');
-        console.log('console canvas_add End')
     }
 
 

--- a/src/assets/scripts/client/canvas/CanvasController.js
+++ b/src/assets/scripts/client/canvas/CanvasController.js
@@ -369,8 +369,10 @@ export default class ConvasController {
      * @param name {string}
      */
     canvas_add(name) {
+        console.log('console canvas_add start')
         $(SELECTORS.DOM_SELECTORS.CANVASES).append(`<canvas id='${name}-canvas'></canvas>`);
         this.canvas.contexts[name] = $(`#${name}-canvas`).get(0).getContext('2d');
+        console.log('console canvas_add End')
     }
 
 


### PR DESCRIPTION
completes #263 
This fixes Firefox not loading by changing ajax to getJSON.  Firefox interprets ajax as a `string` where chrome interprets it as an `object` however the getJSON set the object type to an JSONobject.