### PR TITLE
bugfix/337

### DIFF
--- a/src/assets/scripts/client/aircraft/AircraftCommander.js
+++ b/src/assets/scripts/client/aircraft/AircraftCommander.js
@@ -241,9 +241,6 @@ export default class AircraftCommander {
      * @return {array} [success of operation, readback]
      */
     runClearedAsFiled(aircraft) {
-        const airport = window.airportController.airport_get();
-        const { angle: runwayHeading } = airport.getRunway(aircraft.fms.departureRunway);
-
         return aircraft.pilot.clearedAsFiled();
     }
 
@@ -489,10 +486,10 @@ export default class AircraftCommander {
 
         aircraft.setFlightPhase(FLIGHT_PHASE.WAITING);
 
-        uiController.ui_log(`${aircraft.callsign}, holding short of runway ${aircraft.fms.departureRunway}`);
+        uiController.ui_log(`${aircraft.callsign}, holding short of runway ${aircraft.fms.departureRunway.name}`);
         speech_say([
             { type: 'callsign', content: aircraft },
-            { type: 'text', content: `holding short of runway ${radio_runway(aircraft.fms.departureRunway)}` }
+            { type: 'text', content: `holding short of runway ${radio_runway(aircraft.fms.departureRunway.name)}` }
         ]);
     }
 
@@ -504,8 +501,7 @@ export default class AircraftCommander {
      */
     runTakeoff(aircraft) {
         const airport = this._airportController.airport_get();
-        const runway = airport.getRunway(aircraft.fms.departureRunway);
-        // TODO: this should be a method on the Runway. `findAircraftPositionInQueue(aircraft)`
+        const runway = aircraft.fms.departureRunway;
         const spotInQueue = runway.positionOfAircraftInQueue(aircraft);
         const isInQueue = spotInQueue > -1;
         const aircraftAhead = runway.queue[spotInQueue - 1];
@@ -527,8 +523,8 @@ export default class AircraftCommander {
         }
 
         if (aircraft.flightPhase === FLIGHT_PHASE.TAXI) {
-            readback.log = `unable to take off, we're still taxiing to runway ${aircraft.fms.departureRunway}`;
-            readback.say = `unable to take off, we're still taxiing to runway ${radio_runway(aircraft.fms.departureRunway)}`;
+            readback.log = `unable to take off, we're still taxiing to runway ${runway.name}`;
+            readback.say = `unable to take off, we're still taxiing to runway ${radio_runway(runway.name)}`;
 
             return [false, readback];
         }
@@ -554,10 +550,10 @@ export default class AircraftCommander {
         aircraft.setFlightPhase(FLIGHT_PHASE.TAKEOFF);
         aircraft.scoreWind('taking off');
 
-        readback.log = `wind ${roundedWindAngleInDegrees} at ${roundedWindSpeed}, runway ${aircraft.fms.departureRunway}, ` +
+        readback.log = `wind ${roundedWindAngleInDegrees} at ${roundedWindSpeed}, runway ${runway.name}, ` +
             'cleared for takeoff';
         readback.say = `wind ${radio_spellOut(roundedWindAngleInDegrees)} at ` +
-            `${radio_spellOut(roundedWindSpeed)}, runway ${radio_runway(aircraft.fms.departureRunway)}, cleared for takeoff`;
+            `${radio_spellOut(roundedWindSpeed)}, runway ${radio_runway(runway.name)}, cleared for takeoff`;
 
         return [true, readback];
     }

--- a/src/assets/scripts/client/aircraft/AircraftConflict.js
+++ b/src/assets/scripts/client/aircraft/AircraftConflict.js
@@ -170,17 +170,15 @@ export default class AircraftConflict {
      * Check for a potential head-on collision on a runway
      */
     checkRunwayCollision() {
-        // Check if the aircraft are on a potential collision course
-        // on the runway
-        const airport = window.airportController.airport_get();
+        // Check if the aircraft are on a potential collision course on the runway
 
         // TODO: this logic block needs its own method.
         // Check for the same runway, different ends and under about 6 miles
         if (
             (!this.aircraft[0].isTaxiing() && !this.aircraft[1].isTaxiing()) &&
-            (this.aircraft[0].fms.departureRunway !== null) &&
-            (this.aircraft[0].fms.departureRunway !== this.aircraft[1].fms.departureRunway) &&
-            (airport.getRunway(this.aircraft[1].fms.departureRunway) === airport.getRunway(this.aircraft[0].fms.departureRunway)) &&
+            (this.aircraft[0].fms.currentRunway !== null) &&
+            (this.aircraft[0].fms.currentRunway !== this.aircraft[1].fms.currentRunway) &&
+            (this.aircraft[1].fms.currentRunway.name === this.aircraft[0].fms.currentRunway.name) &&
             (this.distance < 10)
         ) {
             if (!this.conflicts.runwayCollision) {

--- a/src/assets/scripts/client/aircraft/AircraftInstanceModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftInstanceModel.js
@@ -495,11 +495,16 @@ export default class AircraftInstanceModel {
      * Aircraft is established on the course tuned into the nav radio and course buildCurrentTerrainRanges
      *
      * @for AircraftInstanceModel
-     * @method isEstablished
+     * @method isEstablishedOnCourse
      * @return {boolean}
      */
     isEstablishedOnCourse() {
-        const runway = window.airportController.airport_get().getRunway(this.fms.currentRunwayName);
+        const runway = this.fms.arrivalRunway;
+
+        if (!runway) {
+            return false;
+        }
+
         const runwayHeading = runway.angle;
         const approachOffset = getOffset(this, runway.relativePosition, runwayHeading);
         const lateralDistanceFromCourse_nm = abs(nm(approachOffset[0]));
@@ -612,7 +617,7 @@ export default class AircraftInstanceModel {
 
         if (this.isTaxiing()) {
             // show only the first aircraft in the takeoff queue
-            const runway = window.airportController.airport_get().getRunway(this.fms.departureRunway);
+            const runway = this.fms.departureRunway;
             const nextInRunwayQueue = runway.isAircraftNextInQueue(this);
 
             return this.flightPhase === FLIGHT_PHASE.WAITING && nextInRunwayQueue;

--- a/src/assets/scripts/client/aircraft/Pilot/Pilot.js
+++ b/src/assets/scripts/client/aircraft/Pilot/Pilot.js
@@ -676,8 +676,6 @@ export default class Pilot {
         if (this._mcp.speedMode === MCP_MODE.SPEED.OFF) {
             this._mcp.setSpeedN1();
         }
-
-        return [true, `${runway.name}, cleared for takeoff`];
     }
 
     /**

--- a/src/assets/scripts/client/airport/AirportModel.js
+++ b/src/assets/scripts/client/airport/AirportModel.js
@@ -667,8 +667,12 @@ export default class AirportModel {
     }
 
     /**
+     * Return the RunwayModel with the provided name
      *
-     *
+     * @for AirportModel
+     * @method getRunway
+     * @param name {string} name of the runway, eg '28R'
+     * @return {RunwayModel}
      */
     getRunway(name) {
         if (!name) {

--- a/src/assets/scripts/client/canvas/CanvasController.js
+++ b/src/assets/scripts/client/canvas/CanvasController.js
@@ -715,21 +715,20 @@ export default class ConvasController {
     }
 
     /**
+     * Draw a trailing indicator 2.5 NM (4.6km) behind landing aircraft to help with traffic spacing
+     *
      * @for CanvasController
      * @method canvas_draw_separation_indicator
      * @param cc
      * @param aircraft
      */
     canvas_draw_separation_indicator(cc, aircraft) {
-        // Draw a trailing indicator 2.5 NM (4.6km) behind landing aircraft to help with traffic spacing
-        const runwayName = aircraft.fms.currentRunwayName;
-        const rwy = window.airportController.airport_get().getRunway(runwayName);
-
         if (aircraft.category === FLIGHT_CATEGORY.DEPARTURE) {
             return;
         }
 
-        const angle = rwy.angle + Math.PI;
+        const runway = aircraft.fms.currentRunway;
+        const oppositeOfRunwayHeading = runway.angle + Math.PI;
 
         cc.strokeStyle = COLORS.RED_08;
         cc.lineWidth = 3;
@@ -737,7 +736,7 @@ export default class ConvasController {
             window.uiController.km_to_px(aircraft.relativePosition[0]) + this.canvas.panX,
             -window.uiController.km_to_px(aircraft.relativePosition[1]) + this.canvas.panY
         );
-        cc.rotate(angle);
+        cc.rotate(oppositeOfRunwayHeading);
         cc.beginPath();
         cc.moveTo(-5, -window.uiController.km_to_px(5.556));  // 5.556km = 3.0nm
         cc.lineTo(+5, -window.uiController.km_to_px(5.556));  // 5.556km = 3.0nm


### PR DESCRIPTION
Resolves #337.

Fixes cases where the _instance_ of a runway was being passed to `airport.getRunway()` instead of the _name_ of the runway.