### PR TITLE
hotfix/359

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 5.0.1 (April 24, 2017)
+---
+### Hotfix
+- Updates `AircraftStripView` to display departure procedures with the correct `NAME.EXIT` shape [#359](https://github.com/openscope/openscope/issues/359)
+
+
 ## 5.0.0 (April 21, 2017)
 ---
 ### Major

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openscope",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "An ATC simulator in HTML5",
   "engines": {
     "node": "7.0.0",

--- a/src/assets/scripts/client/App.js
+++ b/src/assets/scripts/client/App.js
@@ -33,7 +33,7 @@ const prop = {};
 require('./util');
 
 // saved as this.prop.version and this.prop.version_string
-const VERSION = [5, 0, 0];
+const VERSION = [5, 0, 1];
 
 // are you using a main loop? (you must call update() afterward disable/re-enable)
 let UPDATE = true;

--- a/src/assets/scripts/client/aircraft/AircraftInstanceModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftInstanceModel.js
@@ -1964,10 +1964,7 @@ export default class AircraftInstanceModel {
         const heading = heading_to_string(this.mcp.heading);
         const altitude = this.mcp.altitude;
         const speed = this.mcp.speed;
-
-        let destinationDisplay = !this.pilot.hasDepartureClearance
-            ? this.destination
-            : this.fms.getProcedureAndExitName();
+        let destinationDisplay = this.fms.getProcedureAndExitName();
         const altitudeText = this.taxi_next
             ? 'ready'
             : null;
@@ -1977,11 +1974,11 @@ export default class AircraftInstanceModel {
 
         switch (this.flightPhase) {
             case FLIGHT_PHASE.APRON:
-                this.aircraftStripView.updateViewForApron(this.destination, hasAltitude);
+                this.aircraftStripView.updateViewForApron(destinationDisplay, hasAltitude);
 
                 break;
             case FLIGHT_PHASE.TAXI:
-                this.aircraftStripView.updateViewForTaxi(this.destination, hasAltitude, altitudeText);
+                this.aircraftStripView.updateViewForTaxi(destinationDisplay, hasAltitude, altitudeText);
 
                 break;
             case FLIGHT_PHASE.WAITING:

--- a/src/assets/scripts/client/aircraft/AircraftInstanceModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftInstanceModel.js
@@ -1957,7 +1957,7 @@ export default class AircraftInstanceModel {
      * @method updateStrip
      */
     updateStrip() {
-        if (this.projected) {
+        if (this.projected || !this.inside_ctr) {
             return;
         }
 
@@ -1965,7 +1965,7 @@ export default class AircraftInstanceModel {
         const altitude = this.mcp.altitude;
         const speed = this.mcp.speed;
 
-        let destinationDisplay = !this.mcp.isEnabled
+        let destinationDisplay = !this.pilot.hasDepartureClearance
             ? this.destination
             : this.fms.getProcedureAndExitName();
         const altitudeText = this.taxi_next
@@ -1977,15 +1977,19 @@ export default class AircraftInstanceModel {
 
         switch (this.flightPhase) {
             case FLIGHT_PHASE.APRON:
-                this.aircraftStripView.updateViewForApron(destinationDisplay, hasAltitude);
+                this.aircraftStripView.updateViewForApron(this.destination, hasAltitude);
 
                 break;
             case FLIGHT_PHASE.TAXI:
-                this.aircraftStripView.updateViewForTaxi(destinationDisplay, hasAltitude, altitudeText);
+                this.aircraftStripView.updateViewForTaxi(this.destination, hasAltitude, altitudeText);
 
                 break;
             case FLIGHT_PHASE.WAITING:
-                this.aircraftStripView.updateViewForWaiting(destinationDisplay, this.mcp.isEnabled, hasAltitude);
+                this.aircraftStripView.updateViewForWaiting(
+                    destinationDisplay,
+                    this.pilot.hasDepartureClearance,
+                    hasAltitude
+                );
 
                 break;
             case FLIGHT_PHASE.TAKEOFF:

--- a/src/assets/scripts/client/aircraft/AircraftStripView.js
+++ b/src/assets/scripts/client/aircraft/AircraftStripView.js
@@ -386,6 +386,7 @@ export default class AircraftStripView {
         switch (navMode) {
             case WAYPOINT_NAV_MODE.FIX:
                 this.$heading.text(headingText);
+                this.$destination.text(destinationText.toUpperCase());
 
                 if (isFollowingSID) {
                     this.$heading.addClass(SELECTORS.CLASSNAMES.ALL_SET);
@@ -396,7 +397,6 @@ export default class AircraftStripView {
 
                 if (isFollowingSTAR) {
                     this.$heading.addClass(SELECTORS.CLASSNAMES.FOLLOWING_STAR);
-                    this.$destination.text(destinationText.toUpperCase());
                     this.$destination.addClass(SELECTORS.CLASSNAMES.FOLLOWING_STAR);
 
                     if (fixRestrictions.altitude) {

--- a/src/assets/scripts/client/aircraft/AircraftStripView.js
+++ b/src/assets/scripts/client/aircraft/AircraftStripView.js
@@ -278,6 +278,7 @@ export default class AircraftStripView {
     updateViewForApron(destinationText, hasAltitude) {
         this.$heading.addClass(SELECTORS.CLASSNAMES.RUNWAY);
         this.$heading.text(FLIGHT_PHASE.APRON);
+        this.$destination.text(destinationText.toUpperCase());
 
         if (hasAltitude) {
             this.$altitude.addClass(SELECTORS.CLASSNAMES.RUNWAY);
@@ -295,6 +296,8 @@ export default class AircraftStripView {
         this.$heading.addClass(SELECTORS.CLASSNAMES.RUNWAY);
         this.$heading.text(FLIGHT_PHASE.TAXI);
         this.$speed.addClass(SELECTORS.CLASSNAMES.RUNWAY);
+        this.$destination.text(destinationText.toUpperCase());
+        this.$destination.addClass(SELECTORS.CLASSNAMES.RUNWAY);
 
         if (hasAltitude) {
             this.$altitude.addClass(SELECTORS.CLASSNAMES.RUNWAY);
@@ -303,11 +306,6 @@ export default class AircraftStripView {
         if (altitudeText) {
             this.$altitude.text(altitudeText);
         }
-
-        // if (_isString(destinationText)) {
-        //     this.$destination.text(destinationText.toUpperCase());
-        //     this.$destination.addClass(SELECTORS.CLASSNAMES.RUNWAY);
-        // }
     }
 
     /**
@@ -321,9 +319,9 @@ export default class AircraftStripView {
         this.$heading.addClass(SELECTORS.CLASSNAMES.RUNWAY);
         this.$heading.text(FLIGHT_PHASE.WAITING);
         this.$speed.addClass(SELECTORS.CLASSNAMES.RUNWAY);
+        this.$destination.text(destinationText.toUpperCase());
 
         if (hasClearance) {
-            this.$destination.text(destinationText.toUpperCase());
             this.$destination.addClass(SELECTORS.CLASSNAMES.RUNWAY);
         }
 

--- a/src/assets/scripts/client/aircraft/Pilot/Pilot.js
+++ b/src/assets/scripts/client/aircraft/Pilot/Pilot.js
@@ -713,6 +713,7 @@ export default class Pilot {
 
     /**
      * End of takeoff, stop hand flying, and give the autopilot control of the aircraft
+     *
      * Note: This should be done when the phase changes from takeoff to climb
      * Note: The 'raise landing gear' portion has no relevance, and exists solely for specificity of context
      *


### PR DESCRIPTION
Resolves #359.

Moves insertion of destinationDisplay test to the appropriate place so it displays properly

* switched out mcp.isEnalbed for pilot.hasDepartureClearance
* adds early exit in Aircraft.updateView() for arrival aircraft that are not yet in controlled airspace