### PR TITLE
bugfix/370

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Bugfixes
 - Adds additional check for `undefined` in `CommandParser` when adding args to a `CommandModel` [#364](https://github.com/openscope/openscope/issues/364)
+- Deprecates and removes `AircraftController._setDestinationFromRouteOrProcedure()` as it was implemented to maintain a previous api which is no longer used [#370](https://github.com/openscope/openscope/issues/370)
 
 
 

--- a/src/assets/scripts/client/aircraft/AircraftController.js
+++ b/src/assets/scripts/client/aircraft/AircraftController.js
@@ -420,11 +420,10 @@ export default class AircraftController {
         const { name, fleet } = airlineNameAndFleetHelper([airlineId]);
         const airlineModel = this._airlineController.findAirlineById(name);
         // TODO: impove the `airlineModel` logic here
-        // this seems inefficient to find the model here and then passit back to the controller but
+        // this seems inefficient to find the model here and then pass it back to the controller but
         // since we already have it, it makes little sense to look for it again in the controller
         const flightNumber = this._airlineController.generateFlightNumberWithAirlineModel(airlineModel);
         const aircraftTypeDefinition = this._getRandomAircraftTypeDefinitionForAirlineId(airlineId, airlineModel);
-        const destination = this._setDestinationFromRouteOrProcedure(spawnPatternModel);
         // TODO: this may need to be reworked.
         // if we are building a preSpawn aircraft, cap the altitude at 18000 so aircraft that spawn closer to
         // airspace can safely enter controlled airspace properly
@@ -434,9 +433,9 @@ export default class AircraftController {
         const dynamicPositionModel = convertStaticPositionToDynamic(spawnPatternModel.positionModel);
 
         return {
-            destination,
             fleet,
             altitude,
+            destination: spawnPatternModel.destination,
             callsign: flightNumber,
             category: spawnPatternModel.category,
             airline: airlineModel.icao,
@@ -464,30 +463,5 @@ export default class AircraftController {
      */
     _getRandomAircraftTypeDefinitionForAirlineId(airlineId, airlineModel) {
         return this.aircraftTypeDefinitionCollection.getAircraftDefinitionForAirlineId(airlineId, airlineModel);
-    }
-
-    /**
-     * Determines if `destination` is defined and returns route procedure name if it is not
-     *
-     * The reason we set destination to a procedure names is because the `AircraftStripView`
-     * uses this destination property for display. So for departures, who have no true
-     * destination, the procedure name is used instead
-     *
-     * @for AircraftController
-     * @method _setDestinationFromRouteOrProcedure
-     * @param destination {string}
-     * @param route {string}
-     * @return {string}
-     * @private
-     */
-    _setDestinationFromRouteOrProcedure({ destination, routeString }) {
-        let destinationOrProcedure = destination;
-
-        if (!destination) {
-            const routeModel = new RouteModel(routeString);
-            destinationOrProcedure = routeModel.procedure;
-        }
-
-        return destinationOrProcedure;
     }
 }

--- a/src/assets/scripts/client/aircraft/AircraftInstanceModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftInstanceModel.js
@@ -2005,7 +2005,14 @@ export default class AircraftInstanceModel {
                     altitude: this.fms.currentWaypoint.altitudeRestriction !== -1,
                     speed: this.fms.currentWaypoint.speedRestriction !== -1
                 };
-                destinationDisplay = this.fms.getProcedureAndExitName();
+
+                // TODO: this will need to be addressed when the AircraftStripView is refactored
+                // this block is a bandaid to prevent `destinationDisplay` from being undefined
+                destinationDisplay = this.fms.currentWaypoint.name;
+
+                if (isFollowingStar || isFollowingSid) {
+                    destinationDisplay = this.fms.getProcedureAndExitName();
+                }
 
                 if (this.fms.currentWaypoint.isHold) {
                     cruiseNavMode = WAYPOINT_NAV_MODE.HOLD;

--- a/test/aircraft/AircraftController.spec.js
+++ b/test/aircraft/AircraftController.spec.js
@@ -5,10 +5,7 @@ import AircraftController from '../../src/assets/scripts/client/aircraft/Aircraf
 import { AIRCRAFT_DEFINITION_LIST_MOCK } from './_mocks/aircraftMocks';
 import { airlineControllerFixture } from '../fixtures/airlineFixtures';
 import { navigationLibraryFixture } from '../fixtures/navigationLibraryFixtures';
-import {
-    spawnPatternModelArrivalFixture,
-    spawnPatternModelDepartureFixture
-} from '../fixtures/trafficGeneratorFixtures';
+import { spawnPatternModelArrivalFixture } from '../fixtures/trafficGeneratorFixtures';
 
 global.prop = {};
 
@@ -61,20 +58,4 @@ ava('.removeFlightNumberFromList() calls _airlineController.removeFlightNumberFr
     controller.removeFlightNumberFromList({ airlineId: 'aal', callsign: '123' });
 
     t.true(removeFlightNumberFromListSpy.calledOnce);
-});
-
-ava('._setDestinationFromRouteOrProcedure() returns the SID name as a destination for a departing aircraft', (t) => {
-    const expectedResult = 'COWBY6';
-    const controller = new AircraftController(AIRCRAFT_DEFINITION_LIST_MOCK, airlineControllerFixture, navigationLibraryFixture);
-    const result = controller._setDestinationFromRouteOrProcedure(spawnPatternModelDepartureFixture);
-
-    t.true(result === expectedResult);
-});
-
-ava('._setDestinationFromRouteOrProcedure() returns the destination name an arriving aircraft', (t) => {
-    const expectedResult = 'KLAS';
-    const controller = new AircraftController(AIRCRAFT_DEFINITION_LIST_MOCK, airlineControllerFixture, navigationLibraryFixture);
-    const result = controller._setDestinationFromRouteOrProcedure(spawnPatternModelArrivalFixture);
-
-    t.true(result === expectedResult);
 });


### PR DESCRIPTION
completes openscope/openscope#370 and openscope/openscope#373 and #378 

Deprecates and removes `AircraftController._setDestinationFromRouteOrProcedure()` as it was implemented to maintain a previous api which is no longer used