### PR TITLE
bugfix/399

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Deprecates and removes `AircraftController._setDestinationFromRouteOrProcedure()` as it was implemented to maintain a previous api which is no longer used [#370](https://github.com/openscope/openscope/issues/370)
 - Ensure the verbal and text instructions/readbacks state the correct directionality [#188](https://github.com/openscope/openscope/issues/188)
 - Updates Pilot.applyDepartureProcedure() to use RunwayModel correctly [#396](https://github.com/openscope/openscope/issues/396)
+- Updates `fms.getDestinationName()` to return the `fixName` when `currentLeg` is not a procedure [#399](https://github.com/openscope/openscope/issues/399)
 
 
 

--- a/src/assets/scripts/client/aircraft/FlightManagementSystem/Fms.js
+++ b/src/assets/scripts/client/aircraft/FlightManagementSystem/Fms.js
@@ -383,6 +383,11 @@ export default class Fms {
      * @return {string}
      */
     getDestinationName() {
+        if (!this.currentLeg.isProcedure) {
+            return this.currentWaypoint.name;
+        }
+
+        // TODO: is this needed?
         if (!this.isFollowingStar()) {
             return null;
         }

--- a/test/aircraft/FlightManagementSystem/Fms.spec.js
+++ b/test/aircraft/FlightManagementSystem/Fms.spec.js
@@ -766,6 +766,24 @@ ava('.getDestinationAndRunwayName() returns the name of the current arrival icao
     t.true(result === 'KLAS 19L');
 });
 
+ava('.getDestinationName() returns the currentWaypoint.name when #isProcedure is false', (t) => {
+    const expectedResult = 'dag';
+    const fms = buildFmsMock();
+    fms.legCollection[0].isProcedure = false;
+
+    const result = fms.getDestinationName();
+
+    t.true(result === expectedResult);
+});
+
+ava('.getDestinationName() returns the #currentLeg.exitName when #isFollowingStar is true', (t) => {
+    const expectedResult = 'KLAS';
+    const fms = buildFmsMock();
+    const result = fms.getDestinationName();
+
+    t.true(result === expectedResult);
+});
+
 ava('._buildLegCollection() returns an array of LegModels', (t) => {
     const fms = buildFmsMock(isComplexRoute);
 


### PR DESCRIPTION
fixes #399 

adds additional check to `fms.getDestinationName()` so routes with only fixes will still display a destination