### PR TITLE
bugfix/286

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Add capability for vectors in route strings [#310](https://github.com/openscope/openscope/issues/310)
 - Adds more contex to the Model classes by adding an optional input paramater [#138](https://github.com/openscope/openscope/issues/138)
 - Adds object helper class for object validation  [#191](https://github.com/openscope/openscope/issues/191)
+- Adds early return for ModelSourcePool.releaseReusable   [#286](https://github.com/openscope/openscope/issues/286)
 
 
 

--- a/src/assets/scripts/client/base/ModelSource/ModelSourcePool.js
+++ b/src/assets/scripts/client/base/ModelSource/ModelSourcePool.js
@@ -91,9 +91,13 @@ class ModelSourcePool extends BaseCollection {
     releaseReusable(constructorName, ...args) {
         let model = this._findModelByConstructorName(constructorName);
 
-        if (!model) {
-            model = new CLASS_MAP[constructorName](...args);
+        if(model){
+            model.init(...args);
+            return model;
         }
+
+        model = new CLASS_MAP[constructorName](...args);
+
         // if (constructorName === 'SpawnPatternModel') {debugger;}
         model.init(...args);
 


### PR DESCRIPTION
Completes #286 

Adds an early return for ModelSourcePool.releaseReusable.

I see why one might not have been added here since you need to call `model.init(...args);` either way. But it dose give the advantage of spiking of creating a new constructor object.