### PR TITLE
refactor/427

### DIFF
--- a/assets/airports/ksfo.json
+++ b/assets/airports/ksfo.json
@@ -1,537 +1,584 @@
 {
-    "radio": {
-        "twr": "San Francisco Tower",
-        "app": "NorCal Approach",
-        "dep": "NorCal Departure"
-    },
-    "icao": "KSFO",
-    "iata": "SFO",
-    "magnetic_north": 13.7,
-    "ctr_radius": 80,
-    "ctr_ceiling": 23000,
-    "initial_alt": 5000,
-    "position": ["N37.6195", "W122.3738333", "13ft"],
-    "rr_radius_nm": 5.0,
-    "rr_center": ["N37.6195", "W122.3738333"],
-    "has_terrain": true,
-    "wind": {
-        "angle": 310,
-        "speed": 5
-    },
-    "arrivalRunway": "28L",
-    "departureRunway": "28R",
-    "fixes": {
-        "_FAITH085033": ["N37d19.07m0", "W121d10.80m0"],
-        "_MOVDD038018": ["N37d50.88m0", "W121d09.11m0"],
-        "_PIRAT237029": ["N37d05.73m0", "W123d25.99m0"],
-        "_PYE306024"  : ["N38d23.95m0", "W123d10.44m0"],
-        "_SIPLY233-STINS144": ["N37.468500", "W122.575333"],
-        "_SKUNK155020": ["N36d40.83m0", "W121d57.04m0"],
-        "ALWYS": ["N37d38.01m0", "W120d57.57m0"],
-        "ANJEE": ["N36d44.78m0", "W121d57.89m0"],
-        "ARCHI": ["N37.4908333", "W121.8755"],
-        "AVE"  : ["N35d38m49.11", "W119d58m42.98"],
-        "AXMUL": ["N37.571517", "W122.257208"],
-        "BDEGA": ["N37d49.38m0", "W122d35.53m0"],
-        "BENET": ["N33.596667", "W118.841833"],
-        "BERKS": ["N37.860861", "W122.211678"],
-        "BGGLO": ["N38d13.48m0", "W122d46.05m0"],
-        "BOLDR": ["N37.170833", "W122.0761667"],
-        "BRIXX": ["N37d37.07m0", "W122d22.47m0"],
-        "BSR"  : ["N36.181333", "W121.642167"],
-        "BSR"  : ["N36.1813333", "W121.6421667"],
-        "BYRON": ["N37d49.37m0", "W121d28.16m0"],
-        "CARME": ["N36d27.31m0", "W121d52.78m0"],
-        "CEDES": ["N37.55083", "W121.6246667"],
-        "CEPIN": ["N37.536",   "W122.17283" ],
-        "CIC"  : ["N39.789825", "W121.847195"],
-        "CORKK": ["N37d44.02m0", "W122d29.85m0"],
-        "CYPRS": ["N36.422333", "W122.432167"],
-        "CZQ"  : ["N36d53m3.56", "W119d48m54.48"],
-        "DAISY": ["N34.259500", "W120.131333"],
-        "DEEAN": ["N38d20.95m0", "W123d18.14m0"],
-        "DIVEC": ["N37.432883", "W121.935008"],
-        "DUMBA": ["N37.5035167", "W122.0961472"],
-        "DUXBY": ["N37.6958333", "W122.4553333"],
-        "DYAMD": ["N37d41.95m0", "W120d24.27m0"],
-        "ECA"  : ["N37d50.02m0", "W121d10.28m0"],
-        "EDDYY": ["N37.32645", "W122.0997083"],
-        "ENI"  : ["N39.053167", "W123.274333"],
-        "EPICK": ["N36.9508222", "W121.9526722"],
-        "EUGEN": ["N37.093447", "W122.444214"],
-        "FAITH": ["N37.40121667", "W121.8619"],
-        "FLOWZ": ["N37d35.55m0", "W121d15.88m0"],
-        "FLW"  : ["N35.093084", "W119.865579"],
-        "FRELY": ["N37.510575", "W121.7931528"],
-        "FRIGG": ["N37d27.93m0", "W121d15.44m0"],
-        "GEEHH": ["N38d27.20m0", "W122d25.72m0"],
-        "GROAN": ["N37.5903333", "W121.2851667"],
-        "GVO"  : ["N34.531320", "W120.091088"],
-        "HADLY": ["N37.402358", "W122.575592"],
-        "HEMAN": ["N37d32m1.86", "W122d10m24.00"],
-        "JONNE": ["N38d33.06m0", "W122d51.80m0"],
-        "LAANE": ["N37d39.54m0", "W120d44.84m0"],
-        "LIN"  : ["N38.074588", "W121.003858"],
-        "LOCKE": ["N37.7135", "W121.5096666667"],
-        "LOZIT": ["N37.899333", "W122.6731667"],
-        "LUVVE": ["N37.497367", "W122.231053"],
-        "MCKEY": ["N35.483167", "W121.083167"],
-        "MEHTA": ["N37.461692", "W121.996525" ],
-        "MENLO": ["N37.46367",  "W122.15367" ],
-        "MOLEN": ["N37.997872", "W123.086797"],
-        "MOVDD": ["N37.661333", "W121.4481667"],
-        "MQO"  : ["N35.252255", "W120.759566"],
-        "MSCAT": ["N38d34.00m0", "W122d40.30m0"],
-        "MXW"  : ["N39d19.05m0", "W122d13.29m0"],
-        "NEPIC": ["N37.585894", "W122.296883"],
-        "NORMM": ["N37.720208", "W122.613172"],
-        "OSI"  : ["N37.3925", "W122.28133333"],
-        "OSI":   ["N37.3925", "W122.28133333"],
-        "PIRAT": ["N37d15m27.54", "W122d51m48.07"],
-        "PONKE": ["N37.458817", "W121.996053"],
-        "PORTE": ["N37.489786", "W122.474578"],
-        "PXN"  : ["N36d42m55.56", "W120d46m43.26"],
-        "PYE"  : ["N38.0798333", "W122.8678333"],
-        "QUINN": ["N38d28.80m0", "W123d05.29m0"],
-        "RBL"  : ["N40.098833", "W122.236333"],
-        "REBAS": ["N37.940683", "W122.383667"],
-        "RISTI": ["N37.60817", "W121.53333"],
-        "ROKME": ["N37.510592", "W122.118275"],
-        "RZS"  : ["N34.509534", "W119.770992"],
-        "SAC"  : ["N38.443745", "W121.551649"],
-        "SASLY": ["N37.678500", "W122.334500"],
-        "SASSU": ["N38.367867", "W122.390483"],
-        "SAU"  : ["N37.8553333", "W122.5228333"],
-        "SAWNA": ["N38.868500", "W122.401833"],
-        "SEGUL": ["N36.963036", "W122.572131"],
-        "SENZY": ["N37.666500", "W122.485167"],
-        "SEPDY": ["N37.685667", "W122.363667"],
-        "SFO"  : ["N37.6195", "W122.3738333"],
-        "SHOEY": ["N36.746000", "W122.136000"],
-        "SIPLY": ["N37.585333", "W122.233500"],
-        "SKUNK": ["N37.007594", "W122.033228"],
-        "SNORA": ["N37d38.73m0", "W119d48.38m0"],
-        "SNS"  : ["N36.663833", "W121.603167"],
-        "SOOIE": ["N37d25.71m0", "W121d36.46m0"],
-        "STINS": ["N37.823667", "W122.7566667"],
-        "SWELS": ["N37.3681556","W122.1160806"],
-        "SXC"  : ["N33.375000", "W118.419833"],
-        "TAILS": ["N37.272861", "W122.520369"],
-        "UPEND": ["N38.032",  "W122.097"],
-        "WAGES": ["N36d50m46.00", "W121d44m22.00"],
-        "WAMMY": ["N37.541064", "W122.724056"],
-        "WESLA": ["N37.664372", "W122.480292"],
-        "WETOR": ["N37.484719", "W122.057142"],
-        "YOSEM": ["N37d45.76m0", "W118d46.00m0"],
-        "ZUPAX": ["N37.254497", "W122.588508"]
-    },
-    "runways":[
-        {
-            "name":        ["28R", "10L"],
-            "name_offset": [[0, 0.3], [0, 0.3]],
-            "end":    [ ["N37.6135324", "W122.3571410", "13.0ft"], ["N37.6287386", "W122.3933911", "5.5ft"]],
-            "ils":         [true, true],
-            "ils_distance":[30, 25]
-        },
-        {
-            "name":        ["28L", "10R"],
-            "name_offset": [[0, -0.2], [0, -0.3]],
-            "end":    [["N37.6117091", "W122.3583420", "12.6ft"], ["N37.6262900", "W122.3931054", "7.1ft"]],
-            "ils":         [true, true],
-            "ils_distance":[30, 25]
-        },
-        {
-            "name":        ["19L", "1R"],
-            "name_offset": [[0.3, -0.1], [0.4, 0]],
-            "end":    [["N37.6273412","W122.3671104", "10.5ft"], ["N37.6063291", "W122.3810404", "11.4ft"] ],
-            "ils":         [true, true]
-        },
-        {
-            "name":        ["19R", "1L"],
-            "name_offset": [[-0.3, 0], [-0.3, 0.1]],
-            "end":    [["N37.6264803", "W122.3706090", "9.2ft"], ["N37.6078970","W122.3829280", "10.7ft"]],
-            "ils":         [true, true]
-        }
-    ],
-    "sids": {
-        "OFFSH9": {
-            "icao": "OFFSH9",
-            "name": "Offshore Nine",
-            "rwy": {
-                "1L" : [["SEPDY", "A16+"], "WAMMY"],
-                "1R" : [["SEPDY", "A16+"], "WAMMY"],
-                "28L": [["SENZY", "A25+"], "WAMMY"],
-                "28R": [["SENZY", "A25+"], "WAMMY"]
-            },
-            "body": [["SEGUL", "A160+"], ["CYPRS", "A220+"], "MCKEY"],
-            "exitPoints": {
-                "FLW": ["MQO", "FLW"],
-                "RZS": ["MQO", "RZS"],
-                "GVO": ["MQO", "GVO"],
-                "SXC": ["DAISY", "BENET", "SXC"]
-            },
-            "draw": [["SEPDY","WAMMY"], ["SENZY","WAMMY","SEGUL","CYPRS","MCKEY"], ["MCKEY","MQO"], ["MQO","FLW*"], ["MQO","RZS*"], ["MQO","GVO*"], ["MCKEY","DAISY","BENET","SXC*"]]
-        },
-        "PORTE7": {
-            "icao": "PORTE7",
-            "name": "PORTE SEVEN",
-            "rwy": {
-                "1L" : [["SEPDY", "A19+"], "PORTE"],
-                "1R" : [["SEPDY", "A19+"], "PORTE"],
-                "28L": [["SENZY", "A25+"], "PORTE"],
-                "28R": [["SENZY", "A25+"], "PORTE"]
-            },
-            "body": ["OSI", "WAGES"],
-            "exitPoints": {
-                "CZQ": ["CZQ"],
-                "PXN": ["PXN"],
-                "FLW": ["FLW"],
-                "AVE": ["AVE"]
-            },
-            "draw": [["SEPDY","PORTE"], ["SENZY","PORTE","OSI","WAGES"], ["WAGES","CZQ*"], ["WAGES","AVE*"], ["WAGES","PXN*"], ["WAGES", "FLW*"]]
-        },
-        "QUIET7": {
-            "icao": "QUIET7",
-            "name": "Quiet Seven",
-            "rwy": {
-                "1L" : ["SASLY", "REBAS"],
-                "1R" : ["SASLY", "REBAS"],
-                "28L": ["REBAS"],
-                "28R": ["REBAS"]
-            },
-            "body": [],
-            "exitPoints": {
-                "ENI": ["SASSU", "ENI"],
-                "RBL": ["SASSU", "SAWNA", "RBL"],
-                "CIC": ["SASSU", "SAWNA", "CIC"],
-                "SAC": ["SAC"],
-                "LIN": ["LIN"]
-            },
-            "draw": [["SASLY","REBAS"], ["REBAS","SASSU"], ["SASSU","ENI*"], ["SASSU","SAWNA"], ["SAWNA","RBL*"], ["SAWNA","CIC*"], ["REBAS","SAC*"], ["REBAS","LIN*"]]
-        },
-        "MOLEN7": {
-            "icao": "MOLEN7",
-            "name": "Molen Seven",
-            "rwy": {
-                "10L": [["SIPLY", "A25+"], "_SIPLY233-STINS144", ["STINS", "A220-"]],
-                "10R": [["SIPLY", "A25+"], "_SIPLY233-STINS144", ["STINS", "A220-"]],
-                "28L": [["WESLA", "A18+"], ["STINS", "A220-"]],
-                "28R": [["WESLA", "A18+"], ["STINS", "A220-"]]
-            },
-            "body": ["MOLEN"],
-            "exitPoints": {
-                "ENI": ["ENI"]
-            },
-            "draw": [["SIPLY","_SIPLY233-STINS144","STINS"], ["WESLA","STINS","MOLEN"], ["MOLEN","ENI*"]]
-        }
-    },
-    "stars": {
-        "BDEGA2": {
-            "icao": "BDEGA2",
-            "name": "Bidayga Two",
-            "entryPoints": {
-                "DEEAN": [["DEEAN", "A240+|S280"]],
-                "QUINN": [["QUINN", "A240+|S280"], ["BGGLO", "A190+|S280"]],
-                "JONNE": [["JONNE", "A240+|S280"], ["BGGLO", "A190+|S280"]],
-                "MSCAT": [["MSCAT", "A240+|S280"], ["BGGLO", "A190+|S280"]],
-                "GEEHH": [["GEEHH", "A240+|S280"], ["BGGLO", "A190+|S280"]]
-            },
-            "body": [["LOZIT", "A160-|S280"], ["BDEGA", "A130-"], ["CORKK", "A110|S250"], "BRIXX"],
-            "rwy": {
-                "10L": [],
-                "10R": [],
-                "28L": [],
-                "28R": []
-            },
-            "draw": [["DEEAN*","LOZIT"], ["QUINN*","BGGLO","LOZIT"], ["JONNE*","BGGLO","LOZIT"], ["MSCAT*","BGGLO","LOZIT"], ["GEEHH*","BGGLO","LOZIT"], ["LOZIT","BDEGA","CORKK","BRIXX"]]
-        },
-        "BSR2": {
-            "icao": "BSR2",
-            "name": "Big Sur Two",
-            "entryPoints": {
-                "BSR": ["BSR"]
-            },
-            "body": ["CARME", "ANJEE", ["SKUNK", "A120-|S280"], ["BOLDR", "A100|S250"], "MENLO"],
-            "rwy": {
-                "10L": [],
-                "10R": [],
-                "28L": [],
-                "28R": []
-            },
-            "draw": [["BSR*","CARME","ANJEE","SKUNK","BOLDR","MENLO"]]
-        },
-        "DYAMD2": {
-            "icao": "DYAMD2",
-            "name": "Diamond Two",
-            "entryPoints": {
-                "DYAMD": [["DYAMD", "A270+"]]
-            },
-            "body": [["LAANE", "A260-|S280"], "ALWYS", ["FLOWZ", "A190-|S280"], ["CEDES", "A120-|S250"], ["FRELY", "A80|S240"], ["ARCHI", "A70|S230"]],
-            "rwy": {
-                "10L": [],
-                "10R": [],
-                "28L": [],
-                "28R": []
-            },
-            "draw": [["DYAMD*","LAANE","ALWYS","FLOWZ","CEDES","FRELY","ARCHI"]]
-        },
-        "PYE1": {
-            "icao": "PYE1",
-            "name": "Point Reyes One",
-            "entryPoints": {
-                "ENI": ["ENI"],
-                "MXW": ["MXW"]
-            },
-            "body": [["PYE", "A240|S280"], ["STINS", "A230|S250"], ["HADLY", "A100-|S230"], ["OSI", "A30|S210"]],
-            "rwy": {
-                "10L": [],
-                "10R": [],
-                "28L": [],
-                "28R": []
-            },
-            "draw": [["ENI*","PYE"], ["MXW*","PYE"], ["PYE","STINS","HADLY","OSI"]]
-        },
-        "YOSEM3": {
-            "icao": "YOSEM3",
-            "name": "Yosem Three",
-            "entryPoints": {
-                "YOSEM": ["YOSEM"]
-            },
-            "body": [["SNORA", "A270+|S280"], ["FRIGG", "A190-"], ["SOOIE", "A130-|S250"], ["FAITH", "A80"]],
-            "rwy": {
-                "10L": [],
-                "10R": [],
-                "28L": [],
-                "28R": []
-            },
-            "draw": [["YOSEM*","SNORA","FRIGG","SOOIE","FAITH"]]
-        }
-    },
-    "spawnPatterns": [
-        {
-            "airlines": [
-                ["ual", 10],
-                ["aal", 8],
-                ["dal", 6],
-                ["ual/long", 5],
-                ["aal/long", 2],
-                ["dal/long", 2],
-                ["swa", 5],
-                ["asa", 3],
-                ["aca", 2],
-                ["cpa", 2],
-                ["baw/long", 2],
-                ["ups", 1],
-                ["fdx", 1],
-                ["klm/long", 2],
-                ["afr/long", 2],
-                ["uae", 4],
-                ["kal/long", 2],
-                ["vir", 2]
-            ],
-            "destination": "",
-            "origin": "KSFO",
-            "category": "departure",
-            "route": "KSFO.MOLEN7.ENI",
-            "altitude": null,
-            "method": "random",
-            "rate": 9,
-            "speed": null
-        },
-        {
-            "airlines": [
-                ["ual", 10],
-                ["aal", 8],
-                ["dal", 6],
-                ["ual/long", 5],
-                ["aal/long", 2],
-                ["dal/long", 2],
-                ["swa", 5],
-                ["asa", 3],
-                ["aca", 2],
-                ["cpa", 2],
-                ["baw/long", 2],
-                ["ups", 1],
-                ["fdx", 1],
-                ["klm/long", 2],
-                ["afr/long", 2],
-                ["uae", 4],
-                ["kal/long", 2],
-                ["vir", 2]
-            ],
-            "destination": "",
-            "origin": "KSFO",
-            "category": "departure",
-            "route": "KSFO.OFFSH9.SXC",
-            "altitude": null,
-            "method": "random",
-            "rate": 9,
-            "speed": null
-        },
-        {
-            "airlines": [
-                ["ual", 10],
-                ["aal", 8],
-                ["dal", 6],
-                ["ual/long", 5],
-                ["aal/long", 2],
-                ["dal/long", 2],
-                ["swa", 5],
-                ["asa", 3],
-                ["aca", 2],
-                ["cpa", 2],
-                ["baw/long", 2],
-                ["ups", 1],
-                ["fdx", 1],
-                ["klm/long", 2],
-                ["afr/long", 2],
-                ["uae", 4],
-                ["kal/long", 2],
-                ["vir", 2]
-            ],
-            "destination": "",
-            "origin": "KSFO",
-            "category": "departure",
-            "route": "KSFO.PORTE7.CZQ",
-            "altitude": null,
-            "method": "random",
-            "rate": 9,
-            "speed": null
-        },
-        {
-            "airlines": [
-                ["ual", 10],
-                ["aal", 8],
-                ["dal", 6],
-                ["ual/long", 5],
-                ["aal/long", 2],
-                ["dal/long", 2],
-                ["swa", 5],
-                ["asa", 3],
-                ["aca", 2],
-                ["cpa", 2],
-                ["baw/long", 2],
-                ["ups", 1],
-                ["fdx", 1],
-                ["klm/long", 2],
-                ["afr/long", 2],
-                ["uae", 4],
-                ["kal/long", 2],
-                ["vir", 2]
-            ],
-            "destination": "",
-            "origin": "KSFO",
-            "category": "departure",
-            "route": "KSFO.QUIET7.RBL",
-            "altitude": null,
-            "method": "random",
-            "rate": 9,
-            "speed": null
-        },
-        {
-            "airlines": [
-                ["ual", 5],
-                ["ual/long", 2],
-                ["swa", 1],
-                ["dal", 5],
-                ["dal/long", 2],
-                ["aal", 5],
-                ["aal/long", 2],
-                ["asa", 1],
-                ["fdx", 1]
-            ],
-            "destination": "KSFO",
-            "origin": "",
-            "category": "arrival",
-            "route": "QUINN.BDEGA2.KSFO",
-            "altitude": 24000,
-            "method": "random",
-            "rate": 10,
-            "speed": 280
-        },
-        {
-            "airlines": [
-                ["ual", 5],
-                ["ual/long", 2],
-                ["swa", 1],
-                ["dal", 5],
-                ["dal/long", 2],
-                ["aal", 5],
-                ["aal/long", 2],
-                ["asa", 1],
-                ["fdx", 1]
-            ],
-            "destination": "KSFO",
-            "origin": "",
-            "category": "arrival",
-            "route": "BSR.BSR2.KSFO",
-            "altitude": 18000,
-            "method": "random",
-            "rate": 10,
-            "speed": 280
-        },
-        {
-            "airlines": [
-                ["ual", 5],
-                ["ual/long", 2],
-                ["swa", 1],
-                ["dal", 5],
-                ["dal/long", 2],
-                ["aal", 5],
-                ["aal/long", 2],
-                ["asa", 1],
-                ["fdx", 1]
-            ],
-            "destination": "KSFO",
-            "origin": "",
-            "category": "arrival",
-            "route": "DYAMD.DYAMD2.KSFO",
-            "altitude": 27000,
-            "method": "random",
-            "rate": 10,
-            "speed": 280
-        },
-        {
-            "airlines": [
-                ["ual", 5],
-                ["ual/long", 2],
-                ["swa", 1],
-                ["dal", 5],
-                ["dal/long", 2],
-                ["aal", 5],
-                ["aal/long", 2],
-                ["asa", 1],
-                ["fdx", 1]
-            ],
-            "destination": "KSFO",
-            "origin": "",
-            "category": "arrival",
-            "route": "MXW.PYE1.KSFO",
-            "altitude": 34000,
-            "method": "random",
-            "rate": 10,
-            "speed": 320
-        },
-        {
-            "airlines": [
-                ["ual", 5],
-                ["ual/long", 2],
-                ["swa", 1],
-                ["dal", 5],
-                ["dal/long", 2],
-                ["aal", 5],
-                ["aal/long", 2],
-                ["asa", 1],
-                ["fdx", 1]
-            ],
-            "destination": "KSFO",
-            "origin": "",
-            "category": "arrival",
-            "route": "YOSEM.YOSEM3.KSFO",
-            "altitude": 34000,
-            "method": "random",
-            "rate": 10,
-            "speed": 280
-        }
-    ]
+	"radio": {
+		"twr": "San Francisco Tower",
+		"app": "NorCal Approach",
+		"dep": "NorCal Departure"
+	},
+	"icao": "KSFO",
+	"iata": "SFO",
+	"magnetic_north": 13.7,
+	"ctr_radius": 80,
+	"ctr_ceiling": 23000,
+	"initial_alt": 5000,
+	"position": ["N37.6195", "W122.3738333", "13ft"],
+	"rr_radius_nm": 5.0,
+	"rr_center": ["N37.6195", "W122.3738333"],
+	"has_terrain": true,
+	"wind": {
+		"angle": 310,
+		"speed": 5
+	},
+	"fixes": {
+		"_FAITH085033": ["N37d19.07m0", "W121d10.80m0"],
+		"_MOVDD038018": ["N37d50.88m0", "W121d09.11m0"],
+		"_PIRAT237029": ["N37d05.73m0", "W123d25.99m0"],
+		"_PYE306024"  : ["N38d23.95m0", "W123d10.44m0"],
+		"_SIPLY233-STINS144": ["N37.468500", "W122.575333"],
+		"_SKUNK155020": ["N36d40.83m0", "W121d57.04m0"],
+		"ALWYS": ["N37d38.01m0", "W120d57.57m0"],
+		"ANJEE": ["N36d44.78m0", "W121d57.89m0"],
+		"ARCHI": ["N37.4908333", "W121.8755"],
+		"AVE"  : ["N35d38m49.11", "W119d58m42.98"],
+		"AXMUL": ["N37.571517", "W122.257208"],
+		"BDEGA": ["N37d49.38m0", "W122d35.53m0"],
+		"BENET": ["N33.596667", "W118.841833"],
+		"BERKS": ["N37.860861", "W122.211678"],
+		"BGGLO": ["N38d13.48m0", "W122d46.05m0"],
+		"BOLDR": ["N37.170833", "W122.0761667"],
+		"BRIXX": ["N37d37.07m0", "W122d22.47m0"],
+		"BSR"  : ["N36.1813333", "W121.6421667"],
+		"BYRON": ["N37d49.37m0", "W121d28.16m0"],
+		"CARME": ["N36d27.31m0", "W121d52.78m0"],
+		"CEDES": ["N37.55083", "W121.6246667"],
+		"CEPIN": ["N37.536",   "W122.17283" ],
+		"CIC"  : ["N39.789825", "W121.847195"],
+		"CORKK": ["N37d44.02m0", "W122d29.85m0"],
+		"CYPRS": ["N36.422333", "W122.432167"],
+		"CZQ"  : ["N36d53m3.56", "W119d48m54.48"],
+		"DAISY": ["N34.259500", "W120.131333"],
+		"DEEAN": ["N38d20.95m0", "W123d18.14m0"],
+		"DIVEC": ["N37.432883", "W121.935008"],
+		"DUMBA": ["N37.5035167", "W122.0961472"],
+		"DUXBY": ["N37.6958333", "W122.4553333"],
+		"DYAMD": ["N37d41.95m0", "W120d24.27m0"],
+		"ECA"  : ["N37d50.02m0", "W121d10.28m0"],
+		"ENI"  : ["N39.053167", "W123.274333"],
+		"EUGEN": ["N37.093447", "W122.444214"],
+		"FAITH": ["N37.40121667", "W121.8619"],
+		"FLOWZ": ["N37d35.55m0", "W121d15.88m0"],
+		"FLW"  : ["N35.093084", "W119.865579"],
+		"FRELY": ["N37.510575", "W121.7931528"],
+		"FRIGG": ["N37d27.93m0", "W121d15.44m0"],
+		"GEEHH": ["N38d27.20m0", "W122d25.72m0"],
+		"GROAN": ["N37.5903333", "W121.2851667"],
+		"GVO"  : ["N34.531320", "W120.091088"],
+		"HADLY": ["N37.402358", "W122.575592"],
+		"HEMAN": ["N37d32m1.86", "W122d10m24.00"],
+		"JONNE": ["N38d33.06m0", "W122d51.80m0"],
+		"LAANE": ["N37d39.54m0", "W120d44.84m0"],
+		"LIN"  : ["N38.074588", "W121.003858"],
+		"LOCKE": ["N37.7135", "W121.5096666667"],
+		"LOZIT": ["N37.899333", "W122.6731667"],
+		"LUVVE": ["N37.497367", "W122.231053"],
+		"MCKEY": ["N35.483167", "W121.083167"],
+		"MEHTA": ["N37.461692", "W121.996525" ],
+		"MENLO": ["N37.46367",  "W122.15367" ],
+		"MOLEN": ["N37.997872", "W123.086797"],
+		"MOVDD": ["N37.661333", "W121.4481667"],
+		"MQO"  : ["N35.252255", "W120.759566"],
+		"MSCAT": ["N38d34.00m0", "W122d40.30m0"],
+		"MXW"  : ["N39d19.05m0", "W122d13.29m0"],
+		"NEPIC": ["N37.585894", "W122.296883"],
+		"NORMM": ["N37.720208", "W122.613172"],
+		"OSI":   ["N37.3925", "W122.28133333"],
+		"PIRAT": ["N37d15m27.54", "W122d51m48.07"],
+		"PONKE": ["N37.458817", "W121.996053"],
+		"PORTE": ["N37.489786", "W122.474578"],
+		"PXN"  : ["N36d42m55.56", "W120d46m43.26"],
+		"PYE"  : ["N38.0798333", "W122.8678333"],
+		"QUINN": ["N38d28.80m0", "W123d05.29m0"],
+		"RBL"  : ["N40.098833", "W122.236333"],
+		"REBAS": ["N37.940683", "W122.383667"],
+		"RISTI": ["N37.60817", "W121.53333"],
+		"ROKME": ["N37.510592", "W122.118275"],
+		"RZS"  : ["N34.509534", "W119.770992"],
+		"SAC"  : ["N38.443745", "W121.551649"],
+		"SASLY": ["N37.678500", "W122.334500"],
+		"SASSU": ["N38.367867", "W122.390483"],
+		"SAU"  : ["N37.8553333", "W122.5228333"],
+		"SAWNA": ["N38.868500", "W122.401833"],
+		"SEGUL": ["N36.963036", "W122.572131"],
+		"SENZY": ["N37.666500", "W122.485167"],
+		"SEPDY": ["N37.685667", "W122.363667"],
+		"SFO"  : ["N37.6195", "W122.3738333"],
+		"SHOEY": ["N36.746000", "W122.136000"],
+		"SIPLY": ["N37.585333", "W122.233500"],
+		"SKUNK": ["N37.007594", "W122.033228"],
+		"SNORA": ["N37d38.73m0", "W119d48.38m0"],
+		"SNS"  : ["N36.663833", "W121.603167"],
+		"SOOIE": ["N37d25.71m0", "W121d36.46m0"],
+
+		"TYDYE": ["N37.689319", "W122.268944"],
+		"TRUKN": ["N37.717558", "W122.214589"],
+		"HYPEE": ["N37.880244", "W122.067483"],
+		"COSMC": ["N37.826061", "W122.004900"],
+		"SYRAH": ["N37.991050", "W121.103089"],
+		"TIPRE": ["N38.205833", "W121.035833"],
+		"MOGEE": ["N38.336111", "W121.389722"],
+		"ORRCA": ["N38.443658", "W121.551622"],
+		"DEDHD": ["N38.335517", "W122.112808"],
+		"GRTFL": ["N38.352169", "W122.231469"],
+
+		"SSTIK": ["N37.678344", "W122.361658"],
+		"UTOOB": ["N37.411597", "W122.338883"],
+		"NTELL": ["N36.899719", "W119.889503"],
+		"KAYEX": ["N36.487486", "W120.947858"],
+		"LOSHN": ["N35.847608", "W120.000475"],
+		"SUSEY": ["N36.432464", "W121.063331"],
+		"EBAYE": ["N35.868719", "W120.260558"],
+		"KTINA": ["N36.384333", "W121.163506"],
+		"CISKO": ["N35.697506", "W120.465178"],
+		"FFOIL": ["N37.006203", "W122.564189"],
+		"FLOKK": ["N36.523650", "W122.107556"],
+		"YYUNG": ["N35.516083", "W121.068686"],
+
+		"SERFR": ["N36.068306", "W121.364664"],
+		"NRRLI": ["N36.495600", "W121.699400"],
+		"WWAVS": ["N36.741531", "W121.894233"],
+		"EPICK": ["N36.950822", "W121.952672"],
+		"EDDYY": ["N37.326450", "W122.099708"],
+		"SWELS": ["N37.368156", "W122.116081"],
+
+		"GNNRR": ["N37.674744", "W122.503383"],
+		"AMAKR": ["N39.000000", "W123.750000"],
+		"ALCOA": ["N37.833253", "W125.834525"],
+		"ALLBE": ["N37.506389", "W127.000000"],
+		"BAART": ["N36.461944", "W126.933333"],
+		"ALANN": ["N35.596667", "W125.940000"],
+
+		"OAK": ["N37.725920", "W122.223588"],
+
+		"STINS": ["N37.823678", "W122.756683"],
+		"SXC"  : ["N33.375000", "W118.419833"],
+		"TAILS": ["N37.272861", "W122.520369"],
+		"UPEND": ["N38.032",  "W122.097"],
+		"WAGES": ["N36d50m46.00", "W121d44m22.00"],
+		"WAMMY": ["N37.541064", "W122.724056"],
+		"WESLA": ["N37.664372", "W122.480292"],
+		"WETOR": ["N37.484719", "W122.057142"],
+		"YOSEM": ["N37d45.76m0", "W118d46.00m0"],
+		"ZUPAX": ["N37.254497", "W122.588508"]
+	},
+	"runways":[
+			   {
+			   "name":        ["28R", "10L"],
+			   "name_offset": [[0, 0.3], [0, 0.3]],
+			   "end":    [ ["N37.6135324", "W122.3571410", "13.0ft"], ["N37.6287386", "W122.3933911", "5.5ft"]],
+			   "ils":         [true, true],
+			   "ils_distance":[30, 25]
+			   },
+			   {
+			   "name":        ["28L", "10R"],
+			   "name_offset": [[0, -0.2], [0, -0.3]],
+			   "end":    [["N37.6117091", "W122.3583420", "12.6ft"], ["N37.6262900", "W122.3931054", "7.1ft"]],
+			   "ils":         [true, true],
+			   "ils_distance":[30, 25]
+			   },
+			   {
+			   "name":        ["19L", "1R"],
+			   "name_offset": [[0.3, -0.1], [0.4, 0]],
+			   "end":    [["N37.6273412","W122.3671104", "10.5ft"], ["N37.6063291", "W122.3810404", "11.4ft"] ],
+			   "ils":         [true, true]
+			   },
+			   {
+			   "name":        ["19R", "1L"],
+			   "name_offset": [[-0.3, 0], [-0.3, 0.1]],
+			   "end":    [["N37.6264803", "W122.3706090", "9.2ft"], ["N37.6078970","W122.3829280", "10.7ft"]],
+			   "ils":         [true, true]
+			   }
+			   ],
+	"sids": {
+		"OFFSH1": {
+			"icao": "OFFSH1",
+			"name": "Offshore One",
+			"rwy": {
+				"1L" : [["SEPDY", "A16+"], "WAMMY"],
+				"1R" : [["SEPDY", "A16+"], "WAMMY"],
+				"28L": [["SENZY", "A25+"], "WAMMY"],
+				"28R": [["SENZY", "A25+"], "WAMMY"]
+			},
+			"body": [["SEGUL", "A160+"], ["CYPRS", "A220+"], "MCKEY"],
+			"exitPoints": {
+				"FLW": ["MQO", "FLW"],
+				"RZS": ["MQO", "RZS"],
+				"GVO": ["MQO", "GVO"],
+				"SXC": ["DAISY", "BENET", "SXC"]
+			},
+			"draw": [["SEPDY","WAMMY"], ["SENZY","WAMMY","SEGUL","CYPRS","MCKEY"], ["MCKEY","MQO"], ["MQO","FLW*"], ["MQO","RZS*"], ["MQO","GVO*"], ["MCKEY","DAISY","BENET","SXC*"]]
+		},
+		"PORTE7": {
+			"icao": "PORTE7",
+			"name": "PORTE SEVEN",
+			"rwy": {
+				"1L" : [["SEPDY", "A19+"], "PORTE"],
+				"1R" : [["SEPDY", "A19+"], "PORTE"],
+				"28L": [["SENZY", "A25+"], "PORTE"],
+				"28R": [["SENZY", "A25+"], "PORTE"]
+			},
+			"body": ["OSI", "WAGES"],
+			"exitPoints": {
+				"CZQ": ["CZQ"],
+				"PXN": ["PXN"],
+				"FLW": ["FLW"],
+				"AVE": ["AVE"]
+			},
+			"draw": [["SEPDY","PORTE"], ["SENZY","PORTE","OSI","WAGES"], ["WAGES","CZQ*"], ["WAGES","AVE*"], ["WAGES","PXN*"], ["WAGES", "FLW*"]]
+		},
+		"SSTIK3": {
+			"icao": "SSTIK3",
+			"name": "Shtick Three",
+			"rwy": {
+				"1L" : ["SSTIK", "SEPDY", ["PORTE", "A100-"]],
+				"1R" : ["SSTIK", "SEPDY", ["PORTE", "A100-"]]
+			},
+			"exitPoints": {
+				"CISKO": ["KTINA", "CISKO"],
+				"EBAYE": ["SUSEY", "EBAYE"],
+				"LOSHN": ["KAYEX", "LOSHN"],
+				"NTELL": ["UTOOB", "NTELL"],
+				"YYUNG": ["FFOIL", "FLOKK", "YYUNG"]
+			},
+			"draw": [["SSTIK","PORTE"], ["PORTE", "KTINA", "CISKO*"], ["PORTE","SUSEY","EBAYE*"], ["PORTE","KAYEX","LOSHN*"], ["PORTE","UTOOB","NTELL*"], ["FFOIL","FLOKK", "YYUNG*"]]
+		},
+		"WESLA3": {
+			"icao": "WESLA3",
+			"name": "Wesla Three",
+			"rwy": {
+				"28L" : [["WESLA", "A20+|S230-"]],
+				"28R" : [["WESLA", "A20+|S230-"]]
+			},
+			"body": ["PORTE"],
+			"exitPoints": {
+				"CISKO": ["KTINA", "CISKO"],
+				"EBAYE": ["SUSEY", "EBAYE"],
+				"LOSHN": ["KAYEX", "LOSHN"],
+				"NTELL": ["UTOOB", "NTELL"],
+				"YYUNG": ["FFOIL", "FLOKK", "YYUNG"]
+			},
+			"draw": [["WESLA","PORTE"]]
+		},
+		"GNNRR2": {
+			"icao": "GNNRR2",
+			"name": "Gunner Two",
+			"rwy": {
+				"28L" : ["GNNRR"],
+				"28R" : ["GNNRR"]
+			},
+			"exitPoints": {
+				"AMAKR": ["STINS", "AMAKR"],
+				"ALCOA": ["ALCOA"],
+				"ALLBE": ["ALLBE"],
+				"BAART": ["BAART"],
+				"ALANN": ["ALANN"]
+			},
+			"draw": [["GNNRR","STINS","AMAKR*"], ["GNNRR","ALCOA*"], ["GNNRR","ALLBE*"], ["GNNRR","BAART*"], ["GNNRR","ALANN*"]]
+		},
+		"TRUKN2": {
+			"icao": "TRUKN2",
+			"name": "Trukin Two",
+			"rwy": {
+				"1R" : [["TYDYE", "A30+"], "TRUKN"]
+			},
+			"exitPoints": {
+				"GRTFL": ["GRTFL"],
+				"DEDHD": ["DEDHD"],
+				"ORRCA": ["HYPEE", "ORRCA"],
+				"MOGEE": ["HYPEE", "MOGEE"],
+				"TIPRE": ["COSMC", "TIPRE"],
+				"SYRAH": ["COSMC", "SYRAH"]
+			},
+			"draw": [["TYDYE","TRUKN"], ["TRUKN", "GRTFL*"], ["TRUKN", "DEDHD*"], ["TRUKN", "HYPEE"], ["TRUKN", "COSMC"], ["HYPEE","ORRCA*"], ["HYPEE", "MOGEE*"], ["COSMC", "TIPRE*"], ["COSMC", "SYRAH*"]]
+		},
+		"SFO4": {
+			"icao": "SFO4",
+			"name": "SAN FRANCISCO FOUR",
+			"rwy": {
+				"1L" : ["SASLY", "REBAS"],
+				"1R" : ["SASLY", "REBAS"],
+				"28L": ["REBAS"],
+				"28R": ["REBAS"]
+			},
+			"exitPoints": {
+				"ENI": ["SASSU", "ENI"],
+				"RBL": ["SASSU", "SAWNA", "RBL"],
+				"CIC": ["SASSU", "SAWNA", "CIC"],
+				"SAC": ["SAC"],
+				"LIN": ["LIN"]
+			},
+			"draw": [["SASLY","REBAS"], ["REBAS","SASSU"], ["SASSU","ENI*"], ["SASSU","SAWNA"], ["SAWNA","RBL*"], ["SAWNA","CIC*"], ["REBAS","SAC*"], ["REBAS","LIN*"]]
+		},
+		"MOLEN8": {
+			"icao": "MOLEN8",
+			"name": "Molen Eight",
+			"rwy": {
+				"10L": [["SIPLY", "A25+"], "_SIPLY233-STINS144", ["STINS", "A220-"]],
+				"10R": [["SIPLY", "A25+"], "_SIPLY233-STINS144", ["STINS", "A220-"]],
+				"28L": [["WESLA", "A18+"], ["STINS", "A220-"]],
+				"28R": [["WESLA", "A18+"], ["STINS", "A220-"]]
+			},
+			"body": ["MOLEN"],
+			"exitPoints": {
+				"ENI": ["ENI"]
+			},
+			"draw": [["SIPLY","_SIPLY233-STINS144","STINS"], ["WESLA","STINS","MOLEN"], ["MOLEN","ENI*"]]
+		}
+	},
+	"stars": {
+		"BDEGA2": {
+			"icao": "BDEGA2",
+			"name": "Bidayga Two",
+			"entryPoints": {
+				"DEEAN": [["DEEAN", "A240+|S280"]],
+				"QUINN": [["QUINN", "A240+|S280"], ["BGGLO", "A190+|S280"]],
+				"JONNE": [["JONNE", "A240+|S280"], ["BGGLO", "A190+|S280"]],
+				"MSCAT": [["MSCAT", "A240+|S280"], ["BGGLO", "A190+|S280"]],
+				"GEEHH": [["GEEHH", "A240+|S280"], ["BGGLO", "A190+|S280"]]
+			},
+			"body": [["LOZIT", "A160-|S280"], ["BDEGA", "A130-"], ["CORKK", "A110|S250"], "BRIXX"],
+			"draw": [["DEEAN*","LOZIT"], ["QUINN*","BGGLO","LOZIT"], ["JONNE*","BGGLO","LOZIT"], ["MSCAT*","BGGLO","LOZIT"], ["GEEHH*","BGGLO","LOZIT"], ["LOZIT","BDEGA","CORKK","BRIXX"]]
+		},
+		"BSR2": {
+			"icao": "BSR2",
+			"name": "Big Sur Two",
+			"entryPoints": {
+				"BSR": ["BSR"]
+			},
+			"body": ["CARME", "ANJEE", ["SKUNK", "A120-|S280"], ["BOLDR", "A100|S250"], "MENLO"],
+			"draw": [["BSR*","CARME","ANJEE","SKUNK","BOLDR","MENLO"]]
+		},
+		"DYAMD2": {
+			"icao": "DYAMD2",
+			"name": "Diamond Two",
+			"entryPoints": {
+				"DYAMD": [["DYAMD", "A270+"]]
+			},
+			"body": [["LAANE", "A260-|S280"], "ALWYS", ["FLOWZ", "A190-|S280"], ["CEDES", "A120-|S250"], ["FRELY", "A80|S240"], ["ARCHI", "A70|S230"]],
+			"draw": [["DYAMD*","LAANE","ALWYS","FLOWZ","CEDES","FRELY","ARCHI"]]
+		},
+		"SERFR2": {
+			"icao": "SERFR2",
+			"name": "Surfer Two",
+			"entryPoints": {
+				"SERFR": [["SERFR", "A200+"]]
+			},
+			"body": [["NRRLI", "A200+|S280"], ["WWAVS", "A190-|S280"], ["EPICK", "A150-|S280"], ["EDDYY", "A70|S240"], ["SWELS", "A50|S240"], ["MENLO", "A40|S230"]],
+			"draw": [["SERFR*","NRRLI","WWAVS","EPICK","EDDYY","SWELS","MENLO"]]
+		},
+		"PYE1": {
+			"icao": "PYE1",
+			"name": "Point Reyes One",
+			"entryPoints": {
+				"ENI": ["ENI"],
+				"MXW": ["MXW"]
+			},
+			"body": [["PYE", "A240|S280"], ["STINS", "A230|S250"], ["HADLY", "A100-|S230"], ["OSI", "A30|S210"]],
+			"draw": [["ENI*","PYE"], ["MXW*","PYE"], ["PYE","STINS","HADLY","OSI"]]
+		},
+		"YOSEM3": {
+			"icao": "YOSEM3",
+			"name": "Yosem Three",
+			"entryPoints": {
+				"YOSEM": ["YOSEM"]
+			},
+			"body": [["SNORA", "A270+|S280"], ["FRIGG", "A190-"], ["SOOIE", "A130-|S250"], ["FAITH", "A80"]],
+			"draw": [["YOSEM*","SNORA","FRIGG","SOOIE","FAITH"]]
+		}
+	},
+	"spawnPatterns": [
+					  {
+					  "airlines": [
+								   ["ual/long", 5],
+								   ["aal/long", 2],
+								   ["dal/long", 2],
+								   ["baw/long", 2],
+								   ["ups", 1],
+								   ["fdx", 1],
+								   ["klm/long", 2],
+								   ["afr/long", 2],
+								   ["uae", 4],
+								   ["kal/long", 2],
+								   ["vir", 2]
+								   ],
+					  "destination": "",
+					  "origin": "KSFO",
+					  "category": "departure",
+					  "route": "KSFO.MOLEN8.ENI",
+					  "altitude": null,
+					  "method": "random",
+					  "rate": 2,
+					  "speed": null
+					  },
+					  {
+					  "airlines": [
+								   ["ual", 10],
+								   ["aal", 8],
+								   ["dal", 6],
+								   ["swa", 5],
+								   ["asa", 3],
+								   ["aca", 2]
+								   ],
+					  "destination": "",
+					  "origin": "KSFO",
+					  "category": "departure",
+					  "route": "KSFO.TRUKN2.MOGEE",
+					  "altitude": null,
+					  "method": "random",
+					  "rate": 15,
+					  "speed": null
+					  },
+					  {
+					  "airlines": [
+								   ["ual", 10],
+								   ["aal", 8],
+								   ["dal", 6],
+								   ["swa", 5],
+								   ["asa", 3],
+								   ["aca", 2]
+								   ],
+					  "destination": "",
+					  "origin": "KSFO",
+					  "category": "departure",
+					  "route": "KSFO.SSTIK3.EBAYE",
+					  "altitude": null,
+					  "method": "random",
+					  "rate": 15,
+					  "speed": null
+					  },
+					  {
+					  "airlines": [
+								   ["ual", 10],
+								   ["aal", 8],
+								   ["dal", 6],
+								   ["ual/long", 5],
+								   ["aal/long", 2],
+								   ["dal/long", 2],
+								   ["swa", 5],
+								   ["asa", 3],
+								   ["aca", 2],
+								   ["cpa", 2],
+								   ["baw/long", 2],
+								   ["ups", 1],
+								   ["fdx", 1],
+								   ["klm/long", 2],
+								   ["afr/long", 2],
+								   ["uae", 4],
+								   ["kal/long", 2],
+								   ["vir", 2]
+								   ],
+					  "destination": "",
+					  "origin": "KSFO",
+					  "category": "departure",
+					  "route": "KSFO.OFFSH1.SXC",
+					  "altitude": null,
+					  "method": "random",
+					  "rate": 1,
+					  "speed": null
+					  },
+					  {
+					  "airlines": [
+								   ["ual/long", 5],
+								   ["aal/long", 2],
+								   ["dal/long", 2],
+								   ["cpa", 2],
+								   ["baw/long", 2],
+								   ["ups", 1],
+								   ["fdx", 1],
+								   ["klm/long", 2],
+								   ["afr/long", 2],
+								   ["uae", 4],
+								   ["kal/long", 2],
+								   ["vir", 2]
+								   ],
+					  "destination": "",
+					  "origin": "KSFO",
+					  "category": "departure",
+					  "route": "KSFO.GNNRR2.AMAKR",
+					  "altitude": null,
+					  "method": "random",
+					  "rate": 3,
+					  "speed": null
+					  },
+					  {
+					  "airlines": [
+								   ["ual/long", 5],
+								   ["aal/long", 2],
+								   ["dal/long", 2],
+								   ["cpa", 2],
+								   ["baw/long", 2],
+								   ["ups", 1],
+								   ["fdx", 1],
+								   ["klm/long", 2],
+								   ["afr/long", 2],
+								   ["uae", 4],
+								   ["kal/long", 2],
+								   ["vir", 2]
+								   ],
+					  "destination": "",
+					  "origin": "KSFO",
+					  "category": "departure",
+					  "route": "KSFO.SFO4.RBL",
+					  "altitude": null,
+					  "method": "random",
+					  "rate": 0,
+					  "speed": null
+					  },
+					  {
+					  "airlines": [
+								   ["ual", 5],
+								   ["ual/long", 2],
+								   ["swa", 1],
+								   ["dal", 5],
+								   ["dal/long", 2],
+								   ["aal", 5],
+								   ["aal/long", 2],
+								   ["asa", 1],
+								   ["fdx", 1]
+								   ],
+					  "destination": "KSFO",
+					  "origin": "",
+					  "category": "arrival",
+					  "route": "QUINN.BDEGA2.KSFO",
+					  "altitude": 24000,
+					  "method": "random",
+					  "rate": 6,
+					  "speed": 280
+					  },
+					  {
+					  "airlines": [
+								   ["ual", 2],
+								   ["swa", 2],
+								   ["aal", 2],
+								   ["asa", 2]
+								   ],
+					  "destination": "KSFO",
+					  "origin": "",
+					  "category": "arrival",
+					  "route": "SERFR.SERFR2.KSFO",
+					  "altitude": 22000,
+					  "method": "random",
+					  "rate": 12,
+					  "speed": 280
+					  },
+					  {
+					  "airlines": [
+								   ["ual", 5],
+								   ["ual/long", 2],
+								   ["swa", 1],
+								   ["dal", 5],
+								   ["dal/long", 2],
+								   ["aal", 5],
+								   ["aal/long", 2],
+								   ["asa", 1],
+								   ["fdx", 1]
+								   ],
+					  "destination": "KSFO",
+					  "origin": "",
+					  "category": "arrival",
+					  "route": "DYAMD.DYAMD2.KSFO",
+					  "altitude": 27000,
+					  "method": "random",
+					  "rate": 18,
+					  "speed": 280
+					  }
+					]
 }


### PR DESCRIPTION
Resolves #427.

Add SSTIK3 (1L/1R, turn faked with SEPDY), TRUKN2 (1L/1R only, 28L/28R not entered), GNNRR2 and minor updates for other SIDs
Only use DYMND, BDEGA, SERFR STARs
AAR and departure rate 36/hr