### PR TITLE
hotfix/549

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 5.2.1 (July 1, 2017)
+---
+### Hotfix
+- Ensure previously specified directions of turn are not preserved when a new heading instruction is given [#549](https://github.com/openscope/openscope/issues/549)
+
+
 ## 5.2.0 (July 1, 2017)
 ---
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openscope",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "An ATC simulator in HTML5",
   "engines": {
     "node": "7.0.0",

--- a/src/assets/scripts/client/App.js
+++ b/src/assets/scripts/client/App.js
@@ -16,7 +16,7 @@ const prop = {};
 require('./util');
 
 // Used to display the version number in the console
-const VERSION = '5.2.0';
+const VERSION = '5.2.1';
 
 // are you using a main loop? (you must call update() afterward disable/re-enable)
 let UPDATE = true;

--- a/src/assets/scripts/client/aircraft/AircraftCommander.js
+++ b/src/assets/scripts/client/aircraft/AircraftCommander.js
@@ -229,11 +229,8 @@ export default class AircraftCommander {
         const heading = data[1];
         const incremental = data[2];
         const readback = aircraft.pilot.maintainHeading(aircraft.heading, heading, direction, incremental);
-        const airport = AirportController.airport_get();
 
-        if (readback[0] && direction) {
-            aircraft.target.turn = direction;
-        }
+        aircraft.target.turn = direction;
 
         if (aircraft.hasApproachClearance) {
             aircraft.cancelApproachClearance(aircraft.altitude, aircraft.heading);
@@ -330,6 +327,8 @@ export default class AircraftCommander {
     runDirect(aircraft, data) {
         // TODO: maybe handle with parser?
         const fixName = data[0].toUpperCase();
+
+        aircraft.target.turn = null;
 
         return aircraft.pilot.proceedDirect(fixName);
     }

--- a/src/assets/scripts/client/aircraft/AircraftCommander.js
+++ b/src/assets/scripts/client/aircraft/AircraftCommander.js
@@ -225,10 +225,14 @@ export default class AircraftCommander {
      * @return {array} [success of operation, readback]
      */
     runHeading(aircraft, data) {
-        const direction = data[0];
+        let direction = data[0];
         const heading = data[1];
         const incremental = data[2];
         const readback = aircraft.pilot.maintainHeading(aircraft.heading, heading, direction, incremental);
+
+        if (direction === null) {
+            direction = '';
+        }
 
         aircraft.target.turn = direction;
 


### PR DESCRIPTION
Resolves #549

Ensure previously specified directions of turn are not preserved when a new heading instruction is given