### PR TITLE
enhancement/581

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
     - Adds Copa Airlines (CMP) and PAWA Dominicana (PWD)
 - Add new openScope emblem vector graphic [#572](https://github.com/openscope/openscope/issues/572)
 - Adds additional meta tags to index.html head [#484](https://github.com/openscope/openscope/issues/572)
-
+- Adds a link to the full command reference at the end of the tutorial [#581](https://github.com/openscope/openscope/issues/581)
 
 
 

--- a/src/assets/scripts/client/tutorial/TutorialView.js
+++ b/src/assets/scripts/client/tutorial/TutorialView.js
@@ -550,7 +550,8 @@ export default class TutorialView {
             title: 'Good job!',
             text: ['If you&rsquo;ve gone through this entire tutorial, you should do pretty well with the pressure.',
                    'In the TRACON, minimum separation is 3 miles laterally or 1000 feet vertically. Keep them separated,',
-                   'keep them moving, and you\'ll be a controller in no time!'
+                   'keep them moving, and you\'ll be a controller in no time!',
+                   'A full list of commands can be found <a href="https://github.com/openscope/openscope/wiki/Command-Reference">here</a>.'
                ].join(' '),
             parse: (v) => v,
             side: 'left',

--- a/src/assets/scripts/client/tutorial/TutorialView.js
+++ b/src/assets/scripts/client/tutorial/TutorialView.js
@@ -551,7 +551,7 @@ export default class TutorialView {
             text: ['If you&rsquo;ve gone through this entire tutorial, you should do pretty well with the pressure.',
                    'In the TRACON, minimum separation is 3 miles laterally or 1000 feet vertically. Keep them separated,',
                    'keep them moving, and you\'ll be a controller in no time!',
-                   'A full list of commands can be found <a href="https://github.com/openscope/openscope/wiki/Command-Reference">here</a>.'
+                   'A full list of commands can be found <a title="Command Reference | Openscope Wiki" href="https://github.com/openscope/openscope/wiki/Command-Reference">here</a>.'
                ].join(' '),
             parse: (v) => v,
             side: 'left',


### PR DESCRIPTION
Resolves #581 

Adds a link to the [command reference](https://github.com/openscope/openscope/wiki/Command-Reference) at the end of the tutorial.