### PR TITLE
refactor/593

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 - Recalculate SID/STAR legs when changing assigned runway [#383](https://github.com/openscope/openscope/issues/383)
 - Remove +/-/= zoom hotkey, conflicts with speed [#510](https://github.com/openscope/openscope/issues/510)
 - Correct EGKK's departure fix [#577](https://github.com/openscope/openscope/issues/577)
+- Middle mouse button now resets zoom as intended [#593](https://github.com/openscope/openscope/issues/593)
+
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,6 @@
 - Recalculate SID/STAR legs when changing assigned runway [#383](https://github.com/openscope/openscope/issues/383)
 - Remove +/-/= zoom hotkey, conflicts with speed [#510](https://github.com/openscope/openscope/issues/510)
 - Correct EGKK's departure fix [#577](https://github.com/openscope/openscope/issues/577)
-- Middle mouse button now resets zoom as intended [#593](https://github.com/openscope/openscope/issues/593)
-
 
 
 
@@ -32,6 +30,7 @@
 ### Refactors
 - Fix spelling error of `CanvasController` as `ConvasController` [#586](https://github.com/openscope/openscope/issues/586)
 - Remove deprecated fixRadialDist() [#290](https://github.com/openscope/openscope/issues/290)
+- Renamed `MIDDLE_PESS` as `MIDDLE_PRESS` in `InputController` [#593](https://github.com/openscope/openscope/issues/593)
 
 
 

--- a/src/assets/scripts/client/InputController.js
+++ b/src/assets/scripts/client/InputController.js
@@ -46,7 +46,7 @@ const PARSED_COMMAND_NAME = {
  */
 const MOUSE_EVENT_CODE = {
     LEFT_PRESS: 1,
-    MIDDLE_PESS: 2,
+    MIDDLE_PRESS: 2,
     RIGHT_PRESS: 3
 };
 

--- a/src/assets/scripts/client/InputController.js
+++ b/src/assets/scripts/client/InputController.js
@@ -287,7 +287,7 @@ export default class InputController {
         event.preventDefault();
 
         // TODO: this should use early returns instead of the else if
-        if (event.which === MOUSE_EVENT_CODE.MIDDLE_PESS) {
+        if (event.which === MOUSE_EVENT_CODE.MIDDLE_PRESS) {
             UiController.ui_zoom_reset();
         } else if (event.which === MOUSE_EVENT_CODE.LEFT_PRESS) {
             // Record mouse down position for panning


### PR DESCRIPTION
Resolves #593, MIDDLE_PRESS was misspelled MIDDLE_PESS (as my commit summary should have said, but I misfired).