### PR TITLE
bugfix/618

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 
 ### Bugfixes
+- Fix aircraft not descending at MDSD [#618](https://github.com/openscope/openscope/issues/618)
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 
 ### Bugfixes
-- Fix aircraft not descending at MDSD [#618](https://github.com/openscope/openscope/issues/618)
+- Fix VNAV descents on STARs with only "at/above" and "at/below" restrictions [#618](https://github.com/openscope/openscope/issues/618)
 
 
 

--- a/src/assets/scripts/client/aircraft/AircraftModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftModel.js
@@ -844,7 +844,7 @@ export default class AircraftModel {
         return decelerationTime > timeUntilWaypoint;
     }
 
-    /* TODO: Refactor all this logic into the Fms - #656
+    // TODO: Refactor all this logic into the Fms - #656
     /**
      * Returns whether it is time to begin descent in order to comply with the posted altitude restrictions
      *

--- a/src/assets/scripts/client/aircraft/AircraftModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftModel.js
@@ -1801,11 +1801,7 @@ export default class AircraftModel {
 
                 // Here we trigger the initial descent. Once vacating the filed cruise altitude, subsequent loops
                 // will enter the below block because the flight phase will have become 'DESCENT'.
-                if (_isNil(hardRestrictedWaypointModel)) {
-                    return this.fms.getBottomAltitude();
-                }
-
-                return hardRestrictedWaypointModel.altitudeMaximum;
+                return this._calculateTargetedAltitudeVnavDescent();
             }
 
             case FLIGHT_PHASE.DESCENT:

--- a/src/assets/scripts/client/aircraft/AircraftModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftModel.js
@@ -1800,9 +1800,8 @@ export default class AircraftModel {
                 if (_isNil(hardRestrictedWaypointModel)) {
                     return this.fms.getBottomAltitude();
                 }
-                else {
-                    return hardRestrictedWaypointModel.altitudeMaximum;
-                }
+
+                return hardRestrictedWaypointModel.altitudeMaximum;
             }
 
             case FLIGHT_PHASE.DESCENT:
@@ -1855,12 +1854,11 @@ export default class AircraftModel {
             return this.fms.getBottomAltitude();
         }
 
-        if (nextRestrictedWaypoint.altitudeMinimum !== INVALID_NUMBER) {
-            return nextRestrictedWaypoint.altitudeMinimum;
-        }
-        else {
+        if (nextRestrictedWaypoint.altitudeMinimum === INVALID_NUMBER) {
             return nextRestrictedWaypoint.altitudeMaximum;
         }
+
+        return nextRestrictedWaypoint.altitudeMinimum;
     }
 
     /**

--- a/src/assets/scripts/client/aircraft/AircraftModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftModel.js
@@ -862,12 +862,14 @@ export default class AircraftModel {
         const waypointsWithRelevantCeiling = _filter(waypoints,
                                                      (waypoint) => waypoint.hasMaximumAltitudeBelow(currentAltitude));
 
-        const targetAltitude = _isEmpty(waypointsWithRelevantCeiling) ?
-              this.fms.getBottomAltitude() :
-              _head(waypointsWithRelevantCeiling).altitudeMaximum;
-        const targetPosition = _isEmpty(waypointsWithRelevantCeiling) ?
-              _last(this.fms.waypoints).positionModel :
-              _head(waypointsWithRelevantCeiling).positionModel;
+
+        let targetAltitude = this.fms.getBottomAltitude();
+        let targetPosition = _last(this.fms.waypoints).positionModel;
+
+        if (!_isEmpty(waypointsWithRelevantCeiling)) {
+            targetAltitude = _head(waypointsWithRelevantCeiling).altitudeMaximum;
+            targetPosition = _head(waypointsWithRelevantCeiling).positionModel;
+        }
 
         const waypointDistance = this.positionModel.distanceToPosition(targetPosition);
         const altitudeChange = targetAltitude - this.altitude;

--- a/src/assets/scripts/client/aircraft/AircraftModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftModel.js
@@ -2,6 +2,7 @@ import _defaultTo from 'lodash/defaultTo';
 import _filter from 'lodash/filter';
 import _forEach from 'lodash/forEach';
 import _get from 'lodash/get';
+import _head from 'lodash/head';
 import _isEmpty from 'lodash/isEmpty';
 import _isEqual from 'lodash/isEqual';
 import _isNil from 'lodash/isNil';
@@ -861,10 +862,10 @@ export default class AircraftModel {
 
         const targetAltitude = _isEmpty(waypointsWithRelevantCeiling) ?
               this.fms.getBottomAltitude() :
-              waypointsWithRelevantCeiling[0].altitudeMaximum;
+              _head(waypointsWithRelevantCeiling).altitudeMaximum;
         const targetPosition = _isEmpty(waypointsWithRelevantCeiling) ?
               _last(this.fms.waypoints).positionModel :
-              waypointsWithRelevantCeiling[0].positionModel;
+              _head(waypointsWithRelevantCeiling).positionModel;
 
         const waypointDistance = this.positionModel.distanceToPosition(targetPosition);
         const altitudeChange = targetAltitude - this.altitude;

--- a/src/assets/scripts/client/aircraft/AircraftModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftModel.js
@@ -1,4 +1,5 @@
 import _defaultTo from 'lodash/defaultTo';
+import _filter from 'lodash/filter';
 import _forEach from 'lodash/forEach';
 import _get from 'lodash/get';
 import _isEmpty from 'lodash/isEmpty';
@@ -856,10 +857,7 @@ export default class AircraftModel {
 
         const currentAltitude = this.altitude;
         const waypoints = this.fms.getAltitudeRestrictedWaypoints();
-        const waypointsWithRelevantCeiling = waypoints.filter((wp) => {
-            return (wp.altitudeMaximum !== INVALID_NUMBER) &&
-                (wp.altitudeMaximum < this.altitude)
-        }, this);
+        const waypointsWithRelevantCeiling = _filter(waypoints, (waypoint) => waypoint.hasMaximumAltitudeBelow(this.altitude));
 
         const targetAltitude = _isEmpty(waypointsWithRelevantCeiling) ?
               this.fms.getBottomAltitude() :

--- a/src/assets/scripts/client/aircraft/AircraftModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftModel.js
@@ -844,6 +844,7 @@ export default class AircraftModel {
         return decelerationTime > timeUntilWaypoint;
     }
 
+    /* TODO: Refactor all this logic into the Fms - #656
     /**
      * Returns whether it is time to begin descent in order to comply with the posted altitude restrictions
      *

--- a/src/assets/scripts/client/aircraft/AircraftModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftModel.js
@@ -853,18 +853,17 @@ export default class AircraftModel {
      * @return {boolean}
      */
     shouldStartDescent() {
-        if (_isEmpty(this.fms.waypoints)) {
+        const currentAltitude = this.altitude;
+        const altitudeRestrictedWaypoints = this.fms.getAltitudeRestrictedWaypoints();
+        const waypointsWithRelevantCeiling = _filter(altitudeRestrictedWaypoints,
+            (waypoint) => waypoint.hasMaximumAltitudeBelow(currentAltitude));
+
+        if (_isEmpty(altitudeRestrictedWaypoints)) {
             return;
         }
 
-        const currentAltitude = this.altitude;
-        const waypoints = this.fms.getAltitudeRestrictedWaypoints();
-        const waypointsWithRelevantCeiling = _filter(waypoints,
-                                                     (waypoint) => waypoint.hasMaximumAltitudeBelow(currentAltitude));
-
-
-        let targetAltitude = this.fms.getBottomAltitude();
-        let targetPosition = _last(this.fms.waypoints).positionModel;
+        let targetAltitude = this.mcp.altitude;
+        let targetPosition = _last(altitudeRestrictedWaypoints).positionModel;
 
         if (!_isEmpty(waypointsWithRelevantCeiling)) {
             targetAltitude = _head(waypointsWithRelevantCeiling).altitudeMaximum;
@@ -1849,8 +1848,9 @@ export default class AircraftModel {
         // target in the current iteration.
 
         const nextRestrictedWaypoint = this.fms.nextAltitudeRestrictedWaypoint;
+
         if (_isNil(nextRestrictedWaypoint)) {
-            return this.fms.getBottomAltitude();
+            return this.mcp.altitude;
         }
 
         if (nextRestrictedWaypoint.altitudeMinimum === INVALID_NUMBER) {

--- a/src/assets/scripts/client/aircraft/AircraftModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftModel.js
@@ -1809,7 +1809,7 @@ export default class AircraftModel {
             }
 
             case FLIGHT_PHASE.DESCENT:
-                return this._calculateTargetedAltitudeVnavDescent(hardRestrictedWaypointModel);
+                return this._calculateTargetedAltitudeVnavDescent();
 
             default:
                 return;
@@ -1843,10 +1843,9 @@ export default class AircraftModel {
      *
      * @for AircraftModel
      * @method _calculateTargetedAltitudeVnavDescent
-     * @param  hardRestrictedWaypointModel {WaypointModel}
      * @return {number}
      */
-    _calculateTargetedAltitudeVnavDescent(hardRestrictedWaypointModel) {
+    _calculateTargetedAltitudeVnavDescent() {
         // TODO: This could be improved by making the descent at the exact rate needed to reach
         // the altitude at the same time as reaching the fix. At this point, the problem is that
         // while we DO know the descent rate and descent angle to shoot for, we don't know the

--- a/src/assets/scripts/client/aircraft/AircraftModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftModel.js
@@ -849,10 +849,10 @@ export default class AircraftModel {
      * Returns whether it is time to begin descent in order to comply with the posted altitude restrictions
      *
      * @for AircraftModel
-     * @method isBeyondTopOfDescent
+     * @method shouldStartDescent
      * @return {boolean}
      */
-    isBeyondTopOfDescent() {
+    shouldStartDescent() {
         if (_isEmpty(this.fms.waypoints)) {
             return;
         }
@@ -1793,7 +1793,7 @@ export default class AircraftModel {
                 return this._calculateTargetedAltitudeVnavClimb(hardRestrictedWaypointModel);
 
             case FLIGHT_PHASE.CRUISE: {
-                if (!this.isBeyondTopOfDescent()) {
+                if (!this.shouldStartDescent()) {
                     return;
                 }
 

--- a/src/assets/scripts/client/aircraft/AircraftModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftModel.js
@@ -859,7 +859,8 @@ export default class AircraftModel {
 
         const currentAltitude = this.altitude;
         const waypoints = this.fms.getAltitudeRestrictedWaypoints();
-        const waypointsWithRelevantCeiling = _filter(waypoints, (waypoint) => waypoint.hasMaximumAltitudeBelow(this.altitude));
+        const waypointsWithRelevantCeiling = _filter(waypoints,
+                                                     (waypoint) => waypoint.hasMaximumAltitudeBelow(currentAltitude));
 
         const targetAltitude = _isEmpty(waypointsWithRelevantCeiling) ?
               this.fms.getBottomAltitude() :

--- a/src/assets/scripts/client/aircraft/FlightManagementSystem/WaypointModel.js
+++ b/src/assets/scripts/client/aircraft/FlightManagementSystem/WaypointModel.js
@@ -368,6 +368,32 @@ export default class WaypointModel {
     }
 
     /**
+     * Check for a maximum altitude restriction below the given altitude
+     *
+     * @for WaypointModel
+     * @method hasMaximumAltitudeBelow
+     * @param altitude {number} in feet
+     * @return {boolean}
+     */
+    hasMaximumAltitudeBelow(altitude) {
+        return this.altitudeMaximum !== INVALID_NUMBER
+            && this.altitudeMaximum < altitude;
+    }
+
+    /**
+     * Check for a minimum altitude restriction above the given altitude
+     *
+     * @for WaypointModel
+     * @method hasMinimumAltitudeAbove
+     * @param altitude {number} in feet
+     * @return {boolean}
+     */
+    hasMinimumAltitudeAbove(altitude) {
+        return this.altitudeMinimum !== INVALID_NUMBER
+            && this.altitudeMinimum > altitude;
+    }
+
+    /**
      * Add hold-specific properties to an existing `WaypointModel` instance
      *
      * @for WaypointModel

--- a/test/aircraft/AircraftModel.spec.js
+++ b/test/aircraft/AircraftModel.spec.js
@@ -7,7 +7,8 @@ import {
 import { navigationLibraryFixture } from '../fixtures/navigationLibraryFixtures';
 import {
     ARRIVAL_AIRCRAFT_INIT_PROPS_MOCK,
-    DEPARTURE_AIRCRAFT_INIT_PROPS_MOCK
+    DEPARTURE_AIRCRAFT_INIT_PROPS_MOCK,
+    ARRIVAL_AIRCRAFT_INIT_PROPS_WITH_SOFT_ALTITUDE_RESTRICTIONS_MOCK
 } from './_mocks/aircraftMocks';
 
 ava.beforeEach(() => {
@@ -59,4 +60,24 @@ ava('.getViewModel() includes an altitude that has not been rounded to the neare
     const { assignedAltitude: result } = model.getViewModel();
 
     t.true(result === 77.77123456700001);
+});
+
+ava('.updateTarget() causes arrivals to descend when the STAR includes only AT or ABOVE altitude restrictions', (t) => {
+    const model = new AircraftModel(ARRIVAL_AIRCRAFT_INIT_PROPS_WITH_SOFT_ALTITUDE_RESTRICTIONS_MOCK, navigationLibraryFixture);
+    model.positionModel = navigationLibraryFixture.findFixByName('LEMNZ').positionModel;
+
+    model.groundSpeed = 320;
+    model.updateTarget();
+
+    t.true(model.target.altitude === 8000);
+});
+
+ava('.updateTarget() causes arrivals to descend when the STAR includes AT altitude restrictions', (t) => {
+    const model = new AircraftModel(ARRIVAL_AIRCRAFT_INIT_PROPS_MOCK, navigationLibraryFixture);
+    model.positionModel = navigationLibraryFixture.findFixByName('MISEN').positionModel
+
+    model.groundSpeed = 320;
+    model.updateTarget();
+
+    t.true(model.target.altitude === 24000);
 });

--- a/test/aircraft/AircraftModel.spec.js
+++ b/test/aircraft/AircraftModel.spec.js
@@ -7,8 +7,8 @@ import {
 import { navigationLibraryFixture } from '../fixtures/navigationLibraryFixtures';
 import {
     ARRIVAL_AIRCRAFT_INIT_PROPS_MOCK,
-    DEPARTURE_AIRCRAFT_INIT_PROPS_MOCK,
-    ARRIVAL_AIRCRAFT_INIT_PROPS_WITH_SOFT_ALTITUDE_RESTRICTIONS_MOCK
+    ARRIVAL_AIRCRAFT_INIT_PROPS_WITH_SOFT_ALTITUDE_RESTRICTIONS_MOCK,
+    DEPARTURE_AIRCRAFT_INIT_PROPS_MOCK
 } from './_mocks/aircraftMocks';
 
 ava.beforeEach(() => {

--- a/test/aircraft/AircraftModel.spec.js
+++ b/test/aircraft/AircraftModel.spec.js
@@ -69,7 +69,7 @@ ava('.updateTarget() causes arrivals to descend when the STAR includes only AT o
     model.groundSpeed = 320;
     model.updateTarget();
 
-    t.true(model.target.altitude === 8000);
+    t.true(model.target.altitude === 17000);
 });
 
 ava('.updateTarget() causes arrivals to descend when the STAR includes AT altitude restrictions', (t) => {

--- a/test/aircraft/FlightManagementSystem/WaypointModel.spec.js
+++ b/test/aircraft/FlightManagementSystem/WaypointModel.spec.js
@@ -86,3 +86,45 @@ ava('.updateWaypointWithHoldProps() sets parameters as hold-specific properties'
     t.true(model._turnDirection === 'left');
     t.true(model._legLength === '2min');
 });
+
+ava('.hasMaximumAltitudeBelow returns true when current altitude is above', (t) => {
+    const waypointWithMaximumAltitude = Object.assign({}, waypointMock, {altitudeMaximum: 5000});
+    const model = new WaypointModel(waypointWithMaximumAltitude);
+
+    t.true(model.hasMaximumAltitudeBelow(6000) === true);
+});
+
+ava('.hasMaximumAltitudeBelow returns false when current altitude is below', (t) => {
+    const waypointWithMaximumAltitude = Object.assign({}, waypointMock, {altitudeMaximum: 5000});
+    const model = new WaypointModel(waypointWithMaximumAltitude);
+
+    t.true(model.hasMaximumAltitudeBelow(4000) === false);
+});
+
+ava('.hasMaximumAltitudeBelow returns false when no maximum is specified', (t) => {
+    const waypointWithoutMaximumAltitude = Object.assign({}, waypointMock, {altitudeMaximum: INVALID_NUMBER});
+    const model = new WaypointModel(waypointWithoutMaximumAltitude);
+
+    t.true(model.hasMaximumAltitudeBelow(6000) === false);
+});
+
+ava('.hasMinimumAltitudeAbove returns false when current altitude is above', (t) => {
+    const waypointWithMinimumAltitude = Object.assign({}, waypointMock, {altitudeMinimum: 5000});
+    const model = new WaypointModel(waypointWithMinimumAltitude);
+
+    t.true(model.hasMinimumAltitudeAbove(6000) === false);
+});
+
+ava('.hasMinimumAltitudeAbove returns true when current altitude is below', (t) => {
+    const waypointWithMinimumAltitude = Object.assign({}, waypointMock, {altitudeMinimum: 5000});
+    const model = new WaypointModel(waypointWithMinimumAltitude);
+
+    t.true(model.hasMinimumAltitudeAbove(4000) === true);
+});
+
+ava('.hasMinimumAltitudeAbove returns false when no minimum is specified', (t) => {
+    const waypointWithoutMinimumAltitude = Object.assign({}, waypointMock, {altitudeMinimum: INVALID_NUMBER});
+    const model = new WaypointModel(waypointWithoutMinimumAltitude);
+
+    t.true(model.hasMinimumAltitudeAbove(6000) === false);
+});

--- a/test/aircraft/_mocks/aircraftMocks.js
+++ b/test/aircraft/_mocks/aircraftMocks.js
@@ -122,6 +122,14 @@ export const ARRIVAL_AIRCRAFT_INIT_PROPS_MOCK = {
     waypoints: []
 };
 
+export const ARRIVAL_AIRCRAFT_INIT_PROPS_WITH_SOFT_ALTITUDE_RESTRICTIONS_MOCK = Object.assign(
+    {},
+    ARRIVAL_AIRCRAFT_INIT_PROPS_MOCK,
+    {
+        route: 'MLF.GRNPA2.KLAS',
+    }
+);
+
 export const ARRIVAL_AIRCRAFT_INIT_PROPS_WITH_DIRECT_ROUTE_STRING_MOCK = {
     callsign: '432',
     destination: 'KLAS',

--- a/test/airport/_mocks/airportJsonMock.js
+++ b/test/airport/_mocks/airportJsonMock.js
@@ -310,6 +310,29 @@ export const AIRPORT_JSON_KLAS_MOCK = {
             },
             "draw": [[]]
         },
+        // Not a real route, used to test soft altitude restrictions
+        "GRNPA2": {
+            "icao": "GRNPA2",
+            "name": "Grandpa Two",
+            'suffix': {'01L': '1A', '01R': '1B', '07L': '2A', '07R': '2B', '19L': '3A', '19R': '3B', '25L': '4A', '25R': '4B'},
+            "entryPoints": {
+                "BETHL": ["BETHL", ["HOLDM", "A270+"]],
+                "BCE":   ["BCE"],
+                "DVC":   ["DVC", "BETHL", ["HOLDM", "A270+"]],
+                "MLF":   ["MLF"]
+            },
+            "body": [["KSINO", "A170+"], ["LUXOR", "A120+|S250"], ["GRNPA", "A110+"], ["DUBLX", "A90+"], ["FRAWG", "A80+|S210"], "TRROP", "LEMNZ"],
+            "rwy": {
+                "01L": [],
+                "01R": [],
+                "07L": [],
+                "07R": [],
+                "19L": [],
+                "19R": [],
+                "25L": [],
+                "25R": []
+            }
+        },
         // not a real route. used here to test `SpawnPatternModel._generateWaypointListForRoute()`
         "GRNPA9": {
             "icao": "GRNPA9",

--- a/test/airport/_mocks/airportJsonMock.js
+++ b/test/airport/_mocks/airportJsonMock.js
@@ -331,7 +331,8 @@ export const AIRPORT_JSON_KLAS_MOCK = {
                 "19R": [],
                 "25L": [],
                 "25R": []
-            }
+            },
+            "draw": [[]]
         },
         // not a real route. used here to test `SpawnPatternModel._generateWaypointListForRoute()`
         "GRNPA9": {

--- a/test/navigationLibrary/NavigationLibrary.spec.js
+++ b/test/navigationLibrary/NavigationLibrary.spec.js
@@ -73,7 +73,7 @@ ava('.isGroundedFlightPhase() returns true when passed `WAITING`', (t) => {
     t.true(navigationLibrary.isGroundedFlightPhase('WAITING'));
 });
 
-ava.only('.getAllFixNamesInUse() returns list of all fixnames used in all procedures', (t) => {
+ava('.getAllFixNamesInUse() returns list of all fixnames used in all procedures', (t) => {
     const navigationLibrary = new NavigationLibrary(AIRPORT_JSON_KLAS_MOCK);
     const fixNameList = navigationLibrary._getAllFixNamesInUse();
 


### PR DESCRIPTION
Resolves #618 

Fixes aircraft in cruise phase not descending if they have no waypoints with an AT altitude restriction while on a STAR.  Now aircraft should start their descent correctly just so long as some altitude restriction is in place.