### PR TITLE
bugfix/787

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Bugfixes
 - Fix bug where aircraft cleared twice for ILS won't join glideslope [#667](https://github.com/openscope/openscope/issues/667)
 - Fix bug of aircraft descending via STAR to '0' altitude [#567](https://github.com/openscope/openscope/issues/567)
+- `sid` command no longer sets the aircraft's destination property [#787](https://github.com/openscope/openscope/issues/787)
 
 
 

--- a/src/assets/scripts/client/aircraft/AircraftCommander.js
+++ b/src/assets/scripts/client/aircraft/AircraftCommander.js
@@ -400,10 +400,6 @@ export default class AircraftCommander {
             return response;
         }
 
-        // TODO: toUpperCase might be overly defensive here
-        // update the aircraft destination so the strip display reflects the change of procedure
-        aircraft.destination = sidId.toUpperCase();
-
         return response;
     }
 


### PR DESCRIPTION
Resolves #787 

The purpose of this pull request is to prevent the `sid` command from changing the `AircraftModel.destination` property
