### PR TITLE
hotfix/814

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 5.6.1 (November 1, 2017)
+---
+### Hotfix
+- Fix severe canvas bug for airports with runways that don't draw extended centerlines [#814](https://github.com/openscope/openscope/issues/814)
+
+
 ## 5.6.0 (November 1, 2017)
 ---
 ### New Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openscope",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "description": "An ATC simulator in HTML5",
   "engines": {
     "node": "7.0.0",

--- a/src/assets/scripts/client/canvas/CanvasController.js
+++ b/src/assets/scripts/client/canvas/CanvasController.js
@@ -477,6 +477,8 @@ export default class CanvasController {
         } else {
             // extended centerlines
             if (!runwayModel.ils.enabled) {
+                cc.restore();
+
                 return;
             }
 


### PR DESCRIPTION
Resolves #814

Adds missing .restore() in CanvasController for airports that dont have ils runways

