### PR TITLE
bugfix/870 - A/C appear to stop taxiing after one was told to change runways

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#1086](https://github.com/openscope/openscope/issues/1086) - Update P28A Climb rate fm 2000ft/m to 700ft/m
 - [#1034](https://github.com/openscope/openscope/issues/1034) - Fix waypoint time-to-turn calculations to ensure smooth turns
 - [#935](https://github.com/openscope/openscope/issues/935) - Prevent aircraft from skipping fixes that require tight turns
+- [#870](https://github.com/openscope/openscope/issues/870) - Fix unusable runway bug after changing one aircraft's departure runway
 
 
 

--- a/src/assets/scripts/client/aircraft/AircraftCommander.js
+++ b/src/assets/scripts/client/aircraft/AircraftCommander.js
@@ -597,8 +597,7 @@ export default class AircraftCommander {
         // remove aircraft from previous runway's queue
         aircraftModel.fms.departureRunwayModel.removeAircraftFromQueue(aircraftModel.id);
 
-        const flightPhase = aircraftModel.flightPhase;
-        const readback = aircraftModel.pilot.taxiToRunway(nextRunwayModel, aircraftModel.isDeparture(), flightPhase);
+        const readback = aircraftModel.pilot.taxiToRunway(nextRunwayModel, aircraftModel.isDeparture());
         aircraftModel.taxi_start = taxiStartTime;
 
         // add aircraft to new runway's queue

--- a/src/assets/scripts/client/aircraft/AircraftCommander.js
+++ b/src/assets/scripts/client/aircraft/AircraftCommander.js
@@ -573,7 +573,7 @@ export default class AircraftCommander {
         const requestedRunwayName = data[0];
 
         if (!requestedRunwayName) {
-            return aircraftModel.taxiToRunway(aircraftModel.fms.departureRunwayModel);
+            return aircraftModel.taxiToRunway(airportModel.departureRunwayModel);
         }
 
         const runwayModel = airportModel.getRunway(requestedRunwayName.toUpperCase());

--- a/src/assets/scripts/client/aircraft/AircraftCommander.js
+++ b/src/assets/scripts/client/aircraft/AircraftCommander.js
@@ -603,7 +603,6 @@ export default class AircraftCommander {
         // add aircraft to new runway's queue
         aircraftModel.fms.departureRunwayModel.addAircraftToQueue(aircraftModel.id);
 
-
         aircraftModel.setFlightPhase(FLIGHT_PHASE.TAXI);
         GameController.game_timeout(
             this._changeFromTaxiToWaiting,

--- a/src/assets/scripts/client/aircraft/AircraftConflict.js
+++ b/src/assets/scripts/client/aircraft/AircraftConflict.js
@@ -138,7 +138,7 @@ export default class AircraftConflict {
      */
     checkCollision() {
         if (this.aircraft[0].isOnGround() || this.aircraft[1].isOnGround()) {
-            return;  // TEMPORARY FIX FOR CRASHES BTWN ARRIVALS AND TAXIIED A/C
+            return;  // TEMPORARY FIX FOR CRASHES BTWN ARRIVALS AND TAXIED A/C
         }
 
         // TODO: enumerate the magic numbers.

--- a/src/assets/scripts/client/aircraft/AircraftModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftModel.js
@@ -1270,7 +1270,7 @@ export default class AircraftModel {
         }
 
         if (this.isArrival()) {
-            return  [false, 'uanble to taxi to runway, we have just landed'];
+            return  [false, 'unable to taxi to runway, we have just landed'];
         }
 
         if (!this.fms.isRunwayModelValidForSid(runwayModel)) {

--- a/src/assets/scripts/client/aircraft/AircraftModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftModel.js
@@ -1036,6 +1036,7 @@ export default class AircraftModel {
             this.flightPhase === FLIGHT_PHASE.WAITING;
     }
 
+    // TODO: The function description and what it actually does do not match
     /**
      * Returns whether the aircraft is currently taking off
      *

--- a/src/assets/scripts/client/aircraft/AircraftModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftModel.js
@@ -1277,12 +1277,12 @@ export default class AircraftModel {
             this.pilot.cancelDepartureClearance(this);
         }
 
+        this.setFlightPhase(FLIGHT_PHASE.TAXI);
         // remove aircraft from previous runway's queue
         this.fms.departureRunwayModel.removeAircraftFromQueue(this.id);
-
-        this.setFlightPhase(FLIGHT_PHASE.TAXI);
         this.fms.setDepartureRunway(runwayModel);
         this.fms.departureRunwayModel.addAircraftToQueue(this.id);
+
         this.taxi_start = TimeKeeper.accumulatedDeltaTime;
 
         GameController.game_timeout(

--- a/src/assets/scripts/client/aircraft/Pilot/Pilot.js
+++ b/src/assets/scripts/client/aircraft/Pilot/Pilot.js
@@ -926,16 +926,16 @@ export default class Pilot {
      * @return {array}                      [success of operation, readback]
      */
     taxiToRunway(taxiDestination, isDeparture, flightPhase) {
-        if (flightPhase === FLIGHT_PHASE.TAXI) {
-            return [false, 'already taxiing'];
+        if (!isDeparture) {
+            return [false, 'unable to taxi, we are not a departure'];
         }
 
-        if (flightPhase === FLIGHT_PHASE.WAITING) {
-            return [false, 'already taxiied and waiting in runway queue'];
-        }
+        if (flightPhase === FLIGHT_PHASE.TAKEOFF) {
+            const readback = {};
+            readback.log = `we are already taking off on Runway ${taxiDestination.name}`;
+            readback.say = `we are already taking off on Runway ${radio_runway(taxiDestination.name)}`;
 
-        if (!isDeparture || flightPhase !== FLIGHT_PHASE.APRON) {
-            return [false, 'unable to taxi'];
+            return [false, readback];
         }
 
         this._fms.setDepartureRunway(taxiDestination);

--- a/src/assets/scripts/client/aircraft/Pilot/Pilot.js
+++ b/src/assets/scripts/client/aircraft/Pilot/Pilot.js
@@ -919,23 +919,13 @@ export default class Pilot {
      *
      * @for Pilot
      * @method taxiToRunway
-     * @param taxiDestination {RunwayModel}  runway has already been verified by the
-     *                                       time it is sent to this method
-     * @param isDeparture {boolean}         whether the aircraft's flightPhase is DEPARTURE
-     * @param flightPhase {string}          the flight phase of the aircraft
-     * @return {array}                      [success of operation, readback]
+     * @param {RunwayModel} taxiDestination runway has already been verified by the time it is sent to this method
+     * @param {boolean} isTaxiable whether the aircraft is a departure, on the ground, and not yet cleared for takeoff
+     * @return {array} [success of operation, readback]
      */
-    taxiToRunway(taxiDestination, isDeparture, flightPhase) {
-        if (!isDeparture) {
-            return [false, 'unable to taxi, we are not a departure'];
-        }
-
-        if (flightPhase === FLIGHT_PHASE.TAKEOFF) {
-            const readback = {};
-            readback.log = `we are already taking off on Runway ${taxiDestination.name}`;
-            readback.say = `we are already taking off on Runway ${radio_runway(taxiDestination.name)}`;
-
-            return [false, readback];
+    taxiToRunway(taxiDestination, isTaxiable) {
+        if (!isTaxiable) {
+            return [false, 'unable to taxi'];
         }
 
         this._fms.setDepartureRunway(taxiDestination);

--- a/src/assets/scripts/client/aircraft/Pilot/Pilot.js
+++ b/src/assets/scripts/client/aircraft/Pilot/Pilot.js
@@ -913,27 +913,4 @@ export default class Pilot {
 
         return [true, 'taxiing back to the gate'];
     }
-
-    /**
-     * Taxi the aircraft
-     *
-     * @for Pilot
-     * @method taxiToRunway
-     * @param {RunwayModel} taxiDestination runway has already been verified by the time it is sent to this method
-     * @param {boolean} isTaxiable whether the aircraft is a departure, on the ground, and not yet cleared for takeoff
-     * @return {array} [success of operation, readback]
-     */
-    taxiToRunway(taxiDestination, isTaxiable) {
-        if (!isTaxiable) {
-            return [false, 'unable to taxi'];
-        }
-
-        this._fms.setDepartureRunway(taxiDestination);
-
-        const readback = {};
-        readback.log = `taxi to runway ${taxiDestination.name}`;
-        readback.say = `taxi to runway ${radio_runway(taxiDestination.name)}`;
-
-        return [true, readback];
-    }
 }

--- a/test/aircraft/AircraftModel.spec.js
+++ b/test/aircraft/AircraftModel.spec.js
@@ -6,7 +6,8 @@ import UiController from '../../src/assets/scripts/client/UiController';
 import GameController, { GAME_EVENTS } from '../../src/assets/scripts/client/game/GameController';
 import {
     createAirportControllerFixture,
-    resetAirportControllerFixture
+    resetAirportControllerFixture,
+    airportModelFixture
 } from '../fixtures/airportFixtures';
 import {
     createNavigationLibraryFixture,
@@ -24,6 +25,10 @@ import {
 import { AIRPORT_CONSTANTS } from '../../src/assets/scripts/client/constants/airportConstants';
 
 let sandbox; // using the sinon sandbox ensures stubs are restored after each test
+
+// mocks
+const runwayNameMock = '19L';
+const runwayModelMock = airportModelFixture.getRunway(runwayNameMock);
 
 /* eslint-disable no-unused-vars, no-undef */
 ava.beforeEach(() => {
@@ -421,4 +426,34 @@ ava('.updateTarget() causes arrivals to descend when the STAR includes AT altitu
     model.updateTarget();
 
     t.true(model.target.altitude === 8000);
+});
+
+ava('.taxiToRunway() returns an error when the aircraft is airborne', (t) => {
+    const expectedResult = [false, 'unable to taxi, we\'re airborne'];
+    const arrival = new AircraftModel(ARRIVAL_AIRCRAFT_INIT_PROPS_MOCK);
+    const arrivalResult = arrival.taxiToRunway(runwayModelMock);
+
+    t.deepEqual(arrivalResult, expectedResult);
+
+    const departure = new AircraftModel(DEPARTURE_AIRCRAFT_INIT_PROPS_MOCK);
+    departure.altitude = 28000;
+
+    const departureResult = departure.taxiToRunway(runwayModelMock);
+    t.deepEqual(departureResult, expectedResult);
+});
+
+ava('.taxiToRunway() returns a success message when finished', (t) => {
+    const expectedResult = [
+        true,
+        {
+            log: 'taxi to runway 19L',
+            say: 'taxi to runway one niner left'
+        }
+    ];
+    const model = new AircraftModel(DEPARTURE_AIRCRAFT_INIT_PROPS_MOCK);
+    const result = model.taxiToRunway(runwayModelMock);
+
+    t.deepEqual(result, expectedResult);
+    t.deepEqual(model.flightPhase, FLIGHT_PHASE.TAXI);
+    t.deepEqual(model.fms.departureRunwayModel, runwayModelMock);
 });

--- a/test/aircraft/AircraftModel.spec.js
+++ b/test/aircraft/AircraftModel.spec.js
@@ -443,7 +443,7 @@ ava('.taxiToRunway() returns an error when the aircraft is airborne', (t) => {
 });
 
 ava('.taxiToRunway() returns an error when the aircraft has landed', (t) => {
-    const expectedResult = [false, 'uanble to taxi to runway, we have just landed'];
+    const expectedResult = [false, 'unable to taxi to runway, we have just landed'];
     const arrival = new AircraftModel(ARRIVAL_AIRCRAFT_INIT_PROPS_MOCK);
     arrival.altitude = arrival.fms.arrivalAirportModel.elevation;
 

--- a/test/aircraft/AircraftModel.spec.js
+++ b/test/aircraft/AircraftModel.spec.js
@@ -442,6 +442,37 @@ ava('.taxiToRunway() returns an error when the aircraft is airborne', (t) => {
     t.deepEqual(departureResult, expectedResult);
 });
 
+ava('.taxiToRunway() returns an error when the aircraft has landed', (t) => {
+    const expectedResult = [false, 'uanble to taxi to runway, we have just landed'];
+    const arrival = new AircraftModel(ARRIVAL_AIRCRAFT_INIT_PROPS_MOCK);
+    arrival.altitude = arrival.fms.arrivalAirportModel.elevation;
+
+    const arrivalResult = arrival.taxiToRunway(runwayModelMock);
+
+    t.deepEqual(arrivalResult, expectedResult);
+});
+
+ava('.taxiToRunway() cancels IFR clearance if runway is invalid for the assigned SID', (t) => {
+    const expectedResult = [
+        true,
+        {
+            log: 'taxi to runway 01R',
+            say: 'taxi to runway zero one right'
+        }
+    ];
+    const model = new AircraftModel(DEPARTURE_AIRCRAFT_INIT_PROPS_MOCK);
+    // BOACH6 is the only SID with an invalid runway
+    model.fms.replaceFlightPlanWithNewRoute('KLAS07R.BOACH6.HEC');
+    model.pilot.hasDepartureClearance = true;
+
+    const invalidRunway = airportModelFixture.getRunway("01R");
+
+    const result = model.taxiToRunway(invalidRunway);
+
+    t.deepEqual(result, expectedResult);
+    t.false(model.pilot.hasDepartureClearance);
+});
+
 ava('.taxiToRunway() returns a success message when finished', (t) => {
     const expectedResult = [
         true,

--- a/test/aircraft/Pilot/Pilot.spec.js
+++ b/test/aircraft/Pilot/Pilot.spec.js
@@ -1009,7 +1009,6 @@ ava('.taxiToRunway() returns an error when the aircraft\'s flight phase is not "
     const nonTaxiFlightPhases = _omit(FLIGHT_PHASE, 'APRON', 'TAXI', 'WAITING');
 
     for (const phase in nonTaxiFlightPhases) {
-        console.log(phase);
         const expectedResult = [false, 'unable to taxi'];
         const pilot = createPilotFixture();
         const result = pilot.taxiToRunway(runwayModelMock, false, FLIGHT_PHASE[phase]);

--- a/test/aircraft/Pilot/Pilot.spec.js
+++ b/test/aircraft/Pilot/Pilot.spec.js
@@ -1005,16 +1005,15 @@ ava('.sayTargetHeading() returns a message when #headingMode is OFF', (t) => {
     t.deepEqual(result, expectedResult);
 });
 
-ava('.taxiToRunway() returns an error when the aircraft\'s flight phase is not "APRON", "TAXI", or "WAITING"', (t) => {
-    const nonTaxiFlightPhases = _omit(FLIGHT_PHASE, 'APRON', 'TAXI', 'WAITING');
+ava('.taxiToRunway() returns an error when the aircraft is unable to taxi', (t) => {
+    // TODO: check the flight phases
+    //const nonTaxiFlightPhases = _omit(FLIGHT_PHASE, 'APRON', 'TAXI', 'WAITING');
 
-    for (const phase in nonTaxiFlightPhases) {
-        const expectedResult = [false, 'unable to taxi'];
-        const pilot = createPilotFixture();
-        const result = pilot.taxiToRunway(runwayModelMock, false, FLIGHT_PHASE[phase]);
+    const expectedResult = [false, 'unable to taxi'];
+    const pilot = createPilotFixture();
+    const result = pilot.taxiToRunway(runwayModelMock, false);
 
-        t.deepEqual(result, expectedResult);
-    }
+    t.deepEqual(result, expectedResult);
 });
 
 ava('.taxiToRunway() returns a success message when finished', (t) => {
@@ -1026,7 +1025,7 @@ ava('.taxiToRunway() returns a success message when finished', (t) => {
         }
     ];
     const pilot = createPilotFixture();
-    const result = pilot.taxiToRunway(runwayModelMock, true, FLIGHT_PHASE.APRON);
+    const result = pilot.taxiToRunway(runwayModelMock, true);
 
     t.deepEqual(result, expectedResult);
 });

--- a/test/aircraft/Pilot/Pilot.spec.js
+++ b/test/aircraft/Pilot/Pilot.spec.js
@@ -1004,28 +1004,3 @@ ava('.sayTargetHeading() returns a message when #headingMode is OFF', (t) => {
 
     t.deepEqual(result, expectedResult);
 });
-
-ava('.taxiToRunway() returns an error when the aircraft is unable to taxi', (t) => {
-    // TODO: check the flight phases
-    //const nonTaxiFlightPhases = _omit(FLIGHT_PHASE, 'APRON', 'TAXI', 'WAITING');
-
-    const expectedResult = [false, 'unable to taxi'];
-    const pilot = createPilotFixture();
-    const result = pilot.taxiToRunway(runwayModelMock, false);
-
-    t.deepEqual(result, expectedResult);
-});
-
-ava('.taxiToRunway() returns a success message when finished', (t) => {
-    const expectedResult = [
-        true,
-        {
-            log: 'taxi to runway 19L',
-            say: 'taxi to runway one niner left'
-        }
-    ];
-    const pilot = createPilotFixture();
-    const result = pilot.taxiToRunway(runwayModelMock, true);
-
-    t.deepEqual(result, expectedResult);
-});

--- a/test/aircraft/Pilot/Pilot.spec.js
+++ b/test/aircraft/Pilot/Pilot.spec.js
@@ -3,6 +3,7 @@ import sinon from 'sinon';
 import _isArray from 'lodash/isArray';
 import _isEqual from 'lodash/isEqual';
 import _isObject from 'lodash/isObject';
+import _omit from 'lodash/omit';
 import AircraftModel from '../../../src/assets/scripts/client/aircraft/AircraftModel';
 import ModeController from '../../../src/assets/scripts/client/aircraft/ModeControl/ModeController';
 import Pilot from '../../../src/assets/scripts/client/aircraft/Pilot/Pilot';
@@ -1004,36 +1005,17 @@ ava('.sayTargetHeading() returns a message when #headingMode is OFF', (t) => {
     t.deepEqual(result, expectedResult);
 });
 
-ava('.taxiToRunway() returns an error when flightPhase is equal to FLIGHT_PHASE.TAXI', (t) => {
-    const expectedResult = [false, 'already taxiing'];
-    const pilot = createPilotFixture();
-    const result = pilot.taxiToRunway(runwayModelMock, true, FLIGHT_PHASE.TAXI);
+ava('.taxiToRunway() returns an error when the aircraft\'s flight phase is not "APRON", "TAXI", or "WAITING"', (t) => {
+    const nonTaxiFlightPhases = _omit(FLIGHT_PHASE, 'APRON', 'TAXI', 'WAITING');
 
-    t.deepEqual(result, expectedResult);
-});
+    for (const phase in nonTaxiFlightPhases) {
+        console.log(phase);
+        const expectedResult = [false, 'unable to taxi'];
+        const pilot = createPilotFixture();
+        const result = pilot.taxiToRunway(runwayModelMock, false, FLIGHT_PHASE[phase]);
 
-ava('.taxiToRunway() returns an error when flightPhase is equal to FLIGHT_PHASE.WAITING', (t) => {
-    const expectedResult = [false, 'already taxied and waiting in runway queue'];
-    const pilot = createPilotFixture();
-    const result = pilot.taxiToRunway(runwayModelMock, true, FLIGHT_PHASE.WAITING);
-
-    t.deepEqual(result, expectedResult);
-});
-
-ava('.taxiToRunway() returns an error when isDeparture is false', (t) => {
-    const expectedResult = [false, 'unable to taxi'];
-    const pilot = createPilotFixture();
-    const result = pilot.taxiToRunway(runwayModelMock, false, FLIGHT_PHASE.APRON);
-
-    t.deepEqual(result, expectedResult);
-});
-
-ava('.taxiToRunway() returns an error when flightPhase is not equal to FLIGHT_PHASE.APRON', (t) => {
-    const expectedResult = [false, 'unable to taxi'];
-    const pilot = createPilotFixture();
-    const result = pilot.taxiToRunway(runwayModelMock, true, FLIGHT_PHASE.ARRIVAL);
-
-    t.deepEqual(result, expectedResult);
+        t.deepEqual(result, expectedResult);
+    }
 });
 
 ava('.taxiToRunway() returns a success message when finished', (t) => {

--- a/test/aircraft/Pilot/Pilot.spec.js
+++ b/test/aircraft/Pilot/Pilot.spec.js
@@ -1013,7 +1013,7 @@ ava('.taxiToRunway() returns an error when flightPhase is equal to FLIGHT_PHASE.
 });
 
 ava('.taxiToRunway() returns an error when flightPhase is equal to FLIGHT_PHASE.WAITING', (t) => {
-    const expectedResult = [false, 'already taxiied and waiting in runway queue'];
+    const expectedResult = [false, 'already taxied and waiting in runway queue'];
     const pilot = createPilotFixture();
     const result = pilot.taxiToRunway(runwayModelMock, true, FLIGHT_PHASE.WAITING);
 


### PR DESCRIPTION
Resolves #870.

Fix unusable runway bug after changing one aircraft's departure runway.
Also ensure `taxied` is used in lieu of `taxiied`.