### PR TITLE
bugfix/879

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Bugfixes
 - Resolve console.warning() is not a function (when drawing SIDs), by removing the -ing (https://github.com/openscope/openscope/issues/864)
+- Restore functionality of non-procedural descents to airspace ceiling [#879](https://github.com/openscope/openscope/issues/879)
 
 
 

--- a/src/assets/scripts/client/aircraft/ModeControl/ModeController.js
+++ b/src/assets/scripts/client/aircraft/ModeControl/ModeController.js
@@ -374,7 +374,7 @@ export default class ModeController {
         this.setAltitudeVnav();
 
         // if unable to descend via STAR, force a descent to the top of our airspace
-        if (bottomAltitude === Infinity) {
+        if (bottomAltitude === -1) {
             const descentAltitude = Math.min(currentAltitude, airspaceCeiling);
 
             this.setAltitudeFieldValue(descentAltitude);

--- a/test/aircraft/ModeController/ModeController.spec.js
+++ b/test/aircraft/ModeController/ModeController.spec.js
@@ -92,7 +92,7 @@ ava('.initializeForAirborneFlight() sets MCP for arrival descending via STAR', (
 
 ava('.initializeForAirborneFlight() sets MCP for arrival not descending via STAR', (t) => {
     const mcp = new ModeController();
-    const bottomAltitudeMock = Infinity;
+    const bottomAltitudeMock = -1;
     const airspaceCeilingMock = 12000;
     const currentAltitudeMock = 21000;
     const currentHeadingMock = Math.PI;
@@ -116,7 +116,7 @@ ava('.initializeForAirborneFlight() sets MCP for arrival not descending via STAR
 
 ava('.initializeForAirborneFlight() sets MCP for arrival not descending via STAR already below airspace ceiling', (t) => {
     const mcp = new ModeController();
-    const bottomAltitudeMock = Infinity;
+    const bottomAltitudeMock = -1;
     const airspaceCeilingMock = 12000;
     const currentAltitudeMock = 9000;
     const currentHeadingMock = Math.PI;


### PR DESCRIPTION
Resolves #879.

Restore functionality of non-procedural descents to airspace ceiling
