### PR TITLE
hotfix/953

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 6.1.2 (May 2, 2018)
+### Hotfix
+- [#953](https://github.com/openscope/openscope/issues/953) - Fix aircraft not descending into airspace when airspace ceiling is below STAR bottom altitude
+
+
 # 6.1.1 (May 1, 2018)
 ### Hotfix
 - [#950](https://github.com/openscope/openscope/issues/950) - Fix left turn command `t l ###`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openscope",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "description": "An ATC simulator in HTML5",
   "engines": {
     "node": "7.0.0",

--- a/src/assets/scripts/client/aircraft/ModeControl/ModeController.js
+++ b/src/assets/scripts/client/aircraft/ModeControl/ModeController.js
@@ -370,14 +370,15 @@ export default class ModeController {
      * @param {number} currentSpeed - aircraft's current speed, in knots
      */
     initializeForAirborneFlight(bottomAltitude, airspaceCeiling, currentAltitude, currentHeading, currentSpeed) {
-        this.setAltitudeFieldValue(bottomAltitude);
+        // ensure aircraft will always descend at least to reach our airspace ceiling
+        const descentAltitude = Math.min(bottomAltitude, airspaceCeiling, currentAltitude);
+
+        this.setAltitudeFieldValue(descentAltitude);
         this.setAltitudeVnav();
 
         // if unable to descend via STAR, force a descent to the top of our airspace
         if (bottomAltitude === -1) {
-            const descentAltitude = Math.min(currentAltitude, airspaceCeiling);
-
-            this.setAltitudeFieldValue(descentAltitude);
+            this.setAltitudeFieldValue(Math.min(airspaceCeiling, currentAltitude));
             this.setAltitudeHold();
         }
 

--- a/test/aircraft/ModeController/ModeController.spec.js
+++ b/test/aircraft/ModeController/ModeController.spec.js
@@ -66,7 +66,31 @@ ava('.disable() does not change #isEnabled when #isEnabled is false', (t) => {
     t.false(mcp.isEnabled);
 });
 
-ava('.initializeForAirborneFlight() sets MCP for arrival descending via STAR', (t) => {
+ava('.initializeForAirborneFlight() sets MCP for arrival descending via STAR which ends still above the airspace ceiling', (t) => {
+    const mcp = new ModeController();
+    const bottomAltitudeMock = 15000;
+    const airspaceCeilingMock = 12000;
+    const currentAltitudeMock = 21000;
+    const currentHeadingMock = Math.PI;
+    const currentSpeedMock = 290;
+
+    mcp.initializeForAirborneFlight(
+        bottomAltitudeMock,
+        airspaceCeilingMock,
+        currentAltitudeMock,
+        currentHeadingMock,
+        currentSpeedMock
+    );
+
+    t.true(mcp.altitude === airspaceCeilingMock);
+    t.true(mcp.altitudeMode === MCP_MODE.ALTITUDE.VNAV);
+    t.true(mcp.heading === currentHeadingMock);
+    t.true(mcp.headingMode === MCP_MODE.HEADING.LNAV);
+    t.true(mcp.speed === currentSpeedMock);
+    t.true(mcp.speedMode === MCP_MODE.SPEED.VNAV);
+});
+
+ava('.initializeForAirborneFlight() sets MCP for arrival descending via STAR which ends below the airspace ceiling', (t) => {
     const mcp = new ModeController();
     const bottomAltitudeMock = 6000;
     const airspaceCeilingMock = 12000;
@@ -90,7 +114,7 @@ ava('.initializeForAirborneFlight() sets MCP for arrival descending via STAR', (
     t.true(mcp.speedMode === MCP_MODE.SPEED.VNAV);
 });
 
-ava('.initializeForAirborneFlight() sets MCP for arrival not descending via STAR', (t) => {
+ava('.initializeForAirborneFlight() sets MCP for arrival descending from above airspace ceiling (not via STAR)', (t) => {
     const mcp = new ModeController();
     const bottomAltitudeMock = -1;
     const airspaceCeilingMock = 12000;
@@ -114,7 +138,7 @@ ava('.initializeForAirborneFlight() sets MCP for arrival not descending via STAR
     t.true(mcp.speedMode === MCP_MODE.SPEED.VNAV);
 });
 
-ava('.initializeForAirborneFlight() sets MCP for arrival not descending via STAR already below airspace ceiling', (t) => {
+ava('.initializeForAirborneFlight() sets MCP for arrival spawning below airspace ceiling ', (t) => {
     const mcp = new ModeController();
     const bottomAltitudeMock = -1;
     const airspaceCeilingMock = 12000;


### PR DESCRIPTION
## https://openscope-dev-pr-954.herokuapp.com/

Resolves #953

Fix aircraft not descending into airspace when airspace ceiling is below STAR bottom altitude

Most notable at KDCA (see the southerly arrival stream)