### PR TITLE
bugfix/968

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 
 ### Bugfixes
+- [#968](https://github.com/openscope/openscope/issues/968) - fixed N-numbered GA aircraft having callsign "default" if voice is on
 
 
 
@@ -15,7 +16,6 @@
 - [#956](https://github.com/openscope/openscope/issues/956) - updated 'descend via STAR' documentation to change mentioning SID to STAR
 - [#782](https://github.com/openscope/openscope/issues/782) - Overhaul of KATL
 - [#961](https://github.com/openscope/openscope/issues/961) - updated climb and descent rates using Eurocontrol data
-
 
 
 

--- a/assets/airlines/n.json
+++ b/assets/airlines/n.json
@@ -2,6 +2,7 @@
     "icao": "n",
     "name": "General Aviation",
     "callsign": {
+        "name": "November"
         "callsignFormats": [
             "###@@"
         ]

--- a/assets/airlines/n.json
+++ b/assets/airlines/n.json
@@ -2,7 +2,7 @@
     "icao": "n",
     "name": "General Aviation",
     "callsign": {
-        "name": "November"
+        "name": "November",
         "callsignFormats": [
             "###@@"
         ]


### PR DESCRIPTION
Resolves #968.
Replaces external PR #969.

Fix GA aircraft's spoken callsign (was saying "Default 1-2-3-A-B").

All work by @JPmAn24.