### PR TITLE
refactor/982

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [#782](https://github.com/openscope/openscope/issues/782) - Overhaul of KATL
 - [#961](https://github.com/openscope/openscope/issues/961) - Updated climb and descent rates using Eurocontrol data
 - [#874](https://github.com/openscope/openscope/issues/874) - Continue and clean up following FMS / Route refactor
+- [#982](https://github.com/openscope/openscope/issues/982) - Remove empty .gitkeep file
 
 
 


### PR DESCRIPTION
Resolves openscope/openscope#982 

The purpose of this pull request is to remove an empty `.gitkeep` file

Fairly uncontroversial merge
