### PR TITLE
bugfix/1030

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
     - ensures descents below assigned altitude do not begin until established on the localizer
     - penalizes localizer interception above glideslope
     - triggers go-arounds at final approach fix if not established on both localizer and glideslope
+- [#1030](https://github.com/openscope/openscope/issues/1030) - Fix background color of options menu dropdowns
 
 
 

--- a/src/assets/style/module/optionDialog/_optionDialog.less
+++ b/src/assets/style/module/optionDialog/_optionDialog.less
@@ -56,7 +56,7 @@
 .option-dialog select {
     width: 100%;
     padding-right: 2.5em; /* accommodate with the pseudo elements for the dropdown arrow */
-    background-color: transparent;
+    background-color: #141414;
     color: @light-gray;
     font-family: inherit;
     border: 0;


### PR DESCRIPTION
Resolves #1030.

Fix background color of options menu dropdowns.

![image](https://user-images.githubusercontent.com/5103735/43167543-0ff6d02e-8f68-11e8-8b3c-659370dae9f5.png)

![image](https://user-images.githubusercontent.com/5103735/43167958-767ebbb2-8f69-11e8-99b9-60bd9bc969da.png)