### PR TITLE
enhancement/949

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Enhancements & Refactors
 - [#1005](https://github.com/openscope/openscope/issues/1005) - Minor updates to KRDU
 - [#1023](https://github.com/openscope/openscope/issues/1023) - Standardize `openScope` capitalization
+- [#949](https://github.com/openscope/openscope/issues/949) - Keep video map clearly visible at all zoom levels
 
 
 

--- a/src/assets/scripts/client/canvas/CanvasController.js
+++ b/src/assets/scripts/client/canvas/CanvasController.js
@@ -1867,7 +1867,7 @@ export default class CanvasController {
         cc.save();
         cc.translate(CanvasStageModel.halfWidth, CanvasStageModel.halfHeight);
         cc.strokeStyle = this.theme.SCOPE.VIDEO_MAP;
-        cc.lineWidth = CanvasStageModel.scale / 15;
+        cc.lineWidth = Math.max(1, CanvasStageModel.scale / 15);
         cc.lineJoin = 'round';
         cc.font = BASE_CANVAS_FONT;
         cc.translate(CanvasStageModel._panX, CanvasStageModel._panY);


### PR DESCRIPTION
Resolves #949.

Keep video map clearly visible at all zoom levels

Usually, everything drawn on the canvas is scaled down in size as you zoom out. These changes ensure the video map is always at least 1 full pixel, thus keeping it clearly visible at any zoom level.

![image](https://user-images.githubusercontent.com/5103735/43236700-88869e9c-9054-11e8-8c56-ae40e46476ed.png)
![image](https://user-images.githubusercontent.com/5103735/43236670-69d0c720-9054-11e8-9869-d680172550d1.png)