### PR TITLE
bugfix/1034 - fix waypoint time-to-turn calculations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Bugfixes
 - [#1086](https://github.com/openscope/openscope/issues/1086) - Update P28A Climb rate fm 2000ft/m to 700ft/m
+- [#1034](https://github.com/openscope/openscope/issues/1034) - Fix waypoint time-to-turn calculations to ensure smooth turns
+- [#935](https://github.com/openscope/openscope/issues/935) - Prevent aircraft from skipping fixes that require tight turns
+
 
 
 

--- a/assets/airports/othh.json
+++ b/assets/airports/othh.json
@@ -1962,7 +1962,7 @@
             "rwy": {
                 "OTHH34R": []
             },
-            "body":[["ELEDA", "S250-"], ["^MEBTI", "S250-"], ["BOSUP", "A30+"], ["MUXED", "A40"], ["LADEM", "A40"], ["EMEXA", "A50+"], ["SOLAL", "A60"], "DENSI", ["BAT", "A60"]],
+            "body":[["ELEDA", "S250-"], ["MEBTI", "S250-"], ["BOSUP", "A30+"], ["MUXED", "A40"], ["LADEM", "A40"], ["EMEXA", "A50+"], ["SOLAL", "A60"], "DENSI", ["BAT", "A60"]],
             "exitPoints": {
                 "BAT": []
             },
@@ -2018,7 +2018,7 @@
             "rwy": {
                 "OTHH34R": []
             },
-            "body":[["ELEDA", "S250-"], ["^MEBTI", "S250-"], ["BOSUP", "A30+"], ["PUSNO", "A40"], ["NABIS", "A70"], "GOBLU", "BUNDU"],
+            "body":[["ELEDA", "S250-"], ["MEBTI", "S250-"], ["BOSUP", "A30+"], ["PUSNO", "A40"], ["NABIS", "A70"], "GOBLU", "BUNDU"],
             "exitPoints": {
                 "BUNDU": []
             },
@@ -2130,7 +2130,7 @@
             "rwy": {
                 "OTHH34R": []
             },
-            "body":[["ELEDA", "S250-"], ["^MEBTI", "S250-"], ["BOSUP", "A30+"], ["PUSNO", "A40"], ["NABIS", "A70"], "GOBLU", "NAMLA"],
+            "body":[["ELEDA", "S250-"], ["MEBTI", "S250-"], ["BOSUP", "A30+"], ["PUSNO", "A40"], ["NABIS", "A70"], "GOBLU", "NAMLA"],
             "exitPoints": {
                 "NAMLA": []
             },
@@ -2298,7 +2298,7 @@
             "rwy": {
                 "OTHH34R": []
             },
-            "body":[["ELEDA", "S250-"], ["^MEBTI", "S250-"], ["BOSUP", "A30+"], "MUXED", "OBVER", ["SODER", "A40"], ["BOXED", "A50+"], ["DEBKO", "A60"], ["SALWA", "A60"]],
+            "body":[["ELEDA", "S250-"], ["MEBTI", "S250-"], ["BOSUP", "A30+"], "MUXED", "OBVER", ["SODER", "A40"], ["BOXED", "A50+"], ["DEBKO", "A60"], ["SALWA", "A60"]],
             "exitPoints": {
                 "SALWA": []
             },

--- a/src/assets/scripts/client/aircraft/AircraftModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftModel.js
@@ -1777,6 +1777,11 @@ export default class AircraftModel {
             }
 
             this.fms.moveToNextWaypoint();
+
+            const nextWaypointPosition = this.fms.currentWaypoint.positionModel;
+
+            // initiate the turn
+            return this.positionModel.bearingToPosition(nextWaypointPosition);
         }
 
         return headingToWaypoint;

--- a/src/assets/scripts/client/aircraft/AircraftModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftModel.js
@@ -32,7 +32,7 @@ import {
 } from '../math/core';
 import {
     getOffset,
-    calculateTurnInitiaionDistance
+    calculateTurnInitiationDistance
 } from '../math/flightMath';
 import {
     distance_to_poly,
@@ -1757,7 +1757,7 @@ export default class AircraftModel {
         const waypointPosition = this.fms.currentWaypoint.positionModel;
         const distanceToWaypoint = this.positionModel.distanceToPosition(waypointPosition);
         const headingToWaypoint = this.positionModel.bearingToPosition(waypointPosition);
-        const timeToCompleteTurn = calculateTurnInitiaionDistance(this, waypointPosition);
+        const turnInitiationDistance = calculateTurnInitiationDistance(this, waypointPosition);
         const isTimeToStartTurning = distanceToWaypoint < timeToCompleteTurn;
         const closeToBeingOverFix = distanceToWaypoint < PERFORMANCE.MAXIMUM_DISTANCE_TO_PASS_WAYPOINT_NM;
         const closeEnoughToFlyByFix = distanceToWaypoint < PERFORMANCE.MAXIMUM_DISTANCE_TO_FLY_BY_WAYPOINT_NM;

--- a/src/assets/scripts/client/aircraft/AircraftModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftModel.js
@@ -1757,7 +1757,8 @@ export default class AircraftModel {
         const waypointPosition = this.fms.currentWaypoint.positionModel;
         const distanceToWaypoint = this.positionModel.distanceToPosition(waypointPosition);
         const headingToWaypoint = this.positionModel.bearingToPosition(waypointPosition);
-        const isTimeToStartTurning = distanceToWaypoint < nm(calculateTurnInitiaionDistance(this, waypointPosition));
+        const timeToCompleteTurn = calculateTurnInitiaionDistance(this, waypointPosition);
+        const isTimeToStartTurning = distanceToWaypoint < timeToCompleteTurn;
         const closeToBeingOverFix = distanceToWaypoint < PERFORMANCE.MAXIMUM_DISTANCE_TO_PASS_WAYPOINT_NM;
         const closeEnoughToFlyByFix = distanceToWaypoint < PERFORMANCE.MAXIMUM_DISTANCE_TO_FLY_BY_WAYPOINT_NM;
         const shouldFlyByFix = closeEnoughToFlyByFix && isTimeToStartTurning;

--- a/src/assets/scripts/client/aircraft/AircraftModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftModel.js
@@ -1758,7 +1758,7 @@ export default class AircraftModel {
         const distanceToWaypoint = this.positionModel.distanceToPosition(waypointPosition);
         const headingToWaypoint = this.positionModel.bearingToPosition(waypointPosition);
         const turnInitiationDistance = calculateTurnInitiationDistance(this, waypointPosition);
-        const isTimeToStartTurning = distanceToWaypoint < timeToCompleteTurn;
+        const isTimeToStartTurning = distanceToWaypoint < turnInitiationDistance;
         const closeToBeingOverFix = distanceToWaypoint < PERFORMANCE.MAXIMUM_DISTANCE_TO_PASS_WAYPOINT_NM;
         const closeEnoughToFlyByFix = distanceToWaypoint < PERFORMANCE.MAXIMUM_DISTANCE_TO_FLY_BY_WAYPOINT_NM;
         const shouldFlyByFix = closeEnoughToFlyByFix && isTimeToStartTurning;

--- a/src/assets/scripts/client/aircraft/FlightManagementSystem/Fms.js
+++ b/src/assets/scripts/client/aircraft/FlightManagementSystem/Fms.js
@@ -584,7 +584,7 @@ export default class Fms {
     /**
      * Get the position of the next waypoint in the flight plan
      *
-     * Currently only used in `calculateTurnInitiaionDistance()` helper function
+     * Currently only used in `calculateTurnInitiationDistance()` helper function
      *
      * @for Fms
      * @method getNextWaypointPositionModel

--- a/src/assets/scripts/client/math/flightMath.js
+++ b/src/assets/scripts/client/math/flightMath.js
@@ -26,19 +26,23 @@ import { PHYSICS_CONSTANTS } from '../constants/globalConstants';
 
 /**
  * Calculate the radius of turn of the aircraft, given its groundspeed
- * 
+ *
  * Reference:
  * http://www.flightlearnings.com/2009/08/26/radius-of-turn/
- * 
- * Using constant of 68416 (to yield nm) in lieu of 11.26 (yields ft)
- * 
+ *
+ * Possible conversion factor constants:
+ *    - 68416 (yields nautical miles)
+ *    - 11.26 (yields feet)
+ *
  * @function calcTurnRadius
  * @param speed {number} aircraft groundspeed, in knots
  * @param bankAngle {number} bank angle to use, in radians
  * @return {number} radius of turn, in nautical miles
  */
 export function calcTurnRadius(speed, bankAngle) {
-    return (speed * speed) / (68416 * Math.tan(bankAngle));
+    const conversionFactor = 68416; // yields radius in nautical miles
+
+    return (speed * speed) / (conversionFactor * Math.tan(bankAngle));
 }
 
 /**
@@ -50,8 +54,10 @@ export function calcTurnRadius(speed, bankAngle) {
  */
 export function calcTurnInitiationDistanceNm(speed, bankAngle, courseChange) {
     const turnRadiusNm = calcTurnRadius(speed, bankAngle);
+    const halfCourseChange = courseChange / 2;
+    const halfPi = Math.PI / 2;
 
-    return turnRadiusNm * (courseChange / 2) / (Math.PI / 2);
+    return turnRadiusNm * halfCourseChange / halfPi;
 }
 
 /**

--- a/src/assets/scripts/client/math/flightMath.js
+++ b/src/assets/scripts/client/math/flightMath.js
@@ -177,12 +177,12 @@ function _calculateCourseChangeInRadians(currentHeading, nominalNewCourse) {
  * - http://www.ohio.edu/people/uijtdeha/ee6900_fms_00_overview.pdf, Fly-by waypoint
  * - The Avionics Handbook, ch 15
  *
- * @function aircraft_turn_initiation_distance
+ * @function calculateTurnInitiationDistance
  * @param aircraft {AircraftModel}
  * @param currentWaypointPosition {StaticPositionModel}
  * @return {number} distance before fix to initiate turn to level out on route, in nautical miles
  */
-export function calculateTurnInitiaionDistance(aircraft, currentWaypointPosition) {
+export function calculateTurnInitiationDistance(aircraft, currentWaypointPosition) {
     let currentHeading = aircraft.heading;
     const nominalBankAngleDegrees = 30;
     const bankAngle = degreesToRadians(nominalBankAngleDegrees);

--- a/src/assets/scripts/client/math/flightMath.js
+++ b/src/assets/scripts/client/math/flightMath.js
@@ -23,41 +23,62 @@ import {
     radiansToDegrees
 } from '../utilities/unitConverters';
 import { PHYSICS_CONSTANTS } from '../constants/globalConstants';
+import { PERFORMANCE } from '../constants/aircraftConstants';
 
 /**
  * Calculate the radius of turn of the aircraft, given its groundspeed
  *
  * Reference:
  * http://www.flightlearnings.com/2009/08/26/radius-of-turn/
+ * https://en.wikipedia.org/wiki/Banked_turn#Banked_turn_in_aeronautics
  *
  * Possible conversion factor constants:
  *    - 68416 (yields nautical miles)
  *    - 11.26 (yields feet)
  *
- * @function calcTurnRadius
+ * @function calcTurnRadiusByBankAngle
  * @param speed {number} aircraft groundspeed, in knots
  * @param bankAngle {number} bank angle to use, in radians
  * @return {number} radius of turn, in nautical miles
  */
-export function calcTurnRadius(speed, bankAngle) {
+export function calcTurnRadiusByBankAngle(speed, bankAngle) {
     const conversionFactor = 68416; // yields radius in nautical miles
 
     return (speed * speed) / (conversionFactor * Math.tan(bankAngle));
 }
 
+
 /**
+ * Calculate the radius of turn of the aircraft, given its groundspeed and
+ * its turn rate
+ *
+ * R = speedInKnots / (turnRateInDegreePerSecond * 20 * PI)
+ *
+ * https://en.wikipedia.org/wiki/Standard_rate_turn#Formulae
+ *
+ * @function calcTurnRadiusByTurnRate
+ * @param speed {number} aircraft groundspeed, in knots
+ * @param turnRate {number} in radians per second
+ * @return {number} radius of turn, in nautical miles
+ */
+export function calcTurnRadiusByTurnRate(speed, turnRate) {
+    return speed / (turnRate * 180 * 20);
+}
+
+/**
+ * The turn initiation distance is the distance that is necessary to complete
+ * a turn before reaching of a fly-by turn.
+ *
  * @function calcTurnInitiationDistanceNm
- * @param speed {number}            currentSpeed of an aircraft
- * @param bankAngle {number}        bank angle of an aircraft
- * @param courseChange {number}     angular difference, in radians
+ * @param speed {number}        current speed of the aircraft in knots
+ * @param turnRate {number}     turn rate of the aircraft in radian per second
+ * @param courseChange {number} angular difference, in radians
  * @return {number}
  */
-export function calcTurnInitiationDistanceNm(speed, bankAngle, courseChange) {
-    const turnRadiusNm = calcTurnRadius(speed, bankAngle);
-    const halfCourseChange = courseChange / 2;
-    const halfPi = Math.PI / 2;
+export function calcTurnInitiationDistanceNm(speed, turnRate, courseChange) {
+    const turnRadiusNm = calcTurnRadiusByTurnRate(speed, turnRate);
 
-    return turnRadiusNm * halfCourseChange / halfPi;
+    return turnRadiusNm * Math.tan(courseChange*0.5);
 }
 
 /**
@@ -183,25 +204,28 @@ function _calculateCourseChangeInRadians(currentHeading, nominalNewCourse) {
  * @return {number} distance before fix to initiate turn to level out on route, in nautical miles
  */
 export function calculateTurnInitiationDistance(aircraft, currentWaypointPosition) {
-    let currentHeading = aircraft.heading;
-    const nominalBankAngleDegrees = 30;
-    const bankAngle = degreesToRadians(nominalBankAngleDegrees);
     const nextWaypointModel = aircraft.fms.nextWaypoint;
 
     if (!aircraft.fms.hasNextWaypoint() || nextWaypointModel.isVectorWaypoint) {
         return 0;
     }
 
-    if (currentHeading < 0) {
-        currentHeading += tau();
+    // use the target heading instead of the actual heading to take into account
+    // that we might be already turning and there might be no need to initiate
+    // a turn at the moment. see #935
+    let targetHeading = aircraft.target.heading;
+
+    if (targetHeading < 0) {
+        targetHeading += tau();
     }
 
+    const turnRate = PERFORMANCE.TURN_RATE;
     const nominalNewCourse = _calculateNominalNewCourse(
         nextWaypointModel.relativePosition,
         currentWaypointPosition.relativePosition
     );
-    const courseChange = _calculateCourseChangeInRadians(currentHeading, nominalNewCourse);
-    const turnInitiationDistanceNm = calcTurnInitiationDistanceNm(aircraft.groundSpeed, bankAngle, courseChange);
+    const courseChange = _calculateCourseChangeInRadians(targetHeading, nominalNewCourse);
+    const turnInitiationDistanceNm = calcTurnInitiationDistanceNm(aircraft.groundSpeed, turnRate, courseChange);
 
     return turnInitiationDistanceNm;
 }

--- a/test/math/flightMath.spec.js
+++ b/test/math/flightMath.spec.js
@@ -2,30 +2,44 @@
 import ava from 'ava';
 
 import {
-    calcTurnRadius,
+    calcTurnRadiusByBankAngle,
+    calcTurnRadiusByTurnRate,
     calcTurnInitiationDistanceNm,
     bearingToPoint,
     fixRadialDist,
     calculateCrosswindAngle
 } from '../../src/assets/scripts/client/math/flightMath';
 
-ava('calcTurnRadius() returns a turn radius based on speed and bank angle', t => {
+ava('calcTurnRadiusByBankAngle() returns a turn radius based on speed and bank angle', t => {
     const speed = 190;
     const bankAngle = 0.523599;
     const expectedResult = 0.9139236691657421;
-    const result = calcTurnRadius(speed, bankAngle);
+    const result = calcTurnRadiusByBankAngle(speed, bankAngle);
+
+    t.true(result === expectedResult);
+});
+
+ava('calcTurnRadiusByTurnRate() returns a turn radius based on speed and turn rate', t => {
+    const speed = 190;
+    const turnRate = 0.0523598776;
+    const expectedResult = 1.0079813054753546;
+    const result = calcTurnRadiusByTurnRate(speed, turnRate);
 
     t.true(result === expectedResult);
 });
 
 ava('calcTurnInitiationDistanceNm() returns the distance required for a turn', t => {
-    const speed = 190;
-    const bankAngle = 0.523599;
-    const courseChange = 0.26420086153126987;
-    const expectedResult = 0.07685892074247777;
-    const result = calcTurnInitiationDistanceNm(speed, bankAngle, courseChange);
+    const speedA = 190;
+    const speedB = 500;
+    const turnRate = 0.0523598776;
 
-    t.true(result === expectedResult);
+    t.is(calcTurnInitiationDistanceNm(speedA, turnRate, 0.26420086153126987), 0.1339347496990795);
+    t.is(calcTurnInitiationDistanceNm(speedA, turnRate, Math.PI*0.5), 1.0079813054753544);
+    t.is(calcTurnInitiationDistanceNm(speedA, turnRate, Math.PI*0.75), 2.4334821382971388);
+
+    t.is(calcTurnInitiationDistanceNm(speedB, turnRate, 0.26420086153126987), 0.35245986762915654);
+    t.is(calcTurnInitiationDistanceNm(speedB, turnRate, Math.PI*0.5), 2.65258238282988);
+    t.is(calcTurnInitiationDistanceNm(speedB, turnRate, Math.PI*0.75), 6.403900363939838);
 });
 
 ava('bearingToPoint() returns the bearing from one point to another', t => {

--- a/test/math/flightMath.spec.js
+++ b/test/math/flightMath.spec.js
@@ -18,7 +18,7 @@ ava('calcTurnRadius() returns a turn radius based on speed and bank angle', t =>
     t.true(result === expectedResult);
 });
 
-ava('calcTurnRadius() returns a turn radius based on speed and bank angle', t => {
+ava('calcTurnInitiationDistanceNm() returns the distance required for a turn', t => {
     const speed = 190;
     const bankAngle = 0.523599;
     const courseChange = 0.26420086153126987;

--- a/test/math/flightMath.spec.js
+++ b/test/math/flightMath.spec.js
@@ -3,27 +3,27 @@ import ava from 'ava';
 
 import {
     calcTurnRadius,
-    calcTurnInitiationDistance,
+    calcTurnInitiationDistanceNm,
     bearingToPoint,
     fixRadialDist,
     calculateCrosswindAngle
 } from '../../src/assets/scripts/client/math/flightMath';
 
 ava('calcTurnRadius() returns a turn radius based on speed and bank angle', t => {
-    const speed = 144.0444432;
-    const bankAngle = 0.4363323129985824;
-    const expectedResult = 4535.774583027857;
+    const speed = 190;
+    const bankAngle = 0.523599;
+    const expectedResult = 0.9139236691657421;
     const result = calcTurnRadius(speed, bankAngle);
 
     t.true(result === expectedResult);
 });
 
 ava('calcTurnRadius() returns a turn radius based on speed and bank angle', t => {
-    const speed = 144.0444432;
-    const bankAngle = 0.4363323129985824;
+    const speed = 190;
+    const bankAngle = 0.523599;
     const courseChange = 0.26420086153126987;
-    const expectedResult = 746.732042830424;
-    const result = calcTurnInitiationDistance(speed, bankAngle, courseChange);
+    const expectedResult = 0.07685892074247777;
+    const result = calcTurnInitiationDistanceNm(speed, bankAngle, courseChange);
 
     t.true(result === expectedResult);
 });


### PR DESCRIPTION
Resolves #1034
Resolves #935

Fix waypoint time-to-turn calculations.

The errors were fairly minimal, but became quite noticeable at very high ground speeds from the en route demo. They were constantly undershooting the turn, whereas with this they will cut the corner properly and end up right on the targeted track.