### PR TITLE
bugfix/1044: overriding the target heading caused aircrafts to drift …

### DIFF
--- a/src/assets/scripts/client/aircraft/AircraftModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftModel.js
@@ -1367,8 +1367,6 @@ export default class AircraftModel {
                 break;
 
             case FLIGHT_PHASE.LANDING: {
-                this.target.heading = this.mcp.course;
-
                 if (this.altitude <= this.mcp.nav1Datum.elevation) {
                     this.altitude = this.mcp.nav1Datum.elevation;
                     this.target.speed = 0;


### PR DESCRIPTION
…off ILS localizier during final approach

Resolves #1044

The target heading calculated by _calculateTargetedHeadingDuringLanding() is overridden in overrideTarget() causing aircrafts to drift off the ILS localizer.