### PR TITLE
bugfix/1048 - Aircrafts do not land after ILS clearance

### DIFF
--- a/src/assets/scripts/client/aircraft/AircraftCommander.js
+++ b/src/assets/scripts/client/aircraft/AircraftCommander.js
@@ -341,7 +341,7 @@ export default class AircraftCommander {
             return [false, readback];
         }
 
-        return aircraft.pilot.setArrivalRunway(aircraft, runwayModel);
+        return aircraft.pilot.updateStarLegForArrivalRunway(aircraft, runwayModel);
     }
 
     /**

--- a/src/assets/scripts/client/aircraft/FlightManagementSystem/Fms.js
+++ b/src/assets/scripts/client/aircraft/FlightManagementSystem/Fms.js
@@ -330,7 +330,8 @@ export default class Fms {
         const arrivalRunwayName = this._routeModel.getArrivalRunwayName();
 
         if (!arrivalRunwayName) {
-            return this.setArrivalRunway(this.arrivalAirportModel.arrivalRunwayModel);
+            this.setArrivalRunway(this.arrivalAirportModel.arrivalRunwayModel);
+            return;
         }
 
         const arrivalRunwayModel = this.arrivalAirportModel.getRunway(arrivalRunwayName);
@@ -866,38 +867,13 @@ export default class Fms {
      * @for Fms
      * @method setArrivalRunway
      * @param nextRunwayModel {RunwayModel}
-     * @return {array} [success of operation, response]
      */
     setArrivalRunway(nextRunwayModel) {
-        const currentArrivalRunway = this.arrivalRunwayModel;
-
         if (!(nextRunwayModel instanceof RunwayModel)) {
             throw new TypeError(`Expected instance of RunwayModel, but received ${nextRunwayModel}`);
         }
 
-        if (currentArrivalRunway && currentArrivalRunway.name === nextRunwayModel.name) {
-            const readback = {};
-            readback.log = `expect Runway ${nextRunwayModel.name}`;
-            readback.say = `expect Runway ${nextRunwayModel.getRadioName()}`;
-
-            return [true, readback];
-        }
-
-        if (!this.isRunwayModelValidForStar(nextRunwayModel)) {
-            const readback = {};
-            readback.log = `according to our charts, Runway ${nextRunwayModel.name} is ` +
-                `not valid for the ${this._routeModel.getStarIcao()} arrival, expecting ` +
-                `Runway ${currentArrivalRunway.name} instead`;
-            readback.say = `according to our charts, Runway ${nextRunwayModel.getRadioName()} ` +
-                `is not valid for the ${this._routeModel.getStarName()} arrival, expecting ` +
-                `Runway ${currentArrivalRunway.getRadioName()} instead`;
-
-            return [false, readback];
-        }
-
         this.arrivalRunwayModel = nextRunwayModel;
-
-        return this._routeModel.updateStarLegForArrivalRunwayModel(nextRunwayModel);
     }
 
     /**
@@ -970,6 +946,51 @@ export default class Fms {
     //
     //     return legModel;
     // }
+
+    /**
+     * Ensure the STAR leg has the specified arrival runway as the exit point
+     *
+     * @for Fms
+     * @method updateStarLegForArrivalRunway
+     * @param nextRunwayModel {RunwayModel}
+     * @return {array} [success of operation, response]
+     */
+    updateStarLegForArrivalRunway(nextRunwayModel) {
+        const currentArrivalRunway = this.arrivalRunwayModel;
+
+        if (!(nextRunwayModel instanceof RunwayModel)) {
+            throw new TypeError(`Expected instance of RunwayModel, but received ${nextRunwayModel}`);
+        }
+
+        if (currentArrivalRunway && currentArrivalRunway.name === nextRunwayModel.name) {
+            const readback = {};
+            readback.log = `expect Runway ${nextRunwayModel.name}`;
+            readback.say = `expect Runway ${nextRunwayModel.getRadioName()}`;
+
+            return [true, readback];
+        }
+
+        if (!this._routeModel.isRunwayModelValidForStar(nextRunwayModel)) {
+            const readback = {};
+            readback.log = `unable, according to our charts, Runway ${nextRunwayModel.name} is ` +
+                            `not valid for the ${this._routeModel.getStarIcao()} arrival, expecting ` +
+                            `Runway ${currentArrivalRunway.name} instead`;
+            readback.say = `unable, according to our charts, Runway ${nextRunwayModel.getRadioName()} ` +
+                            `is not valid for the ${this._routeModel.getStarName()} arrival, expecting ` +
+                            `Runway ${currentArrivalRunway.getRadioName()} instead`;
+
+            return [false, readback];
+        }
+
+        this._routeModel.updateStarLegForArrivalRunwayModel(nextRunwayModel);
+        this.setArrivalRunway(nextRunwayModel);
+
+        const readback = {};
+        readback.log = `expecting Runway ${nextRunwayModel.name}`;
+        readback.say = `expecting Runway ${nextRunwayModel.getRadioName()}`;
+
+        return [true, readback];
+    }
 
     /**
      * Update the expected arrival runway based on the STAR's exit point runway

--- a/src/assets/scripts/client/aircraft/FlightManagementSystem/RouteModel.js
+++ b/src/assets/scripts/client/aircraft/FlightManagementSystem/RouteModel.js
@@ -861,38 +861,25 @@ export default class RouteModel extends BaseModel {
     * @for RouteModel
     * @method updateStarLegForArrivalRunwayModel
     * @param runwayModel {RunwayModel}
-    * @return {array} [success of operation, response]
     */
     updateStarLegForArrivalRunwayModel(runwayModel) {
         if (!this.hasStarLeg()) {
             return;
         }
 
+        if (!this.isRunwayModelValidForStar(runwayModel)) {
+            // for tests
+            return;
+        }
+
         const originalCurrentWaypointName = this.currentWaypoint.name;
         const nextExitName = `${this.getArrivalRunwayAirportIcao().toUpperCase()}${runwayModel.name}`;
         const starLegIndex = this._findStarLegIndex();
-        const starLegModel = this._legCollection[starLegIndex];
-
-        if (!starLegModel.procedureHasExit(nextExitName)) {
-            const procedureIcao = starLegModel.getProcedureIcao();
-            const procedureName = starLegModel.getProcedureName();
-            const readback = {};
-            readback.log = `unable, Runway ${runwayModel.name} is not valid for the ${procedureIcao} arrival`;
-            readback.say = `unable, Runway ${runwayModel.getRadioName()} is not valid for the ${procedureName} arrival`;
-
-            return [false, readback];
-        }
 
         const amendedStarLegModel = this._createAmendedStarLegUsingDifferentExitName(nextExitName, starLegIndex);
         this._legCollection[starLegIndex] = amendedStarLegModel;
 
         this.skipToWaypointName(originalCurrentWaypointName);
-
-        const readback = {};
-        readback.log = `expecting Runway ${runwayModel.name}`;
-        readback.say = `expecting Runway ${runwayModel.getRadioName()}`;
-
-        return [true, readback];
     }
 
     // ------------------------------ PRIVATE ------------------------------

--- a/src/assets/scripts/client/aircraft/Pilot/Pilot.js
+++ b/src/assets/scripts/client/aircraft/Pilot/Pilot.js
@@ -341,6 +341,24 @@ export default class Pilot {
     }
 
     /**
+     * Ensure the STAR leg has the specified arrival runway as the exit point and
+     * set the specified runway as the new arrival runway.
+     *
+     * @for Pilot
+     * @method updateStarLegForArrivalRunway
+     * @param aircraft {AircraftModel}
+     * @param nextRunwayModel {RunwayModel}
+     * @return {array} [success of operation, response]
+     */
+    updateStarLegForArrivalRunway(aircraft, nextRunwayModel) {
+        if (aircraft.isOnGround()) {
+            return [false, 'unable to accept arrival runway assignment until airborne'];
+        }
+
+        return this._fms.updateStarLegForArrivalRunway(nextRunwayModel);
+    }
+
+    /**
      * Stop conducting the instrument approach, and maintain:
      * - current or last assigned altitude (whichever is lower)
      * - current heading
@@ -814,23 +832,6 @@ export default class Pilot {
     sayTargetedSpeed() {
         // TODO: How do we handle the cases where aircraft are using VNAV speed?
         return [true, this._mcp.speed];
-    }
-
-    /**
-     * Set the arrival runway to the specified runway model
-     *
-     * @for Pilot
-     * @method setArrivalRunway
-     * @param aircraft {AircraftModel}
-     * @param runwayModel {RunwayModel}
-     * @return {array} [success of operation, response]
-     */
-    setArrivalRunway(aircraft, runwayModel) {
-        if (aircraft.isOnGround()) {
-            return [false, 'unable to accept arrival runway assignment until airborne'];
-        }
-
-        return this._fms.setArrivalRunway(runwayModel);
     }
 
     /**

--- a/test/aircraft/FlightManagementSystem/Fms.spec.js
+++ b/test/aircraft/FlightManagementSystem/Fms.spec.js
@@ -249,10 +249,9 @@ ava('._initializeArrivalRunway() returns early when #arrivalAirportModel is null
 
 ava('._initializeArrivalRunway() sets #arrivalRunwayModel to arrival airport\'s standard arrival runway when unable to deduce arrival runway from route', (t) => {
     const fms = buildFmsForAircraftInCruisePhaseWithRouteString(directOnlyRouteStringMock);
-    const expectedResult = [true, { log: 'expect Runway 25L', say: 'expect Runway two five left' }];
     const result = fms._initializeArrivalRunway();
 
-    t.deepEqual(result, expectedResult);
+    t.true(typeof result === 'undefined');
     t.deepEqual(fms.arrivalRunwayModel, fms.arrivalAirportModel.arrivalRunwayModel);
 });
 
@@ -700,40 +699,55 @@ ava('.setArrivalRunway() throws when passed something other than a RunwayModel i
     t.throws(() => fms.setArrivalRunway('hello'));
 });
 
-ava('.setArrivalRunway() returns early when the specified runway is already the #arrivalRunwayModel', (t) => {
+ava('.updateStarLegForArrivalRunway() throws when passed something other than a RunwayModel instance', (t) => {
     const fms = buildFmsForAircraftInApronPhaseWithRouteString(fullRouteStringMock);
-    const originalRunwayModel = fms.arrivalRunwayModel;
-    const routeModelUpdateStarLegForArrivalRunwayModelSpy = sinon.spy(fms._routeModel, 'updateStarLegForArrivalRunwayModel');
 
-    fms.setArrivalRunway(originalRunwayModel);
-
-    t.true(routeModelUpdateStarLegForArrivalRunwayModelSpy.notCalled);
-    t.deepEqual(fms.arrivalRunwayModel, originalRunwayModel);
+    t.throws(() => fms.updateStarLegForArrivalRunway());
+    t.throws(() => fms.updateStarLegForArrivalRunway({}));
+    t.throws(() => fms.updateStarLegForArrivalRunway([]));
+    t.throws(() => fms.updateStarLegForArrivalRunway(''));
+    t.throws(() => fms.updateStarLegForArrivalRunway(15));
+    t.throws(() => fms.updateStarLegForArrivalRunway('hello'));
 });
 
-ava('.setArrivalRunway() returns early when the specified runway is not valid for the currently assigned STAR', (t) => {
+ava('.updateStarLegForArrivalRunway() returns early when the specified runway is already the #arrivalRunwayModel', (t) => {
     const fms = buildFmsForAircraftInApronPhaseWithRouteString(fullRouteStringMock);
     const originalRunwayModel = fms.arrivalRunwayModel;
-    const nextRunwayModel = airportModelFixture.getRunway('01R');
     const routeModelUpdateStarLegForArrivalRunwayModelSpy = sinon.spy(fms._routeModel, 'updateStarLegForArrivalRunwayModel');
-    const expectedResult = [false, {
-        log: 'according to our charts, Runway 01R is not valid for the KEPEC3 arrival, expecting Runway 07R instead',
-        say: 'according to our charts, Runway zero one right is not valid for the Kepec Three arrival, expecting Runway zero seven right instead'
-    }];
-    const result = fms.setArrivalRunway(nextRunwayModel);
+
+    const expectedResult = [true, { log: `expect Runway ${originalRunwayModel.name}`, say: `expect Runway ${originalRunwayModel.getRadioName()}` }];
+    const result = fms.updateStarLegForArrivalRunway(originalRunwayModel);
 
     t.deepEqual(result, expectedResult);
     t.true(routeModelUpdateStarLegForArrivalRunwayModelSpy.notCalled);
     t.deepEqual(fms.arrivalRunwayModel, originalRunwayModel);
 });
 
-ava('.setArrivalRunway() sets #arrivalRunwayModel to the specified RunwayModel', (t) => {
+ava('.updateStarLegForArrivalRunway() returns early when the specified runway is not valid for the currently assigned STAR', (t) => {
+    const fms = buildFmsForAircraftInApronPhaseWithRouteString(fullRouteStringMock);
+    const originalRunwayModel = fms.arrivalRunwayModel;
+    const nextRunwayModel = airportModelFixture.getRunway('01R');
+    const routeModelUpdateStarLegForArrivalRunwayModelSpy = sinon.spy(fms._routeModel, 'updateStarLegForArrivalRunwayModel');
+    const expectedResult = [false, {
+        log: 'unable, according to our charts, Runway 01R is not valid for the KEPEC3 arrival, expecting Runway 07R instead',
+        say: 'unable, according to our charts, Runway zero one right is not valid for the Kepec Three arrival, expecting Runway zero seven right instead'
+    }];
+    const result = fms.updateStarLegForArrivalRunway(nextRunwayModel);
+
+    t.deepEqual(result, expectedResult);
+    t.true(routeModelUpdateStarLegForArrivalRunwayModelSpy.notCalled);
+    t.deepEqual(fms.arrivalRunwayModel, originalRunwayModel);
+});
+
+ava('.updateStarLegForArrivalRunway() sets #arrivalRunwayModel to the specified RunwayModel', (t) => {
     const fms = buildFmsForAircraftInApronPhaseWithRouteString(fullRouteStringMock);
     const nextRunwayModel = airportModelFixture.getRunway('25R');
     const routeModelUpdateStarLegForArrivalRunwayModelSpy = sinon.spy(fms._routeModel, 'updateStarLegForArrivalRunwayModel');
 
-    fms.setArrivalRunway(nextRunwayModel);
+    const expectedResult = [true, { log: `expecting Runway ${nextRunwayModel.name}`, say: `expecting Runway ${nextRunwayModel.getRadioName()}` }];
+    const result = fms.updateStarLegForArrivalRunway(nextRunwayModel);
 
+    t.deepEqual(result, expectedResult);
     t.true(routeModelUpdateStarLegForArrivalRunwayModelSpy.calledWithExactly(nextRunwayModel));
     t.deepEqual(fms.arrivalRunwayModel, nextRunwayModel);
 });

--- a/test/aircraft/FlightManagementSystem/RouteModel.spec.js
+++ b/test/aircraft/FlightManagementSystem/RouteModel.spec.js
@@ -831,20 +831,16 @@ ava('.updateStarLegForArrivalRunwayModel() returns early when the route contains
     t.true(typeof result === 'undefined');
 });
 
-ava('.updateStarLegForArrivalRunwayModel() returns an unable response when the runway is not valid for the current STAR', (t) => {
+ava('.updateStarLegForArrivalRunwayModel() returns early when the runway is not valid for the current STAR', (t) => {
     const routeModel = new RouteModel('DRK.ZIMBO1.KLAS07R');
     const airportModel = createAirportModelFixture();
     const nextRunwayName = '25L';
     const nextRunwayModel = airportModel.getRunway(nextRunwayName);
     const createAmendedStarLegSpy = sinon.spy(routeModel, '_createAmendedStarLegUsingDifferentExitName');
-    const expectedResult = [false, {
-        log: 'unable, Runway 25L is not valid for the ZIMBO1 arrival',
-        say: 'unable, Runway two five left is not valid for the Zimbo One arrival'
-    }];
     const result = routeModel.updateStarLegForArrivalRunwayModel(nextRunwayModel);
 
     t.true(createAmendedStarLegSpy.notCalled);
-    t.deepEqual(result, expectedResult);
+    t.true(typeof result === 'undefined');
 });
 
 ava('.updateStarLegForArrivalRunwayModel() replaces the STAR leg with a newly created one using the correct parameters', (t) => {
@@ -853,14 +849,10 @@ ava('.updateStarLegForArrivalRunwayModel() replaces the STAR leg with a newly cr
     const nextRunwayName = '25L';
     const nextRunwayModel = airportModel.getRunway(nextRunwayName);
     const createAmendedStarLegSpy = sinon.spy(routeModel, '_createAmendedStarLegUsingDifferentExitName');
-    const expectedResult = [true, {
-        log: 'expecting Runway 25L',
-        say: 'expecting Runway two five left'
-    }];
     const result = routeModel.updateStarLegForArrivalRunwayModel(nextRunwayModel);
 
     t.true(createAmendedStarLegSpy.calledWithExactly('KLAS25L', 0));
-    t.deepEqual(result, expectedResult);
+    t.true(typeof result === 'undefined');
 });
 
 ava('.reset() clears #_legCollection', (t) => {


### PR DESCRIPTION
Resolves #1048 

Allow ILS clearance to a runway that is not part of the STAR.

- moved STAR logic from setArrivalRunway() to updateStarLegForArrivalRunway()
- moved readback from updateStarLegForArrivalRunwayModel() to updateStarLegForArrivalRunway()
- runExpectArrivalRunway is now calling updateStarLegForArrivalRunway()
- updated tests accordingly

original PR #1051