### PR TITLE
bugfix/935 - Aircrafts are skipping a fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 
 ### Bugfixes
-
+- [#935] https://github.com/openscope/openscope/issues/935 - fix "Aircrafts are skipping a fix" (due to huge turn initiation distance)
 
 
 

--- a/assets/airports/othh.json
+++ b/assets/airports/othh.json
@@ -1962,7 +1962,7 @@
             "rwy": {
                 "OTHH34R": []
             },
-            "body":[["ELEDA", "S250-"], ["^MEBTI", "S250-"], ["BOSUP", "A30+"], ["MUXED", "A40"], ["LADEM", "A40"], ["EMEXA", "A50+"], ["SOLAL", "A60"], "DENSI", ["BAT", "A60"]],
+            "body":[["ELEDA", "S250-"], ["MEBTI", "S250-"], ["BOSUP", "A30+"], ["MUXED", "A40"], ["LADEM", "A40"], ["EMEXA", "A50+"], ["SOLAL", "A60"], "DENSI", ["BAT", "A60"]],
             "exitPoints": {
                 "BAT": []
             },
@@ -2018,7 +2018,7 @@
             "rwy": {
                 "OTHH34R": []
             },
-            "body":[["ELEDA", "S250-"], ["^MEBTI", "S250-"], ["BOSUP", "A30+"], ["PUSNO", "A40"], ["NABIS", "A70"], "GOBLU", "BUNDU"],
+            "body":[["ELEDA", "S250-"], ["MEBTI", "S250-"], ["BOSUP", "A30+"], ["PUSNO", "A40"], ["NABIS", "A70"], "GOBLU", "BUNDU"],
             "exitPoints": {
                 "BUNDU": []
             },
@@ -2130,7 +2130,7 @@
             "rwy": {
                 "OTHH34R": []
             },
-            "body":[["ELEDA", "S250-"], ["^MEBTI", "S250-"], ["BOSUP", "A30+"], ["PUSNO", "A40"], ["NABIS", "A70"], "GOBLU", "NAMLA"],
+            "body":[["ELEDA", "S250-"], ["MEBTI", "S250-"], ["BOSUP", "A30+"], ["PUSNO", "A40"], ["NABIS", "A70"], "GOBLU", "NAMLA"],
             "exitPoints": {
                 "NAMLA": []
             },
@@ -2298,7 +2298,7 @@
             "rwy": {
                 "OTHH34R": []
             },
-            "body":[["ELEDA", "S250-"], ["^MEBTI", "S250-"], ["BOSUP", "A30+"], "MUXED", "OBVER", ["SODER", "A40"], ["BOXED", "A50+"], ["DEBKO", "A60"], ["SALWA", "A60"]],
+            "body":[["ELEDA", "S250-"], ["MEBTI", "S250-"], ["BOSUP", "A30+"], "MUXED", "OBVER", ["SODER", "A40"], ["BOXED", "A50+"], ["DEBKO", "A60"], ["SALWA", "A60"]],
             "exitPoints": {
                 "SALWA": []
             },

--- a/src/assets/scripts/client/aircraft/AircraftModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftModel.js
@@ -32,7 +32,7 @@ import {
 } from '../math/core';
 import {
     getOffset,
-    calculateTurnInitiaionDistance
+    calculateTurnInitiationDistance
 } from '../math/flightMath';
 import {
     distance_to_poly,
@@ -1759,7 +1759,7 @@ export default class AircraftModel {
         const waypointPosition = this.fms.currentWaypoint.positionModel;
         const distanceToWaypoint = this.positionModel.distanceToPosition(waypointPosition);
         const headingToWaypoint = this.positionModel.bearingToPosition(waypointPosition);
-        const isTimeToStartTurning = distanceToWaypoint < nm(calculateTurnInitiaionDistance(this, waypointPosition));
+        const isTimeToStartTurning = distanceToWaypoint < nm(calculateTurnInitiationDistance(this, waypointPosition));
         const closeToBeingOverFix = distanceToWaypoint < PERFORMANCE.MAXIMUM_DISTANCE_TO_PASS_WAYPOINT_NM;
         const closeEnoughToFlyByFix = distanceToWaypoint < PERFORMANCE.MAXIMUM_DISTANCE_TO_FLY_BY_WAYPOINT_NM;
         const shouldFlyByFix = closeEnoughToFlyByFix && isTimeToStartTurning;

--- a/src/assets/scripts/client/math/flightMath.js
+++ b/src/assets/scripts/client/math/flightMath.js
@@ -44,7 +44,8 @@ export const calcTurnRadius = (speed, bankAngle) => {
 export const calcTurnInitiationDistance = (speed, bankAngle, courseChange) => {
     const turnRadius = calcTurnRadius(speed, bankAngle);
 
-    return turnRadius * tan(courseChange / 2) + speed;
+    // limit tan to 45° (PI/4) to prevent huge distances for 180° turns. see #935
+    return turnRadius * tan(Math.min(courseChange / 2, Math.PI/4)) + speed;
 };
 
 /**
@@ -168,7 +169,7 @@ const _calculateCourseChangeInRadians = (currentHeading, nominalNewCourse) => {
  * @param aircraft {AircraftModel}
  * @param fix
  */
-export const calculateTurnInitiaionDistance = (aircraft, currentWaypointPosition) => {
+export const calculateTurnInitiationDistance = (aircraft, currentWaypointPosition) => {
     let currentHeading = aircraft.heading;
     const nominalBankAngleDegrees = 25;
     const speed = kn_ms(aircraft.speed);

--- a/src/assets/scripts/client/math/flightMath.js
+++ b/src/assets/scripts/client/math/flightMath.js
@@ -165,7 +165,7 @@ const _calculateCourseChangeInRadians = (currentHeading, nominalNewCourse) => {
  * - http://www.ohio.edu/people/uijtdeha/ee6900_fms_00_overview.pdf, Fly-by waypoint
  * - The Avionics Handbook, ch 15
  *
- * @function aircraft_turn_initiation_distance
+ * @function calculateTurnInitiationDistance
  * @param aircraft {AircraftModel}
  * @param fix
  */

--- a/test/math/flightMath.spec.js
+++ b/test/math/flightMath.spec.js
@@ -18,11 +18,31 @@ ava('calcTurnRadius() returns a turn radius based on speed and bank angle', t =>
     t.true(result === expectedResult);
 });
 
-ava('calcTurnRadius() returns a turn radius based on speed and bank angle', t => {
+ava('calcTurnInitiationDistance() returns a distance for a 80 degree course change', t => {
     const speed = 144.0444432;
     const bankAngle = 0.4363323129985824;
     const courseChange = 0.26420086153126987;
     const expectedResult = 746.732042830424;
+    const result = calcTurnInitiationDistance(speed, bankAngle, courseChange);
+
+    t.true(result === expectedResult);
+});
+
+ava('calcTurnInitiationDistance() returns a distance for a 90 degree course change', t => {
+    const speed = 144.0;
+    const bankAngle = 0.4363323129985824;
+    const courseChange = Math.PI*0.5;
+    const expectedResult = 4676.97609619635;
+    const result = calcTurnInitiationDistance(speed, bankAngle, courseChange);
+
+    t.true(result === expectedResult);
+});
+
+ava('calcTurnInitiationDistance() returns a distance for a 180 degree course change', t => {
+    const speed = 144.0;
+    const bankAngle = 0.4363323129985824;
+    const courseChange = Math.PI;
+    const expectedResult = 4676.97609619635;
     const result = calcTurnInitiationDistance(speed, bankAngle, courseChange);
 
     t.true(result === expectedResult);


### PR DESCRIPTION
Resolves #935.
Related: #1034  (PR #1038).

Hotfix: 
prevent `calcTurnInitiationDistance()` from creating huge distances for large turns (i.e 180 degree)

see openscope/openscope#1034 "Waypoint time-to-turn calculations are slightly off"
