### PR TITLE
bugfix/1045 - Arrivals ignoring altitude restrictions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ### Bugfixes
 - [#1147](https://github.com/openscope/openscope/issues/1147) - Fix Callsigns in tutorial should update when switching airports
-- [#1045](https://github.com/openscope/openscope/issues/1045) - Arrivals ignoring altitude restrictions
+- [#1045](https://github.com/openscope/openscope/issues/1045) - Fix descent planning logic so arrivals can meet their altitude restrictions
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Bugfixes
 - [#1147](https://github.com/openscope/openscope/issues/1147) - Fix Callsigns in tutorial should update when switching airports
+- [#1045](https://github.com/openscope/openscope/issues/1045) - Arrivals ignoring altitude restrictions
 
 
 

--- a/src/assets/scripts/client/aircraft/AircraftModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftModel.js
@@ -1969,31 +1969,34 @@ export default class AircraftModel {
                 return this.mcp.altitude;
             }
 
-            if (this.altitude < nextAltitudeMinimumWaypoint.altitudeMinimum) {
+            const altitudeMinimum = nextAltitudeMinimumWaypoint.altitudeMinimum;
+
+            if (this.altitude < altitudeMinimum) {
                 // ... but we are too low and we have to comply with VNAV restriction
                 return this._calculateTargetedAltitudeVnavClimb(nextAltitudeMinimumWaypoint);
             }
 
             if (maximumAltitudeExists) {
-                if (this.mcp.altitude > nextAltitudeMaximumWaypoint.altitudeMaximum) {
+                const altitudeMaximum = nextAltitudeMaximumWaypoint.altitudeMaximum;
+
+                if (this.mcp.altitude > altitudeMaximum) {
                     // we are too high but we are prioritizing clearance over VNAV restriction
                     return this.mcp.altitude;
                 }
 
-                if (this.altitude > nextAltitudeMaximumWaypoint.altitudeMaximum) {
+                if (this.altitude > altitudeMaximum) {
                     // we are too high...
-
-                    if (nextAltitudeMinimumWaypoint.altitudeMinimum > nextAltitudeMaximumWaypoint.altitudeMaximum) {
+                    if (altitudeMinimum > altitudeMaximum) {
                         // the minimum altitude is above the maximum altiude, check if we can descend all the way down
                         // without violating VNAV restrictions.
                         const firstWaypoint = this._findFirstWaypoint(this.fms.waypoints, nextAltitudeMinimumWaypoint, nextAltitudeMaximumWaypoint);
 
                         if (firstWaypoint.name === nextAltitudeMinimumWaypoint.name) {
                             // ... but we can not descend all the way down yet
-                            return nextAltitudeMinimumWaypoint.altitudeMinimum;
+                            // TODO: descend in-time
+                            return altitudeMinimum;
                         }
                     }
-
                     // ...so descend to comply with VNAV restriction
                     return this._calculateTargetedAltitudeVnavDescent(nextAltitudeMaximumWaypoint);
                 }
@@ -2005,34 +2008,39 @@ export default class AircraftModel {
                 return this.mcp.altitude;
             }
 
-            if (this.altitude > nextAltitudeMaximumWaypoint.altitudeMaximum) {
+            const altitudeMaximum = nextAltitudeMaximumWaypoint.altitudeMaximum;
+
+            if (this.altitude > altitudeMaximum) {
                 // .. but we are too high and have to comply with NAV restriction
                 return this._calculateTargetedAltitudeVnavDescent(nextAltitudeMaximumWaypoint);
             }
 
             if (minimumAltitudeExists) {
-                if (this.mcp.altitude < nextAltitudeMinimumWaypoint.altitudeMinimum) {
+                const altitudeMinimum = nextAltitudeMinimumWaypoint.altitudeMinimum;
+
+                if (this.mcp.altitude < altitudeMinimum) {
                     // we are too low but we are prioritizing clearance over VNAV restriction
                     return this.mcp.altitude;
                 }
 
-                if (this.altitude < nextAltitudeMinimumWaypoint.altitudeMinimum) {
+                if (this.altitude < altitudeMinimum) {
                     // we are too low ...
-                    if (nextAltitudeMaximumWaypoint.altitudeMaximum < nextAltitudeMinimumWaypoint.altitudeMinimum) {
+                    if (altitudeMaximum < altitudeMinimum) {
                         // the maximum altitude is below the minimal altiude, check if we can climb all the way up
                         // without violating VNAV restrictions.
                         const firstWaypoint = this._findFirstWaypoint(this.fms.waypoints, nextAltitudeMinimumWaypoint, nextAltitudeMaximumWaypoint);
 
                         if (firstWaypoint.name === nextAltitudeMaximumWaypoint.name) {
                             // ... but we can not climb all the way up yet
-                            return nextAltitudeMaximumWaypoint.altitudeMaximum;
+                            return altitudeMaximum;
                         }
                     }
-
                     // ... climb to comply with VNAV restriction
                     return this._calculateTargetedAltitudeVnavClimb(nextAltitudeMinimumWaypoint);
                 }
             }
+
+            return altitudeMaximum;
         }
     }
 
@@ -2049,7 +2057,7 @@ export default class AircraftModel {
     _findFirstWaypoint(waypoints, waypointA, waypointB) {
         const indexOfA = _findIndex(waypoints, (waypoint) => waypoint.name === waypointA.name);
         const indexOfB = _findIndex(waypoints, (waypoint) => waypoint.name === waypointB.name);
-        
+
         return indexOfA < indexOfB ? waypointA : waypointB;
     }
 

--- a/src/assets/scripts/client/aircraft/AircraftModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftModel.js
@@ -2063,7 +2063,7 @@ export default class AircraftModel {
      * @for AircraftModel
      * @method _calculateTargetedAltitudeVnavDescent
      * @param waypointModel {WaypointModel} the waypoint at which to comply with the restriction
-     * @param targetAltitude {number} the altitude to comnply with
+     * @param targetAltitude {number} the altitude to comply with
      * @return {number}
      */
     _calculateTargetedAltitudeVnavDescent(waypointModel, targetAltitude) {

--- a/src/assets/scripts/client/aircraft/AircraftModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftModel.js
@@ -1957,29 +1957,87 @@ export default class AircraftModel {
      * @return {number}
      */
     _calculateTargetedAltitudeVnav() {
-        const nextAltitudeMaximumWaypoint = this.fms.findNextWaypointWithMaximumAltitudeAtOrBelow(this.altitude);
-        const nextAltitudeMinimumWaypoint = this.fms.findNextWaypointWithMinimumAltitudeAtOrAbove(this.altitude);
+        const nextAltitudeMaximumWaypoint = this.fms.findNextWaypointWithMaximumAltitudeRestriction();
+        const nextAltitudeMinimumWaypoint = this.fms.findNextWaypointWithMinimumAltitudeRestriction();
         const maximumAltitudeExists = !_isNil(nextAltitudeMaximumWaypoint);
         const minimumAltitudeExists = !_isNil(nextAltitudeMinimumWaypoint);
 
-        if (!maximumAltitudeExists && !minimumAltitudeExists) {
-            return this.mcp.altitude;
+        if (this.mcp.altitude < this.altitude) {
+            // we want to descend...
+            if (!minimumAltitudeExists || nextAltitudeMinimumWaypoint.altitudeMinimum <= this.mcp.altitude) {
+                // ... and there is nothing that can stop us.
+                return this.mcp.altitude;
+            }
+
+            if (this.altitude < nextAltitudeMinimumWaypoint.altitudeMinimum) {
+                // ... but we are too low and we have to comply with VNAV restriction
+                return this._calculateTargetedAltitudeVnavClimb(nextAltitudeMinimumWaypoint);
+            }
+
+            if (maximumAltitudeExists) {
+                if (this.mcp.altitude > nextAltitudeMaximumWaypoint.altitudeMaximum) {
+                    // we are too high but we are prioritizing clearance over VNAV restriction
+                    return this.mcp.altitude;
+                }
+
+                if (this.altitude > nextAltitudeMaximumWaypoint.altitudeMaximum) {
+                    // we are too high...
+
+                    if (nextAltitudeMinimumWaypoint.altitudeMinimum > nextAltitudeMaximumWaypoint.altitudeMaximum) {
+                        // the minimum altitude is above the maximum altiude, check if we can descend all the way down
+                        // without violating VNAV restrictions.
+                        const waypoints = this.fms.waypoints;
+                        const indexOfMax = _findIndex(waypoints, (waypoint) => waypoint.name === nextAltitudeMaximumWaypoint.name);
+                        const indexOfMin = _findIndex(waypoints, (waypoint) => waypoint.name === nextAltitudeMinimumWaypoint.name);
+
+                        if (indexOfMin < indexOfMax) {
+                            // ... but we can not descend all the way down yet
+                            return nextAltitudeMinimumWaypoint.altitudeMinimum;
+                        }
+                    }
+
+                    // ...so descend to comply with VNAV restriction
+                    return this._calculateTargetedAltitudeVnavDescent(nextAltitudeMaximumWaypoint);
+                }
+            }
         }
+        else {
+            // we want to climb...
+            if (!maximumAltitudeExists || this.mcp.altitude <= nextAltitudeMaximumWaypoint.altitudeMaximum) {
+                // ... and there is nothing that can stop us.
+                return this.mcp.altitude;
+            }
 
-        if (maximumAltitudeExists && minimumAltitudeExists) {
-            const waypoints = this.fms.waypoints;
-            const indexOfMax = _findIndex(waypoints, (waypoint) => waypoint.name === nextAltitudeMaximumWaypoint.name);
-            const indexOfMin = _findIndex(waypoints, (waypoint) => waypoint.name === nextAltitudeMinimumWaypoint.name);
-
-            if (indexOfMax < indexOfMin) {
+            if (this.altitude > nextAltitudeMaximumWaypoint.altitudeMaximum) {
+                // .. but we are too high and have to comply with NAV restriction
                 return this._calculateTargetedAltitudeVnavDescent(nextAltitudeMaximumWaypoint);
             }
 
-            return this._calculateTargetedAltitudeVnavClimb(nextAltitudeMinimumWaypoint);
-        } else if (maximumAltitudeExists) {
-            return this._calculateTargetedAltitudeVnavDescent(nextAltitudeMaximumWaypoint);
-        } else if (minimumAltitudeExists) {
-            return this._calculateTargetedAltitudeVnavClimb(nextAltitudeMinimumWaypoint);
+            if (minimumAltitudeExists) {
+                if (this.mcp.altitude < nextAltitudeMinimumWaypoint.altitudeMinimum) {
+                    // we are too low but we are prioritizing clearance over VNAV restriction
+                    return this.mcp.altitude;
+                }
+
+                if (this.altitude < nextAltitudeMinimumWaypoint.altitudeMinimum) {
+                    // we are too low ...
+                    if (nextAltitudeMaximumWaypoint.altitudeMaximum < nextAltitudeMinimumWaypoint.altitudeMinimum) {
+                        // the maximum altitude is below the minimal altiude, check if we can climb all the way up
+                        // without violating VNAV restrictions.
+                        const waypoints = this.fms.waypoints;
+                        const indexOfMax = _findIndex(waypoints, (waypoint) => waypoint.name === nextAltitudeMaximumWaypoint.name);
+                        const indexOfMin = _findIndex(waypoints, (waypoint) => waypoint.name === nextAltitudeMinimumWaypoint.name);
+
+                        if (indexOfMax < indexOfMin) {
+                            // ... but we can not climb all the way up yet
+                            return nextAltitudeMaximumWaypoint.altitudeMaximum;
+                        }
+                    }
+
+                    // ... climb to comply with VNAV restriction
+                    return this._calculateTargetedAltitudeVnavClimb(nextAltitudeMinimumWaypoint);
+                }
+            }
         }
     }
 
@@ -1994,7 +2052,7 @@ export default class AircraftModel {
     _calculateTargetedAltitudeVnavClimb(waypointWithMinimumAltitudeRestriction) {
         const waypointMinimumAltitude = waypointWithMinimumAltitudeRestriction.altitudeMinimum;
 
-        return Math.min(waypointMinimumAltitude, this.mcp.altitude);
+        return waypointMinimumAltitude;
     }
 
     /**
@@ -2011,7 +2069,7 @@ export default class AircraftModel {
             return;
         }
 
-        return Math.min(waypointMaximumAltitude, this.mcp.altitude);
+        return waypointMaximumAltitude;
     }
 
     /**

--- a/src/assets/scripts/client/aircraft/AircraftModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftModel.js
@@ -1986,11 +1986,9 @@ export default class AircraftModel {
                     if (nextAltitudeMinimumWaypoint.altitudeMinimum > nextAltitudeMaximumWaypoint.altitudeMaximum) {
                         // the minimum altitude is above the maximum altiude, check if we can descend all the way down
                         // without violating VNAV restrictions.
-                        const waypoints = this.fms.waypoints;
-                        const indexOfMax = _findIndex(waypoints, (waypoint) => waypoint.name === nextAltitudeMaximumWaypoint.name);
-                        const indexOfMin = _findIndex(waypoints, (waypoint) => waypoint.name === nextAltitudeMinimumWaypoint.name);
+                        const firstWaypoint = this._findFirstWaypoint(this.fms.waypoints, nextAltitudeMinimumWaypoint, nextAltitudeMaximumWaypoint);
 
-                        if (indexOfMin < indexOfMax) {
+                        if (firstWaypoint.name === nextAltitudeMinimumWaypoint.name) {
                             // ... but we can not descend all the way down yet
                             return nextAltitudeMinimumWaypoint.altitudeMinimum;
                         }
@@ -2024,11 +2022,9 @@ export default class AircraftModel {
                     if (nextAltitudeMaximumWaypoint.altitudeMaximum < nextAltitudeMinimumWaypoint.altitudeMinimum) {
                         // the maximum altitude is below the minimal altiude, check if we can climb all the way up
                         // without violating VNAV restrictions.
-                        const waypoints = this.fms.waypoints;
-                        const indexOfMax = _findIndex(waypoints, (waypoint) => waypoint.name === nextAltitudeMaximumWaypoint.name);
-                        const indexOfMin = _findIndex(waypoints, (waypoint) => waypoint.name === nextAltitudeMinimumWaypoint.name);
+                        const firstWaypoint = this._findFirstWaypoint(this.fms.waypoints, nextAltitudeMinimumWaypoint, nextAltitudeMaximumWaypoint);
 
-                        if (indexOfMax < indexOfMin) {
+                        if (firstWaypoint.name === nextAltitudeMaximumWaypoint.name) {
                             // ... but we can not climb all the way up yet
                             return nextAltitudeMaximumWaypoint.altitudeMaximum;
                         }
@@ -2039,6 +2035,22 @@ export default class AircraftModel {
                 }
             }
         }
+    }
+
+    /**
+     * Takes two waypoints and returns the waypoint that comes first in the list of waypoints
+     *
+     * @for AircraftModel
+     * @method _findFirstWaypoint
+     * @param waypoints
+     * @param waypointA {WaypointModel}
+     * @param waypointB {WaypointModel}
+     * @return waypointA or waypointB {WaypointModel}
+     */
+    _findFirstWaypoint(waypoints, waypointA, waypointB) {
+        const indexOfA = _findIndex(waypoints, (waypoint) => waypoint.name === waypointA.name);
+        const indexOfB = _findIndex(waypoints, (waypoint) => waypoint.name === waypointB.name);
+        return indexOfA < indexOfB ? waypointA : waypointB;
     }
 
     /**

--- a/src/assets/scripts/client/aircraft/AircraftModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftModel.js
@@ -1998,8 +1998,7 @@ export default class AircraftModel {
                     return this._calculateTargetedAltitudeVnavDescent(nextAltitudeMaximumWaypoint);
                 }
             }
-        }
-        else {
+        } else {
             // we want to climb...
             if (!maximumAltitudeExists || this.mcp.altitude <= nextAltitudeMaximumWaypoint.altitudeMaximum) {
                 // ... and there is nothing that can stop us.
@@ -2050,6 +2049,7 @@ export default class AircraftModel {
     _findFirstWaypoint(waypoints, waypointA, waypointB) {
         const indexOfA = _findIndex(waypoints, (waypoint) => waypoint.name === waypointA.name);
         const indexOfB = _findIndex(waypoints, (waypoint) => waypoint.name === waypointB.name);
+        
         return indexOfA < indexOfB ? waypointA : waypointB;
     }
 

--- a/src/assets/scripts/client/aircraft/AircraftModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftModel.js
@@ -1829,9 +1829,9 @@ export default class AircraftModel {
         if (shouldMoveToNextFix) {
             if (!this.fms.hasNextWaypoint()) {
                 // we've hit this block because and aircraft is about to fly over the last waypoint in its flightPlan
-                this.pilot.maintainPresentHeading(headingToWaypoint);
+                this.pilot.maintainPresentHeading(this);
 
-                return headingToWaypoint;
+                return this.heading;
             }
 
             this.fms.moveToNextWaypoint();

--- a/src/assets/scripts/client/aircraft/FlightManagementSystem/Fms.js
+++ b/src/assets/scripts/client/aircraft/FlightManagementSystem/Fms.js
@@ -501,6 +501,17 @@ export default class Fms {
     }
 
     /**
+     * Return the next waypoint having an #altitudeMaximum restriction
+     *
+     * @for Fms
+     * @method findNextWaypointWithMaximumAltitudeRestriction
+     * @return {WaypointModel}
+     */
+    findNextWaypointWithMaximumAltitudeRestriction() {
+        return _find(this.waypoints, (waypointModel) => waypointModel.hasAltiudeMaximumRestriction);
+    }
+
+    /**
      * Return the next waypoint having a #speedMaximum equal to or less than the specified value
      *
      * This is helpful to see only future waypoints for which a particular speed is
@@ -530,6 +541,18 @@ export default class Fms {
      */
     findNextWaypointWithMinimumAltitudeAtOrAbove(altitude) {
         return _find(this.waypoints, (waypointModel) => waypointModel.hasMinimumAltitudeAtOrAbove(altitude));
+    }
+
+
+    /**
+     * Return the next waypoint having an #altitudeMinimum restriction
+     *
+     * @for Fms
+     * @method findNextWaypointWithMinimumAltitudeRestriction
+     * @return {WaypointModel}
+     */
+    findNextWaypointWithMinimumAltitudeRestriction(){
+        return _find(this.waypoints, (waypointModel) => waypointModel.hasAltiudeMinimumRestriction);
     }
 
     /**

--- a/test/aircraft/AircraftModel.spec.js
+++ b/test/aircraft/AircraftModel.spec.js
@@ -31,6 +31,20 @@ let sandbox; // using the sinon sandbox ensures stubs are restored after each te
 const runwayNameMock = '19L';
 const runwayModelMock = airportModelFixture.getRunway(runwayNameMock);
 
+function moveAircraftToFix(aircraft, fixName) {
+    const fms = aircraft.fms;
+
+    while (fms.currentWaypoint._name !== fixName) {
+        if (!fms.hasNextWaypoint()) {
+            throw Error(`Can not find waypoint ${fixName}`);
+        }
+
+        fms.moveToNextWaypoint();
+    }
+
+    aircraft.positionModel = NavigationLibrary.findFixByName(fixName).positionModel;
+}
+
 /* eslint-disable no-unused-vars, no-undef */
 ava.beforeEach(() => {
     createNavigationLibraryFixture();
@@ -413,7 +427,7 @@ ava('.updateTarget() causes arrivals to comply with AT altitude restriction', (t
     const model = new AircraftModel(ARRIVAL_AIRCRAFT_INIT_PROPS_WITH_SOFT_ALTITUDE_RESTRICTIONS_MOCK);
     model.groundSpeed = 320;
 
-    moveAircraftToFix(model, "KSINO");
+    moveAircraftToFix(model, 'KSINO');
     model.updateTarget();
 
     t.true(model.target.altitude === 17000);
@@ -423,7 +437,7 @@ ava('.updateTarget() causes arrivals to comply with ABOVE altitude restriction',
     const model = new AircraftModel(ARRIVAL_AIRCRAFT_INIT_PROPS_WITH_SOFT_ALTITUDE_RESTRICTIONS_MOCK);
     model.groundSpeed = 320;
 
-    moveAircraftToFix(model, "LUXOR");
+    moveAircraftToFix(model, 'LUXOR');
     model.updateTarget();
 
     t.true(model.target.altitude >= 12000);
@@ -433,7 +447,7 @@ ava('.updateTarget() causes arrivals to comply with BELOW altitude restriction',
     const model = new AircraftModel(ARRIVAL_AIRCRAFT_INIT_PROPS_WITH_SOFT_ALTITUDE_RESTRICTIONS_MOCK);
     model.groundSpeed = 320;
 
-    moveAircraftToFix(model, "GRNPA");
+    moveAircraftToFix(model, 'GRNPA');
     model.updateTarget();
 
     t.true(model.target.altitude <= 11000);
@@ -444,7 +458,7 @@ ava('.updateTarget() causes departures to comply with AT altitude restriction', 
     model.speed = 320;
     model.altitude = 3000;
 
-    moveAircraftToFix(model, "ROPPR");
+    moveAircraftToFix(model, 'ROPPR');
     model.mcp.enable();
     model.pilot.climbViaSid(model, 31000);
     model.updateTarget();
@@ -457,7 +471,7 @@ ava('.updateTarget() causes departures to comply with ABOVE altitude restriction
     model.speed = 320;
     model.altitude = 3000;
 
-    moveAircraftToFix(model, "CEASR");
+    moveAircraftToFix(model, 'CEASR');
     model.mcp.enable();
     model.pilot.climbViaSid(model, 31000);
     model.updateTarget();
@@ -471,29 +485,13 @@ ava('.updateTarget() causes departures to comply with BELOW altitude restriction
     model.speed = 320;
     model.altitude = 3000;
 
-    moveAircraftToFix(model, "WILLW");
+    moveAircraftToFix(model, 'WILLW');
     model.mcp.enable();
     model.pilot.climbViaSid(model, 31000);
     model.updateTarget();
 
     t.true(model.target.altitude <= 14000);
 });
-
-function moveAircraftToFix(aircraft, fixName) {
-    const fms = aircraft.fms;
-
-    while (fms.currentWaypoint._name !== fixName) {
-        if (!fms.hasNextWaypoint()) {
-            throw Error(`Can not find waypoint ${fixName}`);
-        }
-
-        fms.moveToNextWaypoint();
-    }
-
-    aircraft.positionModel = NavigationLibrary.findFixByName(fixName).positionModel;
-}
-
-
 
 ava('.taxiToRunway() returns an error when the aircraft is airborne', (t) => {
     const expectedResult = [false, 'unable to taxi, we\'re airborne'];

--- a/test/aircraft/AircraftModel.spec.js
+++ b/test/aircraft/AircraftModel.spec.js
@@ -517,7 +517,7 @@ ava('.updateTarget() causes departures to climb to cruise altitude if there is n
     t.true(model.target.altitude === 31000);
 });
 
-ava('.updateTarget() causes arrivals to descend to the assigned altitude if the minimal restriction is above the assigned altitude', (t) => {
+ava('.updateTarget() causes arrivals to descend to the assigned altitude if the minimal altitude restriction is above the assigned altitude', (t) => {
     const model = new AircraftModel(ARRIVAL_AIRCRAFT_INIT_PROPS_WITH_SOFT_ALTITUDE_RESTRICTIONS_MOCK);
     model.groundSpeed = 320;
 
@@ -528,7 +528,7 @@ ava('.updateTarget() causes arrivals to descend to the assigned altitude if the 
     t.true(model.target.altitude === 5000);
 });
 
-ava('.updateTarget() causes departures to climb to cruise altitude if the maximum restriction is below the cruise altitude', (t) => {
+ava('.updateTarget() causes departures to climb to cruise altitude if the maximum altitude restriction is below the cruise altitude', (t) => {
     const model = new AircraftModel(DEPARTURE_AIRCRAFT_INIT_PROPS_WITH_SOFT_ALTITUDE_RESTRICTIONS_MOCK);
     model.speed = 320;
     model.altitude = 3000;
@@ -541,10 +541,55 @@ ava('.updateTarget() causes departures to climb to cruise altitude if the maximu
     t.true(model.target.altitude === 31000);
 });
 
-// TODO: climb on descend
-// TODO: descend on climb
-// TODO: prioritizing clearance over restriction (arrival)
-// TODO: prioritizing clearance over restriction (departure)
+ava('.updateTarget() causes arrivals to climb to comply with minimal altitude restriction', (t) => {
+    const model = new AircraftModel(ARRIVAL_AIRCRAFT_INIT_PROPS_WITH_SOFT_ALTITUDE_RESTRICTIONS_MOCK);
+    model.groundSpeed = 320;
+    model.altitude = 7000;
+
+    moveAircraftToFix(model, 'LUXOR');
+    model.pilot.descendViaStar(model, 5000);
+    model.updateTarget();
+
+    t.true(model.target.altitude === 12000);
+});
+
+ava('.updateTarget() causes departures to descend to comply with maximum altitude restriction', (t) => {
+    const model = new AircraftModel(DEPARTURE_AIRCRAFT_INIT_PROPS_WITH_SOFT_ALTITUDE_RESTRICTIONS_MOCK);
+    model.speed = 320;
+    model.groundSpeed = 320;
+    model.altitude = 15000;
+
+    moveAircraftToFix(model, 'WILLW');
+    model.mcp.enable();
+    model.pilot.climbViaSid(model, 31000);
+    model.updateTarget();
+
+    t.true(model.target.altitude === 14000);
+});
+
+ava('.updateTarget() causes arrivals to prioritize clearance over restriction', (t) => {
+    const model = new AircraftModel(ARRIVAL_AIRCRAFT_INIT_PROPS_WITH_SOFT_ALTITUDE_RESTRICTIONS_MOCK);
+    model.groundSpeed = 320;
+
+    moveAircraftToFix(model, 'GRNPA');
+    model.pilot.descendViaStar(model, 15000);
+    model.updateTarget();
+
+    t.true(model.target.altitude === 15000);
+});
+
+ava('.updateTarget() causes departures to prioritize clearance over restriction', (t) => {
+    const model = new AircraftModel(DEPARTURE_AIRCRAFT_INIT_PROPS_WITH_SOFT_ALTITUDE_RESTRICTIONS_MOCK);
+    model.speed = 320;
+    model.altitude = 3000;
+
+    moveAircraftToFix(model, 'CEASR');
+    model.mcp.enable();
+    model.pilot.climbViaSid(model, 7000);
+    model.updateTarget();
+
+    t.true(model.target.altitude === 7000);
+});
 
 ava('.taxiToRunway() returns an error when the aircraft is airborne', (t) => {
     const expectedResult = [false, 'unable to taxi, we\'re airborne'];

--- a/test/aircraft/AircraftModel.spec.js
+++ b/test/aircraft/AircraftModel.spec.js
@@ -493,6 +493,59 @@ ava('.updateTarget() causes departures to comply with BELOW altitude restriction
     t.true(model.target.altitude <= 14000);
 });
 
+ava('.updateTarget() causes arrivals to descend to the assigned altitude if there is no restriction', (t) => {
+    const model = new AircraftModel(ARRIVAL_AIRCRAFT_INIT_PROPS_WITH_SOFT_ALTITUDE_RESTRICTIONS_MOCK);
+    model.groundSpeed = 320;
+
+    moveAircraftToFix(model, 'LEMNZ');
+    model.pilot.descendViaStar(model, 5000);
+    model.updateTarget();
+
+    t.true(model.target.altitude === 5000);
+});
+
+ava('.updateTarget() causes departures to climb to cruise altitude if there is no restriction', (t) => {
+    const model = new AircraftModel(DEPARTURE_AIRCRAFT_INIT_PROPS_WITH_SOFT_ALTITUDE_RESTRICTIONS_MOCK);
+    model.speed = 320;
+    model.altitude = 3000;
+
+    moveAircraftToFix(model, 'TRALR');
+    model.mcp.enable();
+    model.pilot.climbViaSid(model, 31000);
+    model.updateTarget();
+
+    t.true(model.target.altitude === 31000);
+});
+
+ava('.updateTarget() causes arrivals to descend to the assigned altitude if the minimal restriction is above the assigned altitude', (t) => {
+    const model = new AircraftModel(ARRIVAL_AIRCRAFT_INIT_PROPS_WITH_SOFT_ALTITUDE_RESTRICTIONS_MOCK);
+    model.groundSpeed = 320;
+
+    moveAircraftToFix(model, 'TRROP');
+    model.pilot.descendViaStar(model, 5000);
+    model.updateTarget();
+
+    t.true(model.target.altitude === 5000);
+});
+
+ava('.updateTarget() causes departures to climb to cruise altitude if the maximum restriction is below the cruise altitude', (t) => {
+    const model = new AircraftModel(DEPARTURE_AIRCRAFT_INIT_PROPS_WITH_SOFT_ALTITUDE_RESTRICTIONS_MOCK);
+    model.speed = 320;
+    model.altitude = 3000;
+
+    moveAircraftToFix(model, 'BIKKR');
+    model.mcp.enable();
+    model.pilot.climbViaSid(model, 31000);
+    model.updateTarget();
+
+    t.true(model.target.altitude === 31000);
+});
+
+// TODO: climb on descend
+// TODO: descend on climb
+// TODO: prioritizing clearance over restriction (arrival)
+// TODO: prioritizing clearance over restriction (departure)
+
 ava('.taxiToRunway() returns an error when the aircraft is airborne', (t) => {
     const expectedResult = [false, 'unable to taxi, we\'re airborne'];
     const arrival = new AircraftModel(ARRIVAL_AIRCRAFT_INIT_PROPS_MOCK);

--- a/test/aircraft/_mocks/aircraftMocks.js
+++ b/test/aircraft/_mocks/aircraftMocks.js
@@ -113,6 +113,14 @@ export const DEPARTURE_AIRCRAFT_INIT_PROPS_MOCK = {
 
 export const DEPARTURE_AIRCRAFT_MODEL_MOCK = new AircraftModel(DEPARTURE_AIRCRAFT_INIT_PROPS_MOCK, navigationLibraryFixture);
 
+export const DEPARTURE_AIRCRAFT_INIT_PROPS_WITH_SOFT_ALTITUDE_RESTRICTIONS_MOCK = Object.assign(
+    {},
+    DEPARTURE_AIRCRAFT_INIT_PROPS_MOCK,
+    {
+        routeString: 'KLAS25R.TRALR6.MLF'
+    }
+);
+
 export const ARRIVAL_AIRCRAFT_INIT_PROPS_MOCK = {
     transponderCode: 3377,
     callsign: '432',

--- a/test/airport/_mocks/airportJsonMock.js
+++ b/test/airport/_mocks/airportJsonMock.js
@@ -281,6 +281,7 @@ export const AIRPORT_JSON_KLAS_MOCK = {
                 ["KENNO", "OAL*"]
             ]
         },
+        // Not a real route, used to test soft altitude restrictions
         "TRALR6": {
             "icao": "TRALR6",
             "name": "Trailer Six",
@@ -292,7 +293,7 @@ export const AIRPORT_JSON_KLAS_MOCK = {
                 "KLAS19L": ["FIXIX", ["ROPPR", "A70"], ["CEASR", "A80+"], "FORGE", ["WILLW", "A140+"]],
                 "KLAS19R": ["JAKER", ["ROPPR", "A70"], ["CEASR", "A80+"], "FORGE", ["WILLW", "A140+"]],
                 "KLAS25L": ["PIRMD", ["ROPPR", "A70"], ["CEASR", "A80+"], "FORGE", ["WILLW", "A140+"]],
-                "KLAS25R": ["RBELL", ["ROPPR", "A70"], ["CEASR", "A80+"], "FORGE", ["WILLW", "A140+"]]
+                "KLAS25R": ["RBELL", ["ROPPR", "A70"], ["CEASR", "A80+"], "FORGE", ["WILLW", "A140-"]]
             },
             "body": ["TRALR"],
             "exitPoints": {
@@ -341,7 +342,7 @@ export const AIRPORT_JSON_KLAS_MOCK = {
                 "DVC":   ["DVC", "BETHL", ["HOLDM", "A270+"]],
                 "MLF":   ["MLF"]
             },
-            "body": [["KSINO", "A170+"], ["LUXOR", "A120+|S250"], ["GRNPA", "A110+"], ["DUBLX", "A90+"], ["FRAWG", "A70+|S210"], "TRROP", "LEMNZ"],
+            "body": [["KSINO", "A170"], ["LUXOR", "A120+|S250"], ["GRNPA", "A110-"], ["DUBLX", "A90+"], ["FRAWG", "A70+|S210"], "TRROP", "LEMNZ"],
             "rwy": {
                 "KLAS01L": [],
                 "KLAS01R": [],

--- a/test/airport/_mocks/airportJsonMock.js
+++ b/test/airport/_mocks/airportJsonMock.js
@@ -293,7 +293,7 @@ export const AIRPORT_JSON_KLAS_MOCK = {
                 "KLAS19L": ["FIXIX", ["ROPPR", "A70"], ["CEASR", "A80+"], "FORGE", ["WILLW", "A140+"]],
                 "KLAS19R": ["JAKER", ["ROPPR", "A70"], ["CEASR", "A80+"], "FORGE", ["WILLW", "A140+"]],
                 "KLAS25L": ["PIRMD", ["ROPPR", "A70"], ["CEASR", "A80+"], "FORGE", ["WILLW", "A140+"]],
-                "KLAS25R": ["RBELL", ["ROPPR", "A70"], ["CEASR", "A80+"], "FORGE", ["WILLW", "A140-"]]
+                "KLAS25R": ["RBELL", ["ROPPR", "A70"], ["CEASR", "A80+"], "FORGE", ["WILLW", "A140-"], ["BIKKR", "A400-"], "TRALR"]
             },
             "body": ["TRALR"],
             "exitPoints": {
@@ -342,7 +342,7 @@ export const AIRPORT_JSON_KLAS_MOCK = {
                 "DVC":   ["DVC", "BETHL", ["HOLDM", "A270+"]],
                 "MLF":   ["MLF"]
             },
-            "body": [["KSINO", "A170"], ["LUXOR", "A120+|S250"], ["GRNPA", "A110-"], ["DUBLX", "A90+"], ["FRAWG", "A70+|S210"], "TRROP", "LEMNZ"],
+            "body": [["KSINO", "A170"], ["LUXOR", "A120+|S250"], ["GRNPA", "A110-"], ["DUBLX", "A90+"], ["FRAWG", "A70+|S210"], ["TRROP", "A30+"], "LEMNZ"],
             "rwy": {
                 "KLAS01L": [],
                 "KLAS01R": [],

--- a/test/airport/_mocks/airportJsonMock.js
+++ b/test/airport/_mocks/airportJsonMock.js
@@ -290,9 +290,9 @@ export const AIRPORT_JSON_KLAS_MOCK = {
                 "KLAS01R": ["_NAPSE068", "NAPSE", "TINNK", ["RIOOS", "A130+"]],
                 "KLAS07L": ["WASTE", ["BAKRR", "A70"]],
                 "KLAS07R": ["JESJI", ["BAKRR", "A70"]],
-                "KLAS19L": ["FIXIX", ["ROPPR", "A70"], ["CEASR", "A80+"], "FORGE", ["WILLW", "A140+"]],
-                "KLAS19R": ["JAKER", ["ROPPR", "A70"], ["CEASR", "A80+"], "FORGE", ["WILLW", "A140+"]],
-                "KLAS25L": ["PIRMD", ["ROPPR", "A70"], ["CEASR", "A80+"], "FORGE", ["WILLW", "A140+"]],
+                "KLAS19L": ["FIXIX", ["ROPPR", "A70"], ["CEASR", "A80+"], "FORGE", ["WILLW", "A140-"]],
+                "KLAS19R": ["JAKER", ["ROPPR", "A70"], ["CEASR", "A80+"], "FORGE", ["WILLW", "A140-"]],
+                "KLAS25L": ["PIRMD", ["ROPPR", "A70"], ["CEASR", "A80+"], "FORGE", ["WILLW", "A140-"]],
                 "KLAS25R": ["RBELL", ["ROPPR", "A70"], ["CEASR", "A80+"], "FORGE", ["WILLW", "A140-"], ["BIKKR", "A400-"], "TRALR"]
             },
             "body": ["TRALR"],


### PR DESCRIPTION
Resolves #1045

I tried to come up with a simple solution for openscope/openscope#1045 and ended up completely rewriting `_calculateTargetedAltitudeVnav()`

Now, before I start writing tests, i was hoping that someone could provide some feedback ;-)
@n8rzz  @erikquinn 

There are basically two issues that i am trying to solve here:

1. Aircrafts should not descend to `mcp.altitude` until VNAV minimumal altitude allows it.
2. Some aircrafts are spawned below VNAV minimal altitude. For example aircrafts are spawned at 18,000ft at KBOS and send on a route with VNAV minimal altitude at 21,000ft. Now there is nothing wrong with this (=takeoff from a nearby airport still climbing) but the current implementation ends up sending aircrafts down to 5,000ft (`mcp.altitude`) instead of climbing them to 21,000ft.
