### PR TITLE
bugfix/836 - fix hold in STAR procedure isn't working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [#993](https://github.com/openscope/openscope/issues/993) - fix Arrivals exiting and reentering airspace causes error about missing strip
  - [#724](https://github.com/openscope/openscope/issues/724) - fix settings modal doesn't add active class to control icon
  - [#421](https://github.com/openscope/openscope/issues/421) - Add missing keys to spawnPatternModelJsonValidator
+ - [#836](https://github.com/openscope/openscope/issues/836) - Fix "hold in STAR procedure isn't working"
 
 
 

--- a/src/assets/scripts/client/aircraft/AircraftModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftModel.js
@@ -1791,7 +1791,8 @@ export default class AircraftModel {
         const currentWaypoint = this.fms.currentWaypoint;
         const holdParameters = currentWaypoint.holdParameters;
         const waypointRelativePosition = currentWaypoint.relativePosition;
-        const outboundHeading = radians_normalize(holdParameters.inboundHeading + Math.PI);
+        const inboundHeading = holdParameters.inboundHeading || 0;
+        const outboundHeading = radians_normalize(inboundHeading + Math.PI);
         const offset = getOffset(this, waypointRelativePosition, holdParameters.inboundHeading);
         const holdLegDurationInMinutes = holdParameters.legLength.replace('min', '');
         const holdLegDurationInSeconds = holdLegDurationInMinutes * TIME.ONE_MINUTE_IN_SECONDS;
@@ -1806,9 +1807,8 @@ export default class AircraftModel {
         }
 
         if (!this._isEstablishedOnHoldingPattern) {
-            this.target.heading = bearingToHoldFix;
 
-            return;
+            return bearingToHoldFix;
         }
 
         let nextTargetHeading = outboundHeading;

--- a/src/assets/scripts/client/aircraft/AircraftModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftModel.js
@@ -1813,7 +1813,6 @@ export default class AircraftModel {
         }
 
         if (!this._isEstablishedOnHoldingPattern) {
-
             return bearingToHoldFix;
         }
 

--- a/src/assets/scripts/client/aircraft/AircraftModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftModel.js
@@ -1791,12 +1791,18 @@ export default class AircraftModel {
         const currentWaypoint = this.fms.currentWaypoint;
         const holdParameters = currentWaypoint.holdParameters;
         const waypointRelativePosition = currentWaypoint.relativePosition;
-        const inboundHeading = holdParameters.inboundHeading || 0;
+        const bearingToHoldFix = vradial(vsub(waypointRelativePosition, this.relativePosition));
+
+        if (typeof holdParameters.inboundHeading === 'undefined') {
+            // store the current heading as inbound heading, see #836
+            holdParameters.inboundHeading = bearingToHoldFix;
+        }
+
+        const inboundHeading = holdParameters.inboundHeading;
         const outboundHeading = radians_normalize(inboundHeading + Math.PI);
-        const offset = getOffset(this, waypointRelativePosition, holdParameters.inboundHeading);
+        const offset = getOffset(this, waypointRelativePosition, inboundHeading);
         const holdLegDurationInMinutes = holdParameters.legLength.replace('min', '');
         const holdLegDurationInSeconds = holdLegDurationInMinutes * TIME.ONE_MINUTE_IN_SECONDS;
-        const bearingToHoldFix = vradial(vsub(waypointRelativePosition, this.relativePosition));
         const gameTime = TimeKeeper.accumulatedDeltaTime;
         const isPastFix = offset[1] < 1 && offset[2] < 2;
         const isTimerSet = holdParameters.timer !== INVALID_NUMBER;


### PR DESCRIPTION
Resolves openscope/openscope#836 

Setting a default value for `inboundHeading` to prevent NaN. 

Update: I think the bearing to the fix is a better default value and follows the same logic as in `runHold()`
