### PR TITLE
bugfix/724 - fix settings modal doesn't add active class to control icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#1044](https://github.com/openscope/openscope/issues/1044) - fix aircrafts drift off ILS localizer during final approach causing "strange behaviour after landing"
 - [#1047](https://github.com/openscope/openscope/issues/1047) - fix "Flight number 5000 pronounced incorrectly"
 - [#993](https://github.com/openscope/openscope/issues/993) - fix Arrivals exiting and reentering airspace causes error about missing strip
+ - [#724](https://github.com/openscope/openscope/issues/724) - fix settings modal doesn't add active class to control icon
 
 
 

--- a/src/assets/scripts/client/UiController.js
+++ b/src/assets/scripts/client/UiController.js
@@ -616,16 +616,11 @@ class UiController {
      * @for UiController
      * @method onToggleOptions
      */
-    onToggleOptions() {
-        const $optionsDialog = $(SELECTORS.DOM_SELECTORS.OPTIONS_DIALOG);
+    onToggleOptions(event) {
+        $(event.target).closest(SELECTORS.DOM_SELECTORS.CONTROL).toggleClass(SELECTORS.CLASSNAMES.ACTIVE);
 
-        if ($optionsDialog.hasClass(SELECTORS.CLASSNAMES.OPEN)) {
-            $optionsDialog.removeClass(SELECTORS.CLASSNAMES.OPEN);
-            $optionsDialog.removeClass(SELECTORS.CLASSNAMES.ACTIVE);
-        } else {
-            $optionsDialog.addClass(SELECTORS.CLASSNAMES.OPEN);
-            $optionsDialog.addClass(SELECTORS.CLASSNAMES.ACTIVE);
-        }
+        const $optionsDialog = $(SELECTORS.DOM_SELECTORS.OPTIONS_DIALOG);
+        $optionsDialog.toggleClass(SELECTORS.CLASSNAMES.OPEN);
     }
 }
 

--- a/src/assets/scripts/client/UiController.js
+++ b/src/assets/scripts/client/UiController.js
@@ -77,8 +77,6 @@ class UiController {
         this.$airportDialog = this.$element.find(SELECTORS.DOM_SELECTORS.AIRPORT_SWITCH);
         this.$tutorialDialog = this.$element.find(SELECTORS.DOM_SELECTORS.TOGGLE_TUTORIAL);
         this.$fastForwards = this.$element.find(SELECTORS.DOM_SELECTORS.FAST_FORWARDS);
-        // TODO: Make the options dialog findable by ID, not just by class
-        this.$optionsDialog = this.$element.find(SELECTORS.DOM_SELECTORS.OPTIONS_DIALOG);
         this.$pauseToggle = this.$element.find(SELECTORS.DOM_SELECTORS.PAUSE_TOGGLE);
         this.$pausedImg = this.$element.find(`${SELECTORS.DOM_SELECTORS.PAUSED} img`);
         this.$speechToggle = this.$element.find(SELECTORS.DOM_SELECTORS.SPEECH_TOGGLE);
@@ -202,6 +200,9 @@ class UiController {
         });
 
         $('body').append($options);
+
+        // TODO: Make the options dialog findable by ID, not just by class
+        this.$optionsDialog = this.$element.find(SELECTORS.DOM_SELECTORS.OPTIONS_DIALOG);
     }
 
     /**
@@ -616,11 +617,9 @@ class UiController {
      * @for UiController
      * @method onToggleOptions
      */
-    onToggleOptions(event) {
-        $(event.target).closest(SELECTORS.DOM_SELECTORS.CONTROL).toggleClass(SELECTORS.CLASSNAMES.ACTIVE);
-
-        const $optionsDialog = $(SELECTORS.DOM_SELECTORS.OPTIONS_DIALOG);
-        $optionsDialog.toggleClass(SELECTORS.CLASSNAMES.OPEN);
+    onToggleOptions() {
+        this.$toggleOptions.toggleClass(SELECTORS.CLASSNAMES.ACTIVE);
+        this.$optionsDialog.toggleClass(SELECTORS.CLASSNAMES.OPEN);
     }
 }
 


### PR DESCRIPTION
Ensure settings menu button turns blue when open and closes with ESC.

Resolves openscope/openscope#724

- added active class to settings button
- close settings dialog when ESC is pressed