### PR TITLE
bugfix/421 - added 'variation' to spawnPatternModelJsonValidator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [#1047](https://github.com/openscope/openscope/issues/1047) - fix "Flight number 5000 pronounced incorrectly"
 - [#993](https://github.com/openscope/openscope/issues/993) - fix Arrivals exiting and reentering airspace causes error about missing strip
  - [#724](https://github.com/openscope/openscope/issues/724) - fix settings modal doesn't add active class to control icon
+ - [#421](https://github.com/openscope/openscope/issues/421) - Add missing keys to spawnPatternModelJsonValidator
 
 
 

--- a/src/assets/scripts/client/trafficGenerator/spawnPatternModelJsonValidator.js
+++ b/src/assets/scripts/client/trafficGenerator/spawnPatternModelJsonValidator.js
@@ -17,7 +17,8 @@ const ACCEPTED_KEYS = [
 
 const ACCEPTED_OPTIONAL_KEYS = [
     'offset',
-    'period'
+    'period',
+    'variation'
 ];
 
 const ALL_KEYS = [


### PR DESCRIPTION
Add `variation` as a valid spawn pattern key to prevent incorrect errors.

Resolves #421.