### PR TITLE
documentation/1074

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 6.6.0 (October 1, 2018)
 ### New Features
 - [#989](https://github.com/openscope/openscope/issues/989) - Add in Austin Bergstrom International Airport
+- [#1074](https://github.com/openscope/openscope/issues/1074) - Update link to "aircraft separation rules" in scoring.md
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # 6.6.0 (October 1, 2018)
 ### New Features
 - [#989](https://github.com/openscope/openscope/issues/989) - Add in Austin Bergstrom International Airport
-- [#1074](https://github.com/openscope/openscope/issues/1074) - Update link to "aircraft separation rules" in scoring.md
 
 
 
@@ -15,6 +14,9 @@
 
 ### Enhancements & Refactors
 - [1077](https://github.com/openscope/openscope/issues/1077) - Update flight strips view by separating arrival and departure strips
+- [#1074](https://github.com/openscope/openscope/issues/1074) - Update link to "aircraft separation rules" in scoring.md
+
+
 
 
 

--- a/documentation/scoring.md
+++ b/documentation/scoring.md
@@ -1,7 +1,4 @@
----
-title: Scoring
----
-[back to index](index.html)
+
 
 # Scoring
 
@@ -41,7 +38,7 @@ most common warning is when two aircraft are separated by less 3
 nautical miles or less than 1000 feet of altitude.  However there are
 a number of situations where aircraft can be separated by less, for
 complete details refer to the
-[aircraft separation rules](aircraft-separation.html)
+[aircraft separation rules](aircraft-separation.md)
 
 ## Collisions
 50 points are lost whenever two aircraft collide (within 50 or so feet


### PR DESCRIPTION
Resolves openscope/openscope#1074

Corrects link to aircraft separation rules in Scoring.md
