### PR TITLE
bugfix/1086 - P28A climb rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 
 ### Bugfixes
-
+- [#1086](https://github.com/openscope/openscope/issues/1086) - Update P28A Climb rate fm 2000ft/m to 700ft/m
 
 
 

--- a/assets/aircraft/p28a.json
+++ b/assets/aircraft/p28a.json
@@ -13,7 +13,7 @@
     },
     "ceiling": 14000,
     "rate": {
-        "climb":      2000,
+        "climb":      700,
         "descent":    1000,
         "accelerate": 4,
         "decelerate": 3


### PR DESCRIPTION
Resolves #1086.
Replaces external PR #1082.

Set P28A climb rate to 700fpm instead of 2000fpm.

All work by @danielepancottini.
