### PR TITLE
bugfix/1104 - Fix flight strip console warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Bugfixes
 - [#1099](https://github.com/openscope/openscope/issues/1099) - Fix wrong B747 entry in Turkish Airlines file
+- [#1104](https://github.com/openscope/openscope/issues/1104) - Fix console warnings for removing StripViewModel which doesn't exist
 
 
 

--- a/src/assets/scripts/client/aircraft/AircraftController.js
+++ b/src/assets/scripts/client/aircraft/AircraftController.js
@@ -321,8 +321,6 @@ export default class AircraftController {
         for (let i = 0; i < this.aircraft.list.length; i++) {
             this.aircraft_remove(this.aircraft.list[i]);
         }
-
-        this.aircraft.list = [];
     }
 
     /**

--- a/src/assets/scripts/client/aircraft/AircraftController.js
+++ b/src/assets/scripts/client/aircraft/AircraftController.js
@@ -319,7 +319,11 @@ export default class AircraftController {
      */
     aircraft_remove_all() {
         for (let i = 0; i < this.aircraft.list.length; i++) {
-            this.removeStripView(this.aircraft.list[i]);
+            const aircraft = this.aircraft.list[i];
+
+            if (aircraft.isControllable) {
+                this.removeStripView(aircraft);
+            }
         }
 
         this.aircraft.list = [];

--- a/src/assets/scripts/client/aircraft/AircraftController.js
+++ b/src/assets/scripts/client/aircraft/AircraftController.js
@@ -319,11 +319,7 @@ export default class AircraftController {
      */
     aircraft_remove_all() {
         for (let i = 0; i < this.aircraft.list.length; i++) {
-            const aircraft = this.aircraft.list[i];
-
-            if (aircraft.isControllable) {
-                this.removeStripView(aircraft);
-            }
+            this.aircraft_remove(this.aircraft.list[i]);
         }
 
         this.aircraft.list = [];
@@ -344,7 +340,7 @@ export default class AircraftController {
         if (aircraftModel.isControllable) {
             this.removeStripView(aircraftModel);
         }
-        
+
         this._scopeModel.radarTargetCollection.removeRadarTargetModelForAircraftModel(aircraftModel);
     }
 

--- a/src/assets/scripts/client/aircraft/AircraftController.js
+++ b/src/assets/scripts/client/aircraft/AircraftController.js
@@ -340,7 +340,11 @@ export default class AircraftController {
         this.removeAircraftModelFromList(aircraftModel);
         this._removeTransponderCodeFromUse(aircraftModel);
         this.removeAllAircraftConflictsForAircraft(aircraftModel);
-        this.removeStripView(aircraftModel);
+
+        if (aircraftModel.isControllable) {
+            this.removeStripView(aircraftModel);
+        }
+        
         this._scopeModel.radarTargetCollection.removeRadarTargetModelForAircraftModel(aircraftModel);
     }
 

--- a/src/assets/scripts/client/aircraft/StripView/StripViewController.js
+++ b/src/assets/scripts/client/aircraft/StripView/StripViewController.js
@@ -253,10 +253,13 @@ export default class StripViewController {
         const stripViewModel = this._collection.findStripByAircraftId(aircraftModel.id);
 
         if (!stripViewModel) {
-            console.warn(
-                `Attempted to remove a StripViewModel for ${aircraftModel.callsign} that does not exist.` +
-                'This is likely not a fatal problem, but if you are seeing this, please let somebody know.'
-            );
+
+            if (aircraftModel.isControllable) {
+                console.warn(
+                    `Attempted to remove a StripViewModel for ${aircraftModel.callsign} that does not exist.` +
+                    'This is likely not a fatal problem, but if you are seeing this, please let somebody know.'
+                );
+            }
 
             return;
         }

--- a/src/assets/scripts/client/aircraft/StripView/StripViewController.js
+++ b/src/assets/scripts/client/aircraft/StripView/StripViewController.js
@@ -253,13 +253,10 @@ export default class StripViewController {
         const stripViewModel = this._collection.findStripByAircraftId(aircraftModel.id);
 
         if (!stripViewModel) {
-
-            if (aircraftModel.isControllable) {
-                console.warn(
-                    `Attempted to remove a StripViewModel for ${aircraftModel.callsign} that does not exist.` +
-                    'This is likely not a fatal problem, but if you are seeing this, please let somebody know.'
-                );
-            }
+            console.warn(
+                `Attempted to remove a StripViewModel for ${aircraftModel.callsign} that does not exist.` +
+                'This is likely not a fatal problem, but if you are seeing this, please let somebody know.'
+            );
 
             return;
         }


### PR DESCRIPTION
Resolves #1104.

Fix console warnings for removing `StripViewModel` which doesn't exist.