### PR TITLE
documentation/1115 - Fix broken documentation links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [#1001](https://github.com/openscope/openscope/issues/1001) - Remove support for work-in-progress airports
 - [#1179](https://github.com/openscope/openscope/issues/1179) - Extract settings related code from UiController into its own controller
 - [#1171](https://github.com/openscope/openscope/issues/1171) - Move tutorial from InputController to UiController
+- [#1114](https://github.com/openscope/openscope/issues/1114), [#1115](https://github.com/openscope/openscope/issues/1115) - Update broken documentation links
 
 
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ We do not use forks. Instead, we add to add all contributors to the openScope or
 
 We use the [GitFlow Branching Model](http://nvie.com/posts/a-successful-git-branching-model) for managing branches.  If you would like to contribute, you will be expected to use appropriate branch names based on this methodology (and we can help if you have questions).
 
-Don't know Javascript?  That's cool, we're always looking for beta testers and/or airport contributors.  If you would like to add a new airport, or help update existing airports, please read the [Airport Documentation](https://github.com/openscope/openscope/wiki/Airport.json) to get up to speed on what is expected in that file.
+Don't know Javascript?  That's cool, we're always looking for beta testers and/or airport contributors.  If you would like to add a new airport, or help update existing airports, please read the [Airport Format Documentation](documentation/airport-format.md) and [Airport File Standards Documentation](documentation/airport-file-standards.md) to get up to speed on what is expected in that file.
 
 
 ## License

--- a/documentation/aircraft-format.md
+++ b/documentation/aircraft-format.md
@@ -1,59 +1,55 @@
----
-title: Aircraft Format Wiki
----
-[back to index](index.html)
-
-[!image](http://puu.sh/o6oee/00a63d977a.png)
-
-Link for useful aircraft performance data: https://doc8643.com/index
+# Aircraft Format
+Links for useful aircraft performance data:
+- https://contentzone.eurocontrol.int/aircraftperformance/default.aspx
+- https://doc8643.com/index
 
 ## Example Aircraft File
-
-{
-  "name": "Boeing 747-400",   - Official name of the aircraft²
-  "icao": "B744",             - ICAO identifier of the aircraft¹²
-  "engines": {
-    "number": 4,              - Number of Engines¹²
-    "type": "J"               - Engines type¹² - [J = Jet / T = TurboProp / P = Piston]
-  },
-  "weightclass": "H",   - wake turbulence category¹²
-  "category": {
-    "srs": 3,           - Same Runway Separation Category¹
-    "lahso": 10,        - LAHSO (land-and-hold-short) Category¹
-    "recat": "B"        - Wake Turb Recategorization Category³
-  },
-  "ceiling": 45000,     - Service Ceiling²
-  "rate": {
-    "climb":      2000, - Climb Rate² (DON'T use 7110.65, its values are VERY inaccurate)
-    "descent":    3000, - Descent Rate² (DON'T use 7110.65, its values are VERY inaccurate)
-    "accelerate": 4,    - Accelerate Rate (your best estimate, btwn ~1-5)
-    "decelerate": 2     - Decelerate Rate (your best estimate, btwn ~1-5)
-  },
-  "runway": {
-    "takeoff": 3.352,   - Takeoff Distance Required² (km)
-    "landing": 2.072    - Landing Distance Required² (km)
-  },
-  "speed":{
-    "min":     135,   - Stall Speed² (minimum speed)
-    "landing": 150,   - Landing speed² (at threshold)
-    "cruise":  492    - Typical cruise speed², knots (a/c will fly at slower of these speeds)
-    "cruiseM": 0.81,  - Typical cruise speed², mach  (a/c will fly at slower of these speeds) if unavailable, put null
-    "max":     507,   - Never-Exceed speed² (Vne), knots. Fastest possible speed before structural damage.
-    "maxM":    0.83   - Maximum Speed², mach. If unavailable, put null
-  },
-  "capability": {
-    "ils": true,      - T/F: whether aircraft has ILS equipment
-    "fix": true       - T/F: whether aircraft has VOR or GPS equipment
-  }
-}
-
+```javascript
+{  
+    "name": "Boeing 747-400",   - Official name of the aircraft²  
+    "icao": "B744",             - ICAO identifier of the aircraft¹²  
+    "engines": {  
+        "number": 4,              - Number of Engines¹²  
+        "type": "J"               - Engines type¹² - [J = Jet / T = TurboProp / P = Piston]  
+    },  
+    "weightclass": "H",   - wake turbulence category¹²  
+    "category": {  
+        "srs": 3,           - Same Runway Separation Category¹  
+        "lahso": 10,        - LAHSO (land-and-hold-short) Category¹  
+        "recat": "B"        - Wake Turb Recategorization Category³  
+    },  
+    "ceiling": 45000,     - Service Ceiling²  
+    "rate": {  
+        "climb":      2000, - Climb Rate² (DONT use FAA JO 7110.65, its values are VERY inaccurate)  
+        "descent":    3000, - Descent Rate² (DONT use FAA JO 7110.65, its values are VERY inaccurate)  
+        "accelerate": 4,    - Accelerate Rate (your best estimate, btwn ~1-5)  
+        "decelerate": 2     - Decelerate Rate (your best estimate, btwn ~1-5)  
+    },  
+    "runway": {  
+        "takeoff": 3.352,   - Takeoff Distance Required² (km)  
+        "landing": 2.072    - Landing Distance Required² (km)  
+    },  
+    "speed":{  
+        "min":     135,   - Stall Speed² (minimum speed)  
+        "landing": 150,   - Landing speed² (at threshold)  
+        "cruise":  492    - Typical cruise speed², knots (a/c will fly at slower of these speeds)  
+        "cruiseM": 0.81,  - Typical cruise speed², mach  (a/c will fly at slower of these speeds) if unavailable, put null  
+        "max":     507,   - Never-Exceed speed² (Vne), knots. Fastest possible speed before structural damage.  
+        "maxM":    0.83   - Maximum Speed², mach. If unavailable, put null  
+    },  
+    "capability": {  
+        "ils": true,      - T/F: whether aircraft has ILS equipment  
+        "fix": true       - T/F: whether aircraft has VOR or GPS equipment  
+    }  
+}  
+```
 
 
 ## Notes
 
-¹ Available in FAA JO 7110.65V, Appendix A (http://www.faa.gov/documentLibrary/media/Order/7110.65V.pdf)
-² May be available from Wikipedia, or https://doc8643.com/index , or other internet sources
-³ See FAA JO 7110.659B (http://www.faa.gov/documentLibrary/media/Order/Final_Wake_Recat_Order.pdf)
-  and look up aircraft's MTOW (Max Certified Gross Takeoff Weight) and wingspan. Compare those
-  values to the ranges listed in FAA JO 7110.659B, "Aircraft Wake Categories" section within the
-  document's "Pilot/Controller Glossary". Can be Category A, B, C, D, E, or F.
+¹ Available in FAA JO 7110.65V, Appendix A   (http://www.faa.gov/documentLibrary/media/Order/7110.65V.pdf)  
+² Available at https://contentzone.eurocontrol.int/aircraftperformance/default.aspx  
+or https://doc8643.com/index or Wikipedia  
+³ See FAA JO 7110.659B
+(http://www.faa.gov/documentLibrary/media/Order/Final_Wake_Recat_Order.pdf)  
+and look up aircraft's MTOW (Max Certified Gross Takeoff Weight) and wingspan. Compare those values to the ranges listed in FAA JO 7110.659B, "Aircraft Wake Categories" section within the document's "Pilot/Controller Glossary". Can be Category A, B, C, D, E, or F.  

--- a/documentation/aircraft-format.md
+++ b/documentation/aircraft-format.md
@@ -1,45 +1,42 @@
 # Aircraft Format
-Links for useful aircraft performance data:
-- https://contentzone.eurocontrol.int/aircraftperformance/default.aspx
-- https://doc8643.com/index
 
 ## Example Aircraft File
 ```javascript
 {  
-    "name": "Boeing 747-400",   - Official name of the aircraft²  
-    "icao": "B744",             - ICAO identifier of the aircraft¹²  
+    "name": "Boeing 747-400",   - Official name of the aircraft¹  
+    "icao": "B744",             - ICAO identifier of the aircraft¹  
     "engines": {  
-        "number": 4,              - Number of Engines¹²  
-        "type": "J"               - Engines type¹² - [J = Jet / T = TurboProp / P = Piston]  
+        "number": 4,            - Number of Engines¹   
+        "type": "J"             - Engines type¹ - [J = Jet / T = TurboProp / P = Piston]  
     },  
-    "weightclass": "H",   - wake turbulence category¹²  
+    "weightclass": "H",         - wake turbulence category¹  
     "category": {  
-        "srs": 3,           - Same Runway Separation Category¹  
-        "lahso": 10,        - LAHSO (land-and-hold-short) Category¹  
-        "recat": "B"        - Wake Turb Recategorization Category³  
+        "srs": 3,               - Same Runway Separation Category²  
+        "lahso": 10,            - LAHSO (land-and-hold-short) Category²  
+        "recat": "B"            - Wake Turb Recategorization Category²    
     },  
-    "ceiling": 45000,     - Service Ceiling²  
+    "ceiling": 45000,           - Service Ceiling³  
     "rate": {  
-        "climb":      2000, - Climb Rate² (DONT use FAA JO 7110.65, its values are VERY inaccurate)  
-        "descent":    3000, - Descent Rate² (DONT use FAA JO 7110.65, its values are VERY inaccurate)  
-        "accelerate": 4,    - Accelerate Rate (your best estimate, btwn ~1-5)  
-        "decelerate": 2     - Decelerate Rate (your best estimate, btwn ~1-5)  
+        "climb":      1500,     - Climb Rate³  
+        "descent":    3000,     - Descent Rate³   
+        "accelerate": 4,        - Accelerate Rate (your best estimate, btwn ~1-5)  
+        "decelerate": 2         - Decelerate Rate (your best estimate, btwn ~1-5)  
     },  
     "runway": {  
-        "takeoff": 3.352,   - Takeoff Distance Required² (km)  
-        "landing": 2.072    - Landing Distance Required² (km)  
+        "takeoff": 3.300,       - Takeoff Distance Required³ (km)  
+        "landing": 2.130        - Landing Distance Required³ (km)  
     },  
     "speed":{  
-        "min":     135,   - Stall Speed² (minimum speed)  
-        "landing": 150,   - Landing speed² (at threshold)  
-        "cruise":  492    - Typical cruise speed², knots (a/c will fly at slower of these speeds)  
-        "cruiseM": 0.81,  - Typical cruise speed², mach  (a/c will fly at slower of these speeds) if unavailable, put null  
-        "max":     507,   - Never-Exceed speed² (Vne), knots. Fastest possible speed before structural damage.  
-        "maxM":    0.83   - Maximum Speed², mach. If unavailable, put null  
+        "min":     135,         - Stall speed³ (minimum speed)  
+        "landing": 150,         - Landing speed³ (at threshold)  
+        "cruise":  492          - Typical cruise speed³, knots (a/c will fly at slower of these speeds)  
+        "cruiseM": 0.81,        - Typical cruise speed³, mach  (a/c will fly at slower of these speeds) if unavailable, put null  
+        "max":     507,         - Maximum Operating Limit Speed⁴ (Vmo, knots)  
+        "maxM":    0.83         - Maximum Operating Limit Mach⁴ (Mmo, knots)  
     },  
     "capability": {  
-        "ils": true,      - T/F: whether aircraft has ILS equipment  
-        "fix": true       - T/F: whether aircraft has VOR or GPS equipment  
+        "ils": true,            - T/F: whether aircraft has ILS equipment  
+        "fix": true             - T/F: whether aircraft has VOR or GPS equipment  
     }  
 }  
 ```
@@ -47,9 +44,10 @@ Links for useful aircraft performance data:
 
 ## Notes
 
-¹ Available in FAA JO 7110.65V, Appendix A   (http://www.faa.gov/documentLibrary/media/Order/7110.65V.pdf)  
-² Available at https://contentzone.eurocontrol.int/aircraftperformance/default.aspx  
-or https://doc8643.com/index or Wikipedia  
-³ See FAA JO 7110.659B
-(http://www.faa.gov/documentLibrary/media/Order/Final_Wake_Recat_Order.pdf)  
-and look up aircraft's MTOW (Max Certified Gross Takeoff Weight) and wingspan. Compare those values to the ranges listed in FAA JO 7110.659B, "Aircraft Wake Categories" section within the document's "Pilot/Controller Glossary". Can be Category A, B, C, D, E, or F.  
+Recommended sources:      
+¹ https://www.icao.int/publications/DOC8643/Pages/Search.aspx   
+² https://www.faa.gov/documentLibrary/media/Order/2017-03-07_FAA_Order_JO_7360.1B_Aircraft_Type_Designators.pdf   
+³ https://contentzone.eurocontrol.int/aircraftperformance/default.aspx    
+⁴ https://www.easa.europa.eu/document-library/type-certificates or    
+http://www1.airweb.faa.gov/Regulatory_and_Guidance_Library/rgMakeModel.nsf/MainFrame?OpenFrameSet   
+(Try to find the correct .pdf file and search for "VMO" or "MMO")    

--- a/documentation/aircraft-separation.md
+++ b/documentation/aircraft-separation.md
@@ -1,8 +1,3 @@
----
-title: Aircraft Separation rules
----
-[back to index](index.html)
-
 # Aircraft separation
 
 ## General Separation
@@ -42,16 +37,16 @@ on adjacent final approach courses. Aircraft are considered to be fully
 approach course. At this point, the lower lateral separation requirements
 will be applied, allowing the aircraft to go under 3nm separation, all the
 way down to the appropriate value (depends on distance between runway
-centerlines):
+centerlines):  
 
-  Reduced Separation on Adjacent Final Approach Courses
-  See FAA JO 7110.65, para. 5-9-6
-  +-----------------------+---------------------+
-  | Dist btwn ctrln (ft)  |  Separation Minima  |
-  +-----------------------+---------------------+
-  |    < 2,500'           |  Standard Sep (3nm) |
-  |    2,500' --> 3,600'  |  1.0 nautical mile  |
-  |    3,601' --> 4,300'  |  1.5 nautical miles |
-  |    4,301' --> 9,000'  |  2.0 nautical miles |
-  |             > 9,000'  |  Standard Sep (3nm) |
-  +-----------------------+---------------------+
+  Reduced Separation on Adjacent Final Approach Courses  
+  See FAA JO 7110.65, para. 5-9-6  
+
+
+  | Dist btwn ctrln (ft) | Separation Minima  |   
+  |:--------------------:|:------------------:|   
+  | < 2,500'             | Standard Sep (3nm) |   
+  | 2,500' --> 3,600'    | 1.0 nautical mile  |   
+  | 3,601' --> 4,300'    | 1.5 nautical miles |   
+  | 4,301' --> 9,000'    | 2.0 nautical miles |
+  | > 9,000'             | Standard Sep (3nm) |

--- a/documentation/airline-format.md
+++ b/documentation/airline-format.md
@@ -1,41 +1,59 @@
----
-title: Airline Format
----
-[back to index](index.html)
-
-## Airline format
+# Airline format
 
 Airlines specify a name, radio call sign, flight number generation
 parameters and one or more fleets of aircraft.
 
-###  Example
+##  Example
 
-This specifies the airline Air Canada with a default fleet and a
-long haul fleet.
+This specifies the airline Air Canada with a default fleet, a
+long haul and a short haul fleet.
 
-```
+```json
 {
-  "icao": "ACA",
-  "name": "Air Canada",
-  "callsign": {
+    "icao": "aca",
     "name": "Air Canada",
-    "length": 3,
-    "alpha": false
-  },
-  "fleets": {
-    "default": [      // this MUST NOT BE EMPTY, or game will crash
-      ["A319", 5],
-      ["A320", 1]
-    ],
-    "long": [
-      ["B763", 5],
-      ["B772", 1]
-    ]
-  }
+    "callsign": {
+        "name": "Air Canada",
+        "callsignFormats": [
+            "####",
+            "###",
+            "##"
+        ]
+    },
+    "fleets": {
+        "default": [
+            ["A319", 18],
+            ["A320", 42],
+            ["A321", 15],
+            ["A333", 8],
+            ["B38M", 15],
+            ["B763", 8],
+            ["B77L", 6],
+            ["B77W", 19],
+            ["B788", 8],
+            ["B789", 27],
+            ["E190", 25]
+        ],
+        "long": [
+            ["A333", 8],
+            ["B763", 8],
+            ["B77L", 6],
+            ["B77W", 19],
+            ["B788", 8],
+            ["B789", 27]
+        ],
+        "short": [
+            ["A319", 18],
+            ["A320", 42],
+            ["A321", 15],
+            ["B38M", 15],
+            ["E190", 25]
+        ]
+    }
 }
 ```
 
-### Fleets
+## Fleets
 
 Fleets are used to select from a subset of aircraft which could fly
 under a given operator's name.  They were introduced to handle airports
@@ -55,25 +73,25 @@ An easy weighting to use is the simple count of aircraft in the
 operator's fleet.
 
 Example:
-```
+```javascript
 ...
-"fleets": {
-  "default": [
-    ["A319", 20],
-    ["A320", 40],
-    ["A388", 5]
-  ],
-  "long": [
-    ["A388", 5]
-  ]
-}
+    "fleets": {
+        "default": [
+            ["A319", 20],
+            ["A320", 40],
+            ["A388", 5]
+        ],
+        "long": [
+            ["A388", 5]
+        ]
+    }
 ```
 
 The above specifies a default fleet where an A320 is twice as likely
 to appear as a A319 and eight times as likely as an A388.  A long
 haul fleet is specified which will always spawn an A388.
 
-### Other options
+## Other options
 
 #### Name
 
@@ -83,20 +101,28 @@ Example: `"name": "American Airlines"`
 
 #### Callsign
 
-Specifies the radio identifier and length of the flight number.  If
-alpha is specified and true the last two characters in the flight
-number will be letters.
+Specifies the radio identifier and the composition of the alphanumerical callsign.
 
 Example:
-```
+```javascript
+"icao": "baw",
+...
 "callsign": {
-  "name": "Speedbird",
-  "length": 3
+    "name": "Speedbird",
+    "callsignFormats": [
+        "####",
+        "###@",
+        "#@@",
+        ...
+    ]
+...
 }
 ```
 
-Generates flight numbers like 123 or 838.  Will refer to the aircraft
-as "Speedbird 123" over the radio.
+With each `#` indicating a random number and each `@` indicating a random letter.  
+- `####` will give give you a callsign with 4 random numbers: `BAW3845` `BAW6544` `BAW1028`
+- `###@` will give give you a callsign with 3 random numbers and one random letter at the end: `BAW384H` `BAW654X` `BAW102M`
+- `#@@` will give give you a callsign with 1 random number and two random letters at the end: `BAW3AH` `BAW6YX` `BAW1WM`
 
 #### ICAO (optional)
 

--- a/documentation/airport-file-standards.md
+++ b/documentation/airport-file-standards.md
@@ -1,6 +1,4 @@
-# Airport File Standards generateFlightNumberWithAirlineModel
-
----
+# Airport File Standards
 
 ## Overview
 This document serves as a checklist for airport contributors to review to ensure their airport file is "up to snuff". There are two levels of airports: `Standard` and `Premium`, the latter designator being used only for our most pristine, complete, realistic, and well-documented airports. In order for a new airport to be merged, it must at least meet all the `Standard` specifications listed in the section below. If it does not meet these requirements, it will require extra work before being merged. It will often require a team of people to complete work on an airport, because of the wide variety of tasks to complete.

--- a/documentation/airport-format.md
+++ b/documentation/airport-format.md
@@ -1,5 +1,3 @@
-[noaa-calculator]: https://www.ngdc.noaa.gov/geomag-web/#declination
-
 # Airport Format
 
 * [Property Descriptions](#property-descriptions)
@@ -17,11 +15,11 @@
   * [Identifiers](#icao-and-iata-identifiers)
   * [Flight Level](#flight-level)
 
-The airport JSON file must be in "[assets/airports](assets/airports)"; the filename should be `icao.json` where `icao` is the lowercase four-letter ICAO airport identifier, such as `ksfo` or `kmsp`.  If this is a new airport, an entry must also be added to [airportLoadList.js](../src.assets/scripts/airport/airportLoadList.js) in alphabetical order. See the comments at the top of that file for information on the correct structure to use.
+The airport JSON file must be in "[assets/airports](https://github.com/openscope/openscope/tree/develop/assets/airports)"; the filename should be `icao.json` where `icao` is the lowercase four-letter ICAO airport identifier, such as `ksfo` or `kmsp`.  If this is a new airport, an entry must also be added to [airportLoadList.js](https://github.com/openscope/openscope/blob/develop/assets/airports/airportLoadList.js) in alphabetical order. See the comments at the top of that file for information on the correct structure to use.
 
 ## Example
 
-_Note: The code block shown below is an abbreviated version of [ksea.json](assets/airports/ksea.json)._
+_Note: The code block shown below is an abbreviated version of [ksea.json](https://github.com/openscope/openscope/blob/develop/assets/airports/ksea.json)._
 
 ```javascript
 {
@@ -237,14 +235,14 @@ _all properties in this section are required_
 
 * **icao** ― ICAO identifier of the airport. _see [ICAO identifiers](#icao-and-iata-identifiers) for more information_
 * **iata** ― IATA identifier of the airport. _see [IATA identifiers](#icao-and-iata-identifiers) for more information_
-* **magnetic_north** ― The magnetic declination (variation) of the airport.  Declination is the angular difference between true north and magnetic north (in degrees **EAST**!) _see this [NOAA calculator][noaa-calculator] if you can't find this value_
+* **magnetic_north** ― The magnetic declination (variation) of the airport.  Declination is the angular difference between true north and magnetic north (in degrees **EAST**!) _see this [NOAA calculator](https://www.ngdc.noaa.gov/geomag-web/#declination) if you can't find this value_
 * **ctr_radius** ― The radius (in kilometers) of the controlled airspace that aircraft are simulated within. Outside of this radius aircraft are removed, so ensure it is large enough for your airspace.
 * **ctr_ceiling** ― The ceiling/top of the airspace (in feet). When an `airspace` property is present, that value will take priority over this one.
 * **initial_alt** ― The altitude (in feet) at which all departing aircraft are expected to stop their climb after takeoff unless otherwise instructed.
 * **position** ― The geographical position of the airport. (in latitude, longitude, and elevation: _see [lat, lon, elev](#latitude-longitude-elevation) for formatting_)
 * **rr_radius_nm** ― The distance between each range ring (in nautical miles) within the airspace.
 * **rr_center** ― The position at which the range rings are centered. (in latitude, longitude: _see [lat, lon, elev](#latitude-longitude-elevation) for formatting_)
-* **has_terrain** ― Flag used to determine if the airport has a corresponding `.geoJSON` file in [assets/airports/terrain](../..assets/airports/terrain).
+* **has_terrain** ― Flag used to determine if the airport has a corresponding `.geoJSON` file in [assets/airports/terrain](https://github.com/openscope/openscope/tree/develop/assets/airports/terrain).
 * **wind** ― The true heading (angle) in degrees and speed in knots of the current wind at the airport:
 
 ```javascript
@@ -648,7 +646,7 @@ _At least one `spawnPattern` is required to get aircraft populating into the app
 
 Contains the parameters used to determine how and where aircraft are spawned into the simulation.  At least one `spawnPattern` is required so that aircraft can be added to the simulation.
 
-_see [spawnPatternReadme.md](documentation/spawnPatternReadme.md) for more detailed descriptions on data shape and format of a spawnPattern_
+_see [spawnPatternReadme.md](spawnPatternReadme.md) for more detailed descriptions on data shape and format of a spawnPattern_
 
 ### Maps
 

--- a/documentation/development-processes-checklists.md
+++ b/documentation/development-processes-checklists.md
@@ -1,3 +1,4 @@
+#Development Processes Checklists
 ## Processes of Each Sprint
 **Note**: In order to complete all of the steps below a user will need:
 - to be a member of the `openscope-admins` team within the openScope team on GitHub

--- a/documentation/git-flow-process.md
+++ b/documentation/git-flow-process.md
@@ -1,4 +1,4 @@
-## Naming Convention
+# Naming Convention
 Each issue and corresponding pull request will be placed in one of the following categories:
 - `feature`: addition of a _completely new feature_
 - `enhancement`: notable _improvement or expansion upon an existing feature_
@@ -26,7 +26,7 @@ Resolves #321.
 Short description of the purpose of these changes
 ```
 
-## Git Flow Process
+# Git Flow Process
 
 The post linked below has a thorough explanation of a very effective git branching strategy. Though slightly modified, our branching strategy and conventions are based heavily on this write-up.
 

--- a/documentation/spawnPatternMethodReadme.md
+++ b/documentation/spawnPatternMethodReadme.md
@@ -1,3 +1,4 @@
+#Spawnpattern methods
 At the very least, an arrival stream MUST have definitions for the
 following parameters. Additional may be required if the spawn method
 is set to one other than 'random'.
@@ -66,7 +67,7 @@ increase to ('frequency' + 'variation'), then steadily decrease to
 ```
 
 
-# Wave
+### Wave
 
 The wave algorithm works exactly like the cyclic algorithm, however,
 instead of a linear shift between arrival rates, the arrival rate will

--- a/documentation/spawnPatternMethodReadme.md
+++ b/documentation/spawnPatternMethodReadme.md
@@ -1,4 +1,4 @@
-#Spawnpattern methods
+# Spawnpattern methods  
 At the very least, an arrival stream MUST have definitions for the
 following parameters. Additional may be required if the spawn method
 is set to one other than 'random'.

--- a/documentation/spawnPatternMethodReadme.md
+++ b/documentation/spawnPatternMethodReadme.md
@@ -1,4 +1,4 @@
-# Spawnpattern methods  
+# spawnPattern methods  
 At the very least, an arrival stream MUST have definitions for the
 following parameters. Additional may be required if the spawn method
 is set to one other than 'random'.

--- a/documentation/spawnPatternReadme.md
+++ b/documentation/spawnPatternReadme.md
@@ -1,4 +1,4 @@
-## Spawn Patterns
+# Spawn Patterns
 In version 3.3.0 we completely changed how aircraft coming into the system are defined.  We introduced ***Spawn Patterns***.  Spawn Patterns provide a simple, consistent way to describe aircraft coming into the system.  Spawn Patterns are used for _both_ arrivals and departures.  The shape of the data is exactly the same for both, all keys are expected to be passed all the time.  
 
 Lets look at some examples before we continue:
@@ -99,7 +99,7 @@ Defines the method used to calculate delay between aircraft spawns.
 
 * Should always be one of: `cyclic, random, surge, wave`
 
-*See [spawnPatternMethodReadme.md](documentation/spawnPatternMethodReadme.md) for more information*
+*See [spawnPatternMethodReadme.md](spawnPatternMethodReadme.md) for more information*
 
 #### rate*
 Rate at which aircraft spawn expressed in ACPH (aircraft per hour). This should be a _number_ (eg. `15`), _not a string_ (eg `"15"`).


### PR DESCRIPTION
Resolves openscope/openscope#1115
Resolves openscope/openscope#1165
_(Resolves openscope/openscope#1114)_

The purpose of this pull request is to fix broken documentation links that occurred after moving the github wiki to the in-repo wiki and improve the listed sources for the aircraft documentation
