### PR TITLE
bugfix/1103 - Fix pressing ESC doesn't fully clear the command bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Bugfixes
 - [#1099](https://github.com/openscope/openscope/issues/1099) - Fix wrong B747 entry in Turkish Airlines file
 - [#1104](https://github.com/openscope/openscope/issues/1104) - Fix console warnings for removing StripViewModel which doesn't exist
+- [#1103](https://github.com/openscope/openscope/issues/1103) - Fix pressing ESC doesn't fully clear the command bar
 
 
 

--- a/src/assets/scripts/client/InputController.js
+++ b/src/assets/scripts/client/InputController.js
@@ -450,9 +450,9 @@ export default class InputController {
             case KEY_CODES.ESCAPE: {
                 this.closeAllDialogs();
 
-                const hasCallsign = !_includes(currentCommandInputValue, this.input.callsign);
+                const hasCallsign = _includes(currentCommandInputValue, this.input.callsign);
                 const hasOnlyCallsign = currentCommandInputValue.trim() === this.input.callsign;
-                const hasSelectedCallsign = this.input.callsign === '';
+                const hasSelectedCallsign = this.input.callsign !== '';
 
                 if (!hasCallsign || hasOnlyCallsign || !hasSelectedCallsign) {
                     this.deselectAircraft();

--- a/src/assets/scripts/client/InputController.js
+++ b/src/assets/scripts/client/InputController.js
@@ -450,10 +450,11 @@ export default class InputController {
             case KEY_CODES.ESCAPE: {
                 this.closeAllDialogs();
 
-                if (!_includes(currentCommandInputValue, this.input.callsign) ||
-                    currentCommandInputValue.trim() === this.input.callsign ||
-                    this.input.callsign === ''
-                ) {
+                const noCallsign = !_includes(currentCommandInputValue, this.input.callsign);
+                const hasOnlyCallsign = currentCommandInputValue.trim() === this.input.callsign;
+                const noSelectedCallsign = this.input.callsign === "";
+
+                if (noCallsign || hasOnlyCallsign || noSelectedCallsign) {
                     this.deselectAircraft();
 
                     return;

--- a/src/assets/scripts/client/InputController.js
+++ b/src/assets/scripts/client/InputController.js
@@ -451,7 +451,8 @@ export default class InputController {
                 this.closeAllDialogs();
 
                 if (!_includes(currentCommandInputValue, this.input.callsign) ||
-                    currentCommandInputValue.trim() === this.input.callsign
+                    currentCommandInputValue.trim() === this.input.callsign ||
+                    this.input.callsign === ''
                 ) {
                     this.deselectAircraft();
 

--- a/src/assets/scripts/client/InputController.js
+++ b/src/assets/scripts/client/InputController.js
@@ -450,11 +450,11 @@ export default class InputController {
             case KEY_CODES.ESCAPE: {
                 this.closeAllDialogs();
 
-                const noCallsign = !_includes(currentCommandInputValue, this.input.callsign);
+                const hasCallsign = !_includes(currentCommandInputValue, this.input.callsign);
                 const hasOnlyCallsign = currentCommandInputValue.trim() === this.input.callsign;
-                const noSelectedCallsign = this.input.callsign === "";
+                const hasSelectedCallsign = this.input.callsign === '';
 
-                if (noCallsign || hasOnlyCallsign || noSelectedCallsign) {
+                if (!hasCallsign || hasOnlyCallsign || !hasSelectedCallsign) {
                     this.deselectAircraft();
 
                     return;


### PR DESCRIPTION
Resolves openscope/openscope#1103 

I add the condition to check if the input callsign is empty before fully clear the command bar.