### PR TITLE
refactor/1144 - moved calculateSpawnHeading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [#1112](https://github.com/openscope/openscope/issues/1112) - Cleanup of eslint errors and warnings
 - [#1138](https://github.com/openscope/openscope/issues/1138) - Remove contributors block from package.json
 - [#696](https://github.com/openscope/openscope/issues/696) - Default canvas theme no longer hardcoded in CanvasController
+- [#1144](https://github.com/openscope/openscope/issues/1144) - Move calculateSpawnHeading to SpawnPattenModel
 
 
 

--- a/src/assets/scripts/client/aircraft/FlightManagementSystem/RouteModel.js
+++ b/src/assets/scripts/client/aircraft/FlightManagementSystem/RouteModel.js
@@ -234,23 +234,6 @@ export default class RouteModel extends BaseModel {
     }
 
     /**
-     * Calculate the heading from the first waypoint to the second waypoint
-     *
-     * This is used to determine the heading of newly spawned aircraft
-     *
-     * @for RouteModel
-     * @method calculateSpawnHeading
-     * @return {number} heading, in radians
-     */
-    calculateSpawnHeading() {
-        const firstWaypointPositionModel = this.waypoints[0].positionModel;
-        const secondWaypointPositionModel = this.waypoints[1].positionModel;
-        const heading = firstWaypointPositionModel.bearingToPosition(secondWaypointPositionModel);
-
-        return heading;
-    }
-
-    /**
     * Return an array of waypoints in the flight plan that have altitude restrictions
     *
     * @for RouteModel

--- a/src/assets/scripts/client/trafficGenerator/SpawnPatternModel.js
+++ b/src/assets/scripts/client/trafficGenerator/SpawnPatternModel.js
@@ -1000,7 +1000,25 @@ export default class SpawnPatternModel extends BaseModel {
         }
 
         this._positionModel = this._routeModel.waypoints[0].positionModel;
-        this.heading = this._routeModel.calculateSpawnHeading();
+        this.heading = this._calculateSpawnHeading();
+    }
+
+
+    /**
+     * Calculate the heading from the first waypoint to the second waypoint
+     *
+     * This is used to determine the heading of newly spawned aircraft
+     *
+     * @for SpawnPatternModel
+     * @method calculateSpawnHeading
+     * @return {number} heading, in radians
+     */
+    _calculateSpawnHeading() {
+        const firstWaypointPositionModel = this._routeModel.waypoints[0].positionModel;
+        const secondWaypointPositionModel = this._routeModel.waypoints[1].positionModel;
+        const heading = firstWaypointPositionModel.bearingToPosition(secondWaypointPositionModel);
+
+        return heading;
     }
 
     /**

--- a/src/assets/scripts/client/trafficGenerator/SpawnPatternModel.js
+++ b/src/assets/scripts/client/trafficGenerator/SpawnPatternModel.js
@@ -1003,7 +1003,6 @@ export default class SpawnPatternModel extends BaseModel {
         this.heading = this._calculateSpawnHeading();
     }
 
-
     /**
      * Calculate the heading from the first waypoint to the second waypoint
      *

--- a/test/aircraft/FlightManagementSystem/RouteModel.spec.js
+++ b/test/aircraft/FlightManagementSystem/RouteModel.spec.js
@@ -248,14 +248,6 @@ ava('.activateHoldForWaypointName() calls LegModel.activateHoldForWaypointName()
     t.true(activateHoldForWaypointNameSpy2.calledWithExactly('KEPEC', holdParametersMock));
 });
 
-ava('.calculateSpawnHeading() returns bearing between route\'s first and second waypoints', (t) => {
-    const model = new RouteModel('JESJI..BAKRR');
-    const expectedResult = 1.3415936051582544;
-    const result = model.calculateSpawnHeading();
-
-    t.true(result === expectedResult);
-});
-
 ava('._createLegModelsFromWaypointModels() returns an array of LegModels matching the specified array of WaypointModels', (t) => {
     const model = new RouteModel('TNP.KEPEC3.KLAS07R');
 

--- a/test/trafficGenerator/SpawnPatternModel.spec.js
+++ b/test/trafficGenerator/SpawnPatternModel.spec.js
@@ -248,3 +248,19 @@ ava('._initializePositionAndHeadingForArrival() calculates aircraft heading and 
     t.true(model.heading === expectedHeadingResult);
     t.true(_isEqual(model.relativePosition, expectedPositionResult));
 });
+
+ava('.calculateSpawnHeading() returns bearing between route\'s first and second waypoints', (t) => {
+    const mock = Object.assign(
+        {},
+        ARRIVAL_PATTERN_MOCK,
+        {
+            route: 'JESJI..BAKRR'
+        }
+    );
+
+    const model = new SpawnPatternModel(mock);
+    const expectedResult = 1.3415936051582544;
+    const result = model._calculateSpawnHeading();
+
+    t.true(result === expectedResult);
+});

--- a/test/trafficGenerator/SpawnPatternModel.spec.js
+++ b/test/trafficGenerator/SpawnPatternModel.spec.js
@@ -249,7 +249,7 @@ ava('._initializePositionAndHeadingForArrival() calculates aircraft heading and 
     t.true(_isEqual(model.relativePosition, expectedPositionResult));
 });
 
-ava('.calculateSpawnHeading() returns bearing between route\'s first and second waypoints', (t) => {
+ava('._calculateSpawnHeading() returns bearing between route\'s first and second waypoints', (t) => {
     const mock = Object.assign(
         {},
         ARRIVAL_PATTERN_MOCK,


### PR DESCRIPTION
… from RouteModel to SpawnPattenModel

IMHO spawn related code should be in the SpawnPatternModel and not in the RouteModel.

Resolves #1144 