### PR TITLE
feature/793 - Add `airac` command and property to airports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 6.7.0 (November 1, 2018)
 ### New Features
 - [#1033](https://github.com/openscope/openscope/issues/1033) - Add support for overflights
+- [#793](https://github.com/openscope/openscope/issues/793) - Add AIRAC airport file key and system command
 
 
 

--- a/assets/airports/cyow.json
+++ b/assets/airports/cyow.json
@@ -1,4 +1,5 @@
 {
+    "airac": 1801,
     "radio": {
         "twr": "Ottawa Tower",
         "app": "Ottawa Arrivals",

--- a/assets/airports/eddm.json
+++ b/assets/airports/eddm.json
@@ -1,4 +1,5 @@
 {
+    "airac": 1702,
     "radio": {
         "twr": "München Tower",
         "app": "München Radar",

--- a/assets/airports/kabq.json
+++ b/assets/airports/kabq.json
@@ -1,4 +1,5 @@
 {
+    "airac": 1711,
     "radio": {
         "twr": "Albuquerque Tower",
         "app": "Albuquerque Approach",

--- a/assets/airports/kbos.json
+++ b/assets/airports/kbos.json
@@ -1,4 +1,5 @@
 {
+    "airac": 1802,
     "radio": {
         "twr": "Boston Tower",
         "app": "Boston Approach",

--- a/assets/airports/kdtw.json
+++ b/assets/airports/kdtw.json
@@ -1,4 +1,5 @@
 {
+    "airac": 1712,
     "radio": {
         "twr": "Metro Tower",
         "app": "Detroit Approach",
@@ -21,7 +22,7 @@
     "arrivalRunway": "22R",
     "departureRunway": "22L",
     "airspace": [
-        { 
+        {
             "floor": 0,
             "ceiling": 130,
             "airspace_class": "B",

--- a/assets/airports/kpdx.json
+++ b/assets/airports/kpdx.json
@@ -1,4 +1,5 @@
 {
+    "airac": 1802,
     "radio": {
         "twr": "Portland Tower",
         "app": "Portland Approach",

--- a/assets/airports/ksea.json
+++ b/assets/airports/ksea.json
@@ -1,4 +1,5 @@
 {
+    "airac": 1711,
     "radio": {
         "twr": "Seatle Tower",
         "app": "Seattle Approach",

--- a/assets/airports/kstl.json
+++ b/assets/airports/kstl.json
@@ -1,4 +1,5 @@
 {
+    "airac": 1802,
     "radio": {
         "twr": "Saint Louis Tower",
         "app": "Saint Louis Approach",
@@ -536,7 +537,7 @@
             "draw": [
                 ["CSX", "TWILA"],
                 ["TOY", "TWILA"],
-                ["STL", "TWILA"], 
+                ["STL", "TWILA"],
                 ["BIB*"],
                 ["VHP*"],
                 ["CREEP*"],

--- a/assets/airports/rjtt.json
+++ b/assets/airports/rjtt.json
@@ -1,4 +1,5 @@
 {
+    "airac": 1702,
     "radio": {
         "twr": "Tokyo Tower",
         "app": "Tokyo Approach",

--- a/documentation/airport-format.md
+++ b/documentation/airport-format.md
@@ -25,6 +25,7 @@ _Note: The code block shown below is an abbreviated version of [ksea.json](asset
 
 ```javascript
 {
+    "airac": 1801,
     "radio": {
         "twr": "Seatle Tower",
         "app": "Seattle Approach",
@@ -223,6 +224,7 @@ _Note: The code block shown below is an abbreviated version of [ksea.json](asset
 
 _all properties in this section are required_
 
+* **airac** ― AIRAC cycle from which data for the airport was taken. The airport must be fully compliant as of the specified cycle in order for this value to be changed.
 * **radio** ― The radio callsigns for each controller:
 
 ```javascript

--- a/src/assets/scripts/client/InputController.js
+++ b/src/assets/scripts/client/InputController.js
@@ -701,13 +701,14 @@ export default class InputController {
             }
             case PARSED_COMMAND_NAME.AIRAC: {
                 const airacCycle = AirportController.getAiracCycle();
+
                 if (airacCycle === null) {
                     UiController.ui_log('unknown airac cycle');
                 } else {
                     UiController.ui_log(`airac cycle ${airacCycle}`);
                 }
 
-                break;
+                return true;
             }
             // TODO: this will be removed entirely, eventually.
             case PARSED_COMMAND_NAME.RATE:

--- a/src/assets/scripts/client/InputController.js
+++ b/src/assets/scripts/client/InputController.js
@@ -699,6 +699,16 @@ export default class InputController {
 
                 return true;
             }
+            case PARSED_COMMAND_NAME.AIRAC: {
+                const airacCycle = AirportController.getAiracCycle();
+                if (airacCycle === null) {
+                    UiController.ui_log('unknown airac cycle');
+                } else {
+                    UiController.ui_log(`airac cycle ${airacCycle}`);
+                }
+
+                break;
+            }
             // TODO: this will be removed entirely, eventually.
             case PARSED_COMMAND_NAME.RATE:
                 UiController.ui_log('this command has been deprecated', true);

--- a/src/assets/scripts/client/InputController.js
+++ b/src/assets/scripts/client/InputController.js
@@ -700,13 +700,16 @@ export default class InputController {
                 return true;
             }
             case PARSED_COMMAND_NAME.AIRAC: {
+                const airportIcao = AirportController.current.icao.toUpperCase();
                 const airacCycle = AirportController.getAiracCycle();
 
-                if (airacCycle) {
-                    UiController.ui_log(`AIRAC cycle ${airacCycle}`);
-                } else {
-                    UiController.ui_log('unknown AIRAC cycle');
+                if (!airacCycle) {
+                    UiController.ui_log(`${airportIcao} AIRAC cycle: unknown`);
+
+                    return true;
                 }
+
+                UiController.ui_log(`${airportIcao} AIRAC cycle: ${airacCycle}`);
 
                 return true;
             }

--- a/src/assets/scripts/client/InputController.js
+++ b/src/assets/scripts/client/InputController.js
@@ -702,10 +702,10 @@ export default class InputController {
             case PARSED_COMMAND_NAME.AIRAC: {
                 const airacCycle = AirportController.getAiracCycle();
 
-                if (airacCycle === null) {
-                    UiController.ui_log('unknown airac cycle');
+                if (airacCycle) {
+                    UiController.ui_log(`AIRAC cycle ${airacCycle}`);
                 } else {
-                    UiController.ui_log(`airac cycle ${airacCycle}`);
+                    UiController.ui_log('unknown AIRAC cycle');
                 }
 
                 return true;

--- a/src/assets/scripts/client/airport/AirportController.js
+++ b/src/assets/scripts/client/airport/AirportController.js
@@ -168,7 +168,8 @@ class AirportController {
     }
 
     /**
-     * @for InputController
+     * @for AirportController
+     * @method getAiracCycle
      * @property airac
      * @return {number}
     */

--- a/src/assets/scripts/client/airport/AirportController.js
+++ b/src/assets/scripts/client/airport/AirportController.js
@@ -170,10 +170,10 @@ class AirportController {
     /**
      * @for InputController
      * @property airac
-     * @return {string}
+     * @return {number}
     */
     getAiracCycle() {
-        return this.current.airac.toString();
+        return this.current.airac;
     }
 
     /**

--- a/src/assets/scripts/client/airport/AirportController.js
+++ b/src/assets/scripts/client/airport/AirportController.js
@@ -168,6 +168,15 @@ class AirportController {
     }
 
     /**
+     * @for InputController
+     * @property airac
+     * @return {string}
+    */
+    getAiracCycle() {
+        return this.current.airac.toString();
+    }
+
+    /**
      * Retrieve a specific `AirportModel` instance
      *
      * @for AirportController

--- a/src/assets/scripts/client/airport/AirportModel.js
+++ b/src/assets/scripts/client/airport/AirportModel.js
@@ -115,7 +115,7 @@ export default class AirportModel {
         this.wip = null;
 
         /**
-         * This is what AIRAC cycle that the airport has been based off
+         * AIRAC cycle from which data for the airport was taken
          *
          * @property airac
          * @type {number}

--- a/src/assets/scripts/client/airport/AirportModel.js
+++ b/src/assets/scripts/client/airport/AirportModel.js
@@ -115,6 +115,15 @@ export default class AirportModel {
         this.wip = null;
 
         /**
+         * This is what AIRAC cycle that the airport has been based off
+         *
+         * @property airac
+         * @type {number}
+         * @default null
+        */
+        this.airac = null;
+
+        /**
          * @property radio
          * @type
          * @default null
@@ -353,6 +362,7 @@ export default class AirportModel {
 
         this.setCurrentPosition(data.position, degreesToRadians(data.magnetic_north));
 
+        this.airac = _get(data, 'airac', this.airac);
         this.radio = _get(data, 'radio', this.radio);
         this.has_terrain = _get(data, 'has_terrain', false);
         this.ctr_radius = _get(data, 'ctr_radius', DEFAULT_CTR_RADIUS_KM);

--- a/src/assets/scripts/client/constants/inputConstants.js
+++ b/src/assets/scripts/client/constants/inputConstants.js
@@ -65,12 +65,13 @@ export const MOUSE_EVENT_CODE = {
  * @final
  */
 export const PARSED_COMMAND_NAME = {
-    TUTORIAL: 'tutorial',
-    AUTO: 'auto',
-    PAUSE: 'pause',
-    TIMEWARP: 'timewarp',
-    CLEAR: 'clear',
+    AIRAC: 'airac',
     AIRPORT: 'airport',
+    AUTO: 'auto',
+    CLEAR: 'clear',
+    PAUSE: 'pause',
     RATE: 'rate',
-    TRANSMIT: 'transmit'
+    TIMEWARP: 'timewarp',
+    TRANSMIT: 'transmit',
+    TUTORIAL: 'tutorial'
 };

--- a/src/assets/scripts/client/parsers/aircraftCommandParser/aircraftCommandDefinitions.js
+++ b/src/assets/scripts/client/parsers/aircraftCommandParser/aircraftCommandDefinitions.js
@@ -51,6 +51,10 @@ const noop = (args) => args;
  */
 const ZERO_ARG_AIRCRAFT_COMMANDS = {
     // system commands
+    airac: {
+        validate: zeroArgumentsValidator,
+        parse: noop
+    },
     auto: {
         validate: zeroArgumentsValidator,
         parse: noop

--- a/src/assets/scripts/client/parsers/aircraftCommandParser/aircraftCommandMap.js
+++ b/src/assets/scripts/client/parsers/aircraftCommandParser/aircraftCommandMap.js
@@ -24,6 +24,11 @@ export const AIRCRAFT_COMMAND_MAP = {
         functionName: 'runAbort',
         isSystemCommand: false
     },
+    airac: {
+        aliases: ['airac'],
+        functionName: '',
+        isSystemCommand: true
+    },
     airport: {
         aliases: ['airport'],
         functionName: '',

--- a/test/airport/_mocks/airportJsonMock.js
+++ b/test/airport/_mocks/airportJsonMock.js
@@ -1,5 +1,6 @@
 /* eslint-disable */
 export const AIRPORT_JSON_KLAS_MOCK = {
+    "airac": 1004,
     "radio": {
         "twr": "Las Vegas Tower",
         "app": "Las Vegas Approach",


### PR DESCRIPTION
Resolves #793.

Add `airac` command and property to airports, such that users (or more likely, developers) can type `airac` and have the simulator respond with the airac number the airport is using.