### PR TITLE
refactor/727 - Update the tutorial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Enhancements & Refactors
 - [#1264](https://github.com/openscope/openscope/issues/1264) &[#1265](https://github.com/openscope/openscope/issues/1265) - Change the "super" weight class identifier from `U` to `J`
 - [#1269](https://github.com/openscope/openscope/issues/1269) - Updates [Google Analytics](https://developers.google.com/analytics/devguides/collection/gtagjs/migration) tracking function from `ga` to `gtag`
+- [#727](https://github.com/openscope/openscope/issues/727) &[#1265](https://github.com/openscope/openscope/issues/1265) - Updates to the tutorial
 
 
 # 6.8.0 (December 1, 2018)

--- a/src/assets/scripts/client/ui/TutorialStep.js
+++ b/src/assets/scripts/client/ui/TutorialStep.js
@@ -25,6 +25,9 @@ export default class TutorialStep {
     }
 
     /**
+     * Replace tokens with values from current sim state
+     * or return simple text.
+     *
      * @for TutorialStep
      * @method getText
      * @return {string}

--- a/src/assets/scripts/client/ui/TutorialView.js
+++ b/src/assets/scripts/client/ui/TutorialView.js
@@ -220,7 +220,7 @@ export default class TutorialView {
 
         this.tutorial_step({
             title: 'Welcome!',
-            text: ['Welcome to Air Traffic Control simulator. It&rsquo;s not easy',
+            text: ['Welcome to Air Traffic Control simulator. It\'s not easy',
                    'to control dozens of aircraft while maintaining safe distances',
                    'between them; to get started with the ATC simulator tutorial, click the arrow on',
                    'the right. You can also click the graduation cap icon in the lower right corner',
@@ -240,9 +240,9 @@ export default class TutorialView {
 
         this.tutorial_step({
             title: 'Departing aircraft',
-            text: ['Let&rsquo;s route some planes out of here. On the right side of the screen, there',
+            text: ['Let\'s route some planes out of here. On the right side of the screen, there',
                    'should be a strip with a blue bar on the left, meaning the strip represents a departing aircraft.',
-                   'Click the first one ({CALLSIGN}). The aircraft&rsquo;s callsign will appear in the command entry box',
+                   'Click the first one ({CALLSIGN}). The aircraft\'s callsign will appear in the command entry box',
                    'and the strip will move slightly to the side. This means that the aircraft is selected.'
                ].join(' '),
             parse: (t) => {
@@ -277,7 +277,7 @@ export default class TutorialView {
         this.tutorial_step({
             title: 'Takeoff, part 1',
             text: ['When it appears at the start of runway ({RUNWAY}) (which may take a couple of seconds), click it (or press the up arrow once)',
-                   'and type in &lsquo;caf&rsquo; (for &lsquo;cleared as filed&rsquo;). This tells the aircraft it is cleared to follow its flightplan.',
+                   'and type in &lsquo;caf&rsquo; (for "cleared as filed"). This tells the aircraft it is cleared to follow its flightplan.',
                    'Just as in real life, this step must be done before clearing the aircraft for takeoff, so they know where they\'re supposed to go.'
                 ].join(' '),
             parse: (t) => {
@@ -311,7 +311,7 @@ export default class TutorialView {
 
         this.tutorial_step({
             title: 'Aircraft strips, part 1',
-            text: ['On the right, there&rsquo;s a row of strips, one for each aircraft.',
+            text: ['On the right, there\'s a row of strips, one for each aircraft.',
                    'Each strip has a bar on its left side, colored blue for departures and',
                    'red for arrivals.'
             ].join(' '),
@@ -328,7 +328,7 @@ export default class TutorialView {
 
         this.tutorial_step({
             title: 'Aircraft strips, part 2',
-            text: ['The top row shows the aircraft&rsquo;s callsign, what it\'s doing (parked at apron,',
+            text: ['The top row shows the aircraft\'s callsign, what it\'s doing (parked at apron,',
                    'using a runway, flying to a fix, on a heading, etc), and its assigned altitude. The bottom row shows the model',
                    '({MODEL} here, which is a {MODELNAME}) to the left, its destination in the middle, and its assigned speed to the right.'
             ].join(' '),
@@ -346,10 +346,10 @@ export default class TutorialView {
         this.tutorial_step({
             title: 'Moving aircraft',
             text: ['Once {CALLSIGN} has taken off, you\'ll notice it will climb to {INIT_ALT} by itself. This is one of the instructions ',
-                    'we gave them when we cleared them &lsquo;as filed&rsquo;. Aircraft perform better when they are able to climb directly',
+                    'we gave them when we cleared them "as filed". Aircraft perform better when they are able to climb directly',
                     'from the ground to their cruise altitude without leveling off, so let\'s keep them climbing! Click it and type &lsquo;cvs&rsquo; (for',
-                    '&lsquo;climb via SID&rsquo;). Then they will follow the altitudes and speeds defined in the {SID_NAME} departure',
-                    'procedure. Feel free to click the speedup button on the right side of the input box (it&rsquo;s two small arrows)',
+                    '"climb via SID"). Then they will follow the altitudes and speeds defined in the {SID_NAME} departure',
+                    'procedure. Feel free to click the speedup button on the right side of the input box (it\'s two small arrows)',
                     'to watch the departure climb along the SID. Then just click it again to return to 1x speed.'
             ].join(' '),
             parse: (t) => {
@@ -369,7 +369,7 @@ export default class TutorialView {
             title: 'Departure destinations',
             text: ['If you zoom out (using the mouse wheel) and click',
                    'on {CALLSIGN}, you will see a blue dashed line that shows where they are heading. At the end of the',
-                   'line is its &lsquo;departure fix&rsquo;. Your goal is to get every departure cleared to their filed departure fix. As',
+                   'line is its "departure fix". Your goal is to get every departure cleared to their filed departure fix. As',
                    'you have probably noticed, this is very easy with SIDs, as the aircraft do all the hard work themselves.'
             ].join(' '),
             parse: (t) => {
@@ -470,7 +470,7 @@ export default class TutorialView {
             title: 'Bon voyage, aircraft!',
             text: ['When the aircraft crosses the airspace boundary, it will ',
                    'automatically remove itself from the flight strip bay on the right.',
-                   'Congratulations, you&rsquo;ve successfully taken off one aircraft.'
+                   'Congratulations, you\'ve successfully taken off one aircraft.'
                ].join(' '),
             parse: (v) => v,
             side: 'left',
@@ -480,7 +480,7 @@ export default class TutorialView {
         this.tutorial_step({
             title: 'Arrivals',
             text: ['Now, onto arrivals. Click on any arriving aircraft in the radar screen; after',
-                   'you&rsquo;ve selected it, use the altitude/heading/speed controls you\'ve learned in',
+                   'you\'ve selected it, use the altitude/heading/speed controls you\'ve learned in',
                    'order to guide it to be in front of a runway. Make sure to get the aircraft down to',
                    'around 4,000ft, and 10-15 nautical miles (2-3 range rings) away from the airport.',
                    'While you work the airplane, read the next step.'
@@ -492,7 +492,7 @@ export default class TutorialView {
 
         this.tutorial_step({
             title: 'Approach Clearances, part 1',
-            text: ['You can clear aircraft for an ILS approach with the &quot;ILS&quot; command, followed by a runway name. Before you can do so, however,',
+            text: ['You can clear aircraft for an ILS approach with the &lsquo;ILS&rsquo; command, followed by a runway name. Before you can do so, however,',
                    'it must be on a heading that will cross the runway\'s extended centerline, that is no more than 30 degrees offset from the',
                    'runway\'s heading. Once we eventually give them an approach clearance, you can expect aircraft to capture the ILS\'s localizer',
                    'once they\'re within a few degrees of the extended centerline.'
@@ -505,8 +505,8 @@ export default class TutorialView {
         this.tutorial_step({
             title: 'Approach Clearances, part 2',
             text: ['When you have the aircraft facing the right direction, just select it and type &lsquo;i &lt;runway&gt;&rsquo;',
-                   'with the runway that&rsquo;s in front of it. Once it\'s close enough to capture the localizer, the assigned altitude on its strip',
-                   'will change to &lsquo;ILS locked&rsquo; (meaning the aircraft is capable of guiding itself down to the runway via',
+                   'with the runway that\'s in front of it. Once it\'s close enough to capture the localizer, the assigned altitude on its strip',
+                   'will change to "ILS locked" (meaning the aircraft is capable of guiding itself down to the runway via',
                    'the Instrument Landing System), and the assigned heading should now show the runway to which it has an approach clearance.'
                ].join(' '),
             parse: (v) => v,
@@ -517,8 +517,8 @@ export default class TutorialView {
         this.tutorial_step({
             title: 'Approach Clearances, part 3',
             text: ['You may choose to enter one command at a time, but air traffic controllers usually do multiple. Particularly in approach clearances,',
-                   'they follow an acronym &ldquo;PTAC&rdquo; for the four elements of an approach clearance, the &lsquo;T&rsquo; and &lsquo;C&rsquo; of which',
-                   'stand for &lsquo;Turn&rsquo; and &lsquo;Clearance&rsquo;, both of which we entered separately in this tutorial. Though longer, it is both ',
+                   'they follow an acronym "PTAC" for the four elements of an approach clearance, the "T" and "C" of which',
+                   'stand for "Turn" and "Clearance", both of which we entered separately in this tutorial. Though longer, it is both ',
                    'easier and more real-world accurate to enter them together, like this: &lsquo;fh 250 i 28r&rsquo;.'
                ].join(' '),
             parse: (v) => v,
@@ -529,7 +529,7 @@ export default class TutorialView {
         this.tutorial_step({
             title: 'Wind sock',
             text: ['In the lower right corner of the map is a small circle with a line. It\'s like a flag: the line trails in the direction',
-                   'the wind is blowing toward. If it&rsquo;s pointing straight down, the wind is blowing from the North',
+                   'the wind is blowing toward. If it\'s pointing straight down, the wind is blowing from the North',
                    'to the South. Aircraft must be assigned to different runways such that they always take off and land into the wind, unless the',
                    'wind is less than 5 knots.'
                ].join(' '),
@@ -540,9 +540,9 @@ export default class TutorialView {
 
         this.tutorial_step({
             title: 'Scope Commands',
-            text: ['There are also various commands that can be entered into your "scope" which deal with moving ' +
-                'aircraft data blocks (labels), transferring control of aircraft, etc. To toggle between aircraft ' +
-                'commands and scope commands, press the tab key.'
+            text: ['There are also various commands that can be entered into your "scope" which deal with moving',
+                   'aircraft data blocks (labels), transferring control of aircraft, etc. To toggle between aircraft',
+                   'commands and scope commands, press the tab key.'
                ].join(' '),
             parse: (v) => v,
             side: 'left',
@@ -554,7 +554,7 @@ export default class TutorialView {
             text: ['The lower-right corner of the page has a small number in it; this is your score.',
                    'Whenever you successfully route an aircraft to the ground or out of the screen, you earn points. As you make mistakes,',
                    'like directing aircraft to a runway with a strong crosswind/tailwind, losing separation between aircraft, or ignoring an',
-                   'aircraft, you will also lose points. If you&rsquo;d like, you can just ignore the score; it doesn&rsquo;t have any effect',
+                   'aircraft, you will also lose points. If you\'d like, you can just ignore the score; it doesn\'t have any effect',
                    'with the simulation.'
                ].join(' '),
             parse: (v) => v,
@@ -564,7 +564,7 @@ export default class TutorialView {
 
         this.tutorial_step({
             title: 'Good job!',
-            text: ['If you&rsquo;ve gone through this entire tutorial, you should do pretty well with the pressure.',
+            text: ['If you\'ve gone through this entire tutorial, you should do pretty well with the pressure.',
                    'In the TRACON, minimum separation is 3 miles laterally or 1000 feet vertically. Keep them separated,',
                    'keep them moving, and you\'ll be a controller in no time!',
                    'A full list of commands can be found <a title="openScope Command Reference" href="https://github.com/openscope/openscope/blob/develop/documentation/commands.md">here</a>.'

--- a/src/assets/scripts/client/ui/TutorialView.js
+++ b/src/assets/scripts/client/ui/TutorialView.js
@@ -303,9 +303,8 @@ export default class TutorialView {
 
         this.tutorial_step({
             title: 'Aircraft strips, part 1',
-            text: ['On the right, there\'s a row of strips, one for each aircraft.',
-                   'Each strip has a bar on its left side, colored blue for departures and',
-                   'red for arrivals.'
+            text: ['On the right, there\'s a row of strips, one for each aircraft. You may need to pull it out with the',
+                   '\'|<\' tab. Each strip has a bar on its left side, colored blue for departures and red for arrivals.'
             ].join(' '),
             side: 'left',
             position: tutorial_position
@@ -388,7 +387,7 @@ export default class TutorialView {
                    'vectors in three ways. Usually, you will use &lsquo;t l ###&rsquo; or &lsquo;t r ###&rsquo;. Be careful, as it is both easy',
                    'and dangerous to give a turn in the wrong direction. If the heading is only slightly left or right, to avoid choosing the wrong direction,',
                    'you can tell them to &lsquo;fly heading&rsquo; by typing &lsquo;fh ###&rsquo;, and the aircraft will simply turn the shortest direction',
-                   'to face that heading.'
+                   'to face that heading. You can also instruct an aircraft to turn left and right by a given number of degrees if you give only a two-digit number.'
             ].join(' '),
             side: 'left',
             position: tutorial_position
@@ -476,8 +475,10 @@ export default class TutorialView {
         });
 
         this.tutorial_step({
+            // TODO: the windsock will be moving soon. Update this when that happens
             title: 'Wind sock',
-            text: ['In the lower right corner of the map is a small circle with a line. It\'s like a flag: the line trails in the direction',
+            text: ['In the lower right corner of the map is a small circle with a line. You may need to collapse the',
+                   'the flight strips with the \'>|\' tab. It\'s like a flag: the line trails in the direction',
                    'the wind is blowing toward. If it\'s pointing straight down, the wind is blowing from the North',
                    'to the South. Aircraft must be assigned to different runways such that they always take off and land into the wind, unless the',
                    'wind is less than 5 knots.'

--- a/src/assets/scripts/client/ui/TutorialView.js
+++ b/src/assets/scripts/client/ui/TutorialView.js
@@ -313,16 +313,18 @@ export default class TutorialView {
 
         this.tutorial_step({
             title: 'Aircraft strips, part 2',
-            text: ['The top row shows the aircraft\'s callsign, what it\'s doing (parked at apron,',
-                   'using a runway, flying to a fix, on a heading, etc), and its assigned altitude. The bottom row shows the model',
-                   '({MODEL} here, which is a {MODELNAME}) to the left, its destination in the middle, and its assigned speed to the right.'
+            text: ['The strip is split into four parts: the left section shows te aircraft\'s callsign, model number',
+                   '(in this case {MODEL}, representing {MODELNAME}), and computer identification number.',
+                   'The next column has the aircraft\' transponder code, assigned altitude, and flight plan altitude',
+                   'and the two rightmost blocks contain the departure airport code and flight plan route.'
             ].join(' '),
             parse: (t) => {
                 if (prop.aircraft.list.length <= 0) {
                     return t;
                 }
 
-                return t.replace('{MODEL}', departureAircraft.model.icao).replace('{MODELNAME}', departureAircraft.model.name);
+                return t.replace('{MODEL}', departureAircraft.model.icao)
+                        .replace('{MODELNAME}', departureAircraft.model.name);
             },
             side: 'left',
             position: tutorial_position
@@ -353,8 +355,8 @@ export default class TutorialView {
         this.tutorial_step({
             title: 'Departure destinations',
             text: ['If you zoom out (using the mouse wheel) and click',
-                   'on {CALLSIGN}, you will see a blue dashed line that shows where they are heading. At the end of the',
-                   'line is its "departure fix". Your goal is to get every departure cleared to their filed departure fix. As',
+                   'on {CALLSIGN}, you will see a solid blue line that shows where they are heading. At the end of the',
+                   'planned route is its "departure fix". Your goal is to get every departure cleared to their filed departure fix. As',
                    'you have probably noticed, this is very easy with SIDs, as the aircraft do all the hard work themselves.'
             ].join(' '),
             parse: (t) => {
@@ -446,21 +448,11 @@ export default class TutorialView {
 
         this.tutorial_step({
             title: 'Approach Clearances, part 1',
-            text: ['You can clear aircraft for an ILS approach with the &lsquo;ILS&rsquo; command, followed by a runway name. Before you can do so, however,',
-                   'it must be on a heading that will cross the runway\'s extended centerline, that is no more than 30 degrees offset from the',
-                   'runway\'s heading. Once we eventually give them an approach clearance, you can expect aircraft to capture the ILS\'s localizer',
-                   'once they\'re within a few degrees of the extended centerline.'
-            ].join(' '),
-            side: 'left',
-            position: tutorial_position
-        });
-
-        this.tutorial_step({
-            title: 'Approach Clearances, part 2',
-            text: ['When you have the aircraft facing the right direction, just select it and type &lsquo;i {RUNWAY}&rsquo;',
-                   'with the runway that\'s in front of it. Once it\'s close enough to capture the localizer, the assigned altitude on its strip',
-                   'will change to "ILS locked" (meaning the aircraft is capable of guiding itself down to the runway via',
-                   'the Instrument Landing System), and the assigned heading should now show the runway to which it has an approach clearance.'
+            text: ['You can clear aircraft for an ILS approach with the &lsquo;ILS&rsquo; command, followed by a runway name.',
+                   'When you do so, the aircraft will try to find a route that intercepts the localiser, represented by the',
+                   'extended centerline. Try giving radar vectors to get the aircraft on shallow intercept with this marking',
+                   'and then issue the instruction &lsquo;i {RUNWAY}&rsquo; to clear it to land. It should then guide itself',
+                   'the rest of the way to the runway, managing its own height and direction.'
             ].join(' '),
             parse: (t) => {
                 // This isn't robust. If there are multiple runways in use, or the arrival a/c has filed to land
@@ -473,7 +465,7 @@ export default class TutorialView {
         });
 
         this.tutorial_step({
-            title: 'Approach Clearances, part 3',
+            title: 'Approach Clearances, part 2',
             text: ['You may choose to enter one command at a time, but air traffic controllers usually do multiple. Particularly in approach clearances,',
                    'they follow an acronym "PTAC" for the four elements of an approach clearance, the "T" and "C" of which',
                    'stand for "Turn" and "Clearance", both of which we entered separately in this tutorial. Though longer, it is both ',

--- a/src/assets/scripts/client/ui/TutorialView.js
+++ b/src/assets/scripts/client/ui/TutorialView.js
@@ -7,7 +7,6 @@ import EventTracker from '../EventTracker';
 import TimeKeeper from '../engine/TimeKeeper';
 import TutorialStep from './TutorialStep';
 import { round, clamp } from '../math/core';
-import { heading_to_string } from '../utilities/unitConverters';
 import { EVENT } from '../constants/eventNames';
 import { STORAGE_KEY } from '../constants/storageKeys';
 import { SELECTORS } from '../constants/selectors';
@@ -15,13 +14,13 @@ import { TRACKABLE_EVENT } from '../constants/trackableEvents';
 
 const tutorial = {};
 
-const TUTORIAL_TEMPLATE = '' +
-    '<div id="tutorial">' +
-    '   <h1></h1>' +
-    '   <main></main>' +
-    '   <div class="prev"><img src="assets/images/prev.png" title="Previous step" /></div>' +
-    '   <div class="next"><img src="assets/images/next.png" title="Next step" /></div>' +
-    '</div>';
+const TUTORIAL_TEMPLATE = ''
+    + '<div id="tutorial">'
+    + '   <h1></h1>'
+    + '   <main></main>'
+    + '   <div class="prev"><img src="assets/images/prev.png" title="Previous step" /></div>'
+    + '   <div class="next"><img src="assets/images/next.png" title="Next step" /></div>'
+    + '</div>';
 
 /**
  * @class TutorialView
@@ -185,7 +184,6 @@ export default class TutorialView {
         this.$tutorialView = null;
         this.$tutorialPrevious = null;
         this.$tutorialNext = null;
-
         this.tutorial = {};
         this.tutorial.steps = [];
         this.tutorial.step = 0;
@@ -220,10 +218,10 @@ export default class TutorialView {
 
         this.tutorial_step({
             title: 'Welcome!',
-            text: ['Welcome to Air Traffic Control simulator. It\'s not easy',
+            text: ['Welcome to the OpenScope Air Traffic Control simulator. It\'s not easy',
                    'to control dozens of aircraft while maintaining safe distances',
                    'between them; to get started with the ATC simulator tutorial, click the arrow on',
-                   'the right. You can also click the graduation cap icon in the lower right corner',
+                   'the right. You can click the graduation cap icon in the lower right corner',
                    'of the window at any time to close this tutorial.'
                 ].join(' '),
             position: tutorial_position
@@ -258,7 +256,7 @@ export default class TutorialView {
 
         this.tutorial_step({
             title: 'Taxiing',
-            text: ['Now type in &lsquo;taxi {RUNWAY}&rsquo; or &lsquo;wait {RUNWAY}&rsquo; into the command box after the callsign and hit Return;',
+            text: ['Now type in "taxi {RUNWAY}" or "wait {RUNWAY}" into the command box after the callsign and hit Return;',
                    'the messages area above it will show that the aircraft is taxiing to runway ({RUNWAY}) in',
                    'preparation for takeoff.'
             ].join(' '),
@@ -276,7 +274,7 @@ export default class TutorialView {
         this.tutorial_step({
             title: 'Takeoff, part 1',
             text: ['When it appears at the start of runway ({RUNWAY}) (which may take a couple of seconds), click it (or press the up arrow once)',
-                   'and type in &lsquo;caf&rsquo; (for "cleared as filed"). This tells the aircraft it is cleared to follow its flightplan.',
+                   'and type in "caf" (for "cleared as filed"). This tells the aircraft it is cleared to follow its flightplan.',
                    'Just as in real life, this step must be done before clearing the aircraft for takeoff, so they know where they\'re supposed to go.'
             ].join(' '),
             parse: (t) => {
@@ -293,7 +291,7 @@ export default class TutorialView {
         this.tutorial_step({
             title: 'Takeoff, part 2',
             text: ['Now the aircraft is ready for take off. Click the aircraft again (or press up arrow once)',
-                   'and type &lsquo;takeoff&rsquo; (or &lsquo;to&rsquo;) to clear the aircraft for take off.',
+                   'and type "takeoff" (or "to") to clear the aircraft for take off.',
                    'Once it\'s going fast enough, it should lift off the ground and you should',
                    'see its altitude increasing. Meanwhile, read the next step.'
             ].join(' '),
@@ -333,7 +331,7 @@ export default class TutorialView {
             title: 'Moving aircraft',
             text: ['Once {CALLSIGN} has taken off, you\'ll notice it will climb to {INIT_ALT} by itself. This is one of the instructions ',
                     'we gave them when we cleared them "as filed". Aircraft perform better when they are able to climb directly',
-                    'from the ground to their cruise altitude without leveling off, so let\'s keep them climbing! Click it and type &lsquo;cvs&rsquo; (for',
+                    'from the ground to their cruise altitude without leveling off, so let\'s keep them climbing! Click it and type "cvs" (for',
                     '"climb via SID"). Then they will follow the altitudes and speeds defined in the {SID_NAME} departure',
                     'procedure. Feel free to click the speedup button on the right side of the input box (it\'s two small arrows)',
                     'to watch the departure climb along the SID. Then just click it again to return to 1x speed.'
@@ -371,11 +369,11 @@ export default class TutorialView {
 
         this.tutorial_step({
             title: 'Basic Control Instructions: Altitude',
-            text: ['You can assign altitudes with the &lsquo;climb&rsquo; command, or any of its aliases (other words that',
-                   'act identically). Running the command &lsquo;climb&rsquo; is the same as the commands &lsquo;descend&rsquo;, &lsquo;d&rsquo;,',
-                   '&lsquo;clear&rsquo;, &lsquo;c&rsquo;, &lsquo;altitude&rsquo;, or &lsquo;a&rsquo;. Just use whichever feels correct in your situation.',
-                   'Remember, just as in real ATC, altitudes are ALWAYS written in hundreds of feet, eg. &lsquo;descend 30&rsquo; for 3,000ft or &lsquo;climb',
-                   ' 100&rsquo; for 10,000ft.'
+            text: ['You can assign altitudes with the "climb" command, or any of its aliases (other words that',
+                   'act identically). Running the command "climb" is the same as the commands "descend", "d",',
+                   '"clear", "c", "altitude", or "a". Just use whichever feels correct in your situation.',
+                   'Remember, just as in real ATC, altitudes are ALWAYS written in hundreds of feet, eg. "descend 30" for 3,000ft or "climb',
+                   ' 100" for 10,000ft.'
             ].join(' '),
             side: 'left',
             position: tutorial_position
@@ -384,9 +382,9 @@ export default class TutorialView {
         this.tutorial_step({
             title: 'Basic Control Instructions: Radar Vectors',
             text: ['Radar vectors are an air traffic controller\'s way of telling aircraft to fly a specific magnetic heading. We can give aircraft radar',
-                   'vectors in three ways. Usually, you will use &lsquo;t l ###&rsquo; or &lsquo;t r ###&rsquo;. Be careful, as it is both easy',
+                   'vectors in three ways. Usually, you will use "t l ###" or "t r ###". Be careful, as it is both easy',
                    'and dangerous to give a turn in the wrong direction. If the heading is only slightly left or right, to avoid choosing the wrong direction,',
-                   'you can tell them to &lsquo;fly heading&rsquo; by typing &lsquo;fh ###&rsquo;, and the aircraft will simply turn the shortest direction',
+                   'you can tell them to "fly heading" by typing "fh ###", and the aircraft will simply turn the shortest direction',
                    'to face that heading. You can also instruct an aircraft to turn left and right by a given number of degrees if you give only a two-digit number.'
             ].join(' '),
             side: 'left',
@@ -397,7 +395,7 @@ export default class TutorialView {
             title: 'Basic Control Instructions: Speed',
             text: ['Speed control is the TRACON controller\'s best friend. Making good use of speed control can help keep the pace manageable and allow',
                    'you to carefully squeeze aircraft closer and closer to minimums while still maintaining safety. To enter speed instructions, use the',
-                   '&lsquo;+&rsquo; and &lsquo;-&rsquo; keys on the numpad, followed by the speed, in knots. Note that this assigned speed is indicated',
+                   '"+" and "-" keys on the numpad, followed by the speed, in knots. Note that this assigned speed is indicated',
                    'airspeed, and our radar scope can only display groundspeed; so, the values may be different.'
             ].join(' '),
             side: 'left',
@@ -407,7 +405,7 @@ export default class TutorialView {
         this.tutorial_step({
             title: 'Route',
             text: ['Instead of guiding each aircraft based on heading, you can also clear each aircraft to proceed to a fix or navaid (shown on the map',
-                   'as a small triangle). Just use the command &lsquo;route&rsquo; and the name of a fix, and the aircraft will fly to it. Upon passing the',
+                   'as a small triangle). Just use the command "route" and the name of a fix, and the aircraft will fly to it. Upon passing the',
                    'fix, it will continue flying along its present heading.'
             ].join(' '),
             side: 'left',
@@ -416,8 +414,8 @@ export default class TutorialView {
 
         this.tutorial_step({
             title: 'Proceed Direct',
-            text: ['The proceed direct command &lsquo;pd&rsquo; instructs an aircraft to go directly to a waypoint in the flight plan. For example, if an',
-                   'aircraft is flying to fixes [A, B, C], issuing the command &lsquo;pd B&rsquo; will cause the aircraft to go to B, then C.'
+            text: ['The proceed direct command "pd" instructs an aircraft to go directly to a waypoint in the flight plan. For example, if an',
+                   'aircraft is flying to fixes [A, B, C], issuing the command "pd B" will cause the aircraft to go to B, then C.'
             ].join(' '),
             side: 'left',
             position: tutorial_position
@@ -447,10 +445,10 @@ export default class TutorialView {
 
         this.tutorial_step({
             title: 'Approach Clearances, part 1',
-            text: ['You can clear aircraft for an ILS approach with the &lsquo;ILS&rsquo; command, followed by a runway name.',
+            text: ['You can clear aircraft for an ILS approach with the "ILS" command, followed by a runway name.',
                    'When you do so, the aircraft will try to find a route that intercepts the localiser, represented by the',
                    'extended centerline. Try giving radar vectors to get the aircraft on shallow intercept with this marking',
-                   'and then issue the instruction &lsquo;i {RUNWAY}&rsquo; to clear it to land. It should then guide itself',
+                   'and then issue the instruction "i {RUNWAY}" to clear it to land. It should then guide itself',
                    'the rest of the way to the runway, managing its own height and direction.'
             ].join(' '),
             parse: (t) => {
@@ -468,7 +466,7 @@ export default class TutorialView {
             text: ['You may choose to enter one command at a time, but air traffic controllers usually do multiple. Particularly in approach clearances,',
                    'they follow an acronym "PTAC" for the four elements of an approach clearance, the "T" and "C" of which',
                    'stand for "Turn" and "Clearance", both of which we entered separately in this tutorial. Though longer, it is both ',
-                   'easier and more real-world accurate to enter them together, like this: &lsquo;fh 250 i 28r&rsquo;.'
+                   'easier and more real-world accurate to enter them together, like this: "fh 250 i 28r".'
             ].join(' '),
             side: 'left',
             position: tutorial_position

--- a/src/assets/scripts/client/ui/TutorialView.js
+++ b/src/assets/scripts/client/ui/TutorialView.js
@@ -234,7 +234,7 @@ export default class TutorialView {
             text: ['To move the middle of the radar screen, use the right click button and drag.',
                 'Zoom in and out by scrolling, and press the middle mouse button or scroll wheel to reset the zoom.',
                 'To select an aircraft when it is in flight, simply left-click.'
-                ].join(' '),
+            ].join(' '),
             position: tutorial_position
         });
 
@@ -244,7 +244,7 @@ export default class TutorialView {
                    'should be a strip with a blue bar on the left, meaning the strip represents a departing aircraft.',
                    'Click the first one ({CALLSIGN}). The aircraft\'s callsign will appear in the command entry box',
                    'and the strip will move slightly to the side. This means that the aircraft is selected.'
-               ].join(' '),
+            ].join(' '),
             parse: (t) => {
                 if (prop.aircraft.list.length <= 0) {
                     return t;
@@ -258,17 +258,16 @@ export default class TutorialView {
 
         this.tutorial_step({
             title: 'Taxiing',
-            text: ['Now type in &lsquo;taxi&rsquo; or &lsquo;wait&rsquo; into the command box after the callsign and hit Return;',
+            text: ['Now type in &lsquo;taxi {RUNWAY}&rsquo; or &lsquo;wait {RUNWAY}&rsquo; into the command box after the callsign and hit Return;',
                    'the messages area above it will show that the aircraft is taxiing to runway ({RUNWAY}) in',
-                   'preparation for takeoff. (You could also specify to which runway to taxi the aircraft by',
-                   'entering the runway name after &lsquo;taxi&rsquo; or &lsquo;wait&rsquo;.)'
-               ].join(' '),
+                   'preparation for takeoff.'
+            ].join(' '),
             parse: (t) => {
                 if (prop.aircraft.list.length < 0) {
                     return t;
                 }
 
-                return t.replace('{RUNWAY}', departureAircraft.fms.departureRunwayModel.name);
+                return t.replace(/{RUNWAY}/g, departureAircraft.fms.departureRunwayModel.name);
             },
             side: 'left',
             position: tutorial_position
@@ -279,7 +278,7 @@ export default class TutorialView {
             text: ['When it appears at the start of runway ({RUNWAY}) (which may take a couple of seconds), click it (or press the up arrow once)',
                    'and type in &lsquo;caf&rsquo; (for "cleared as filed"). This tells the aircraft it is cleared to follow its flightplan.',
                    'Just as in real life, this step must be done before clearing the aircraft for takeoff, so they know where they\'re supposed to go.'
-                ].join(' '),
+            ].join(' '),
             parse: (t) => {
                 if (prop.aircraft.list.length <= 0) {
                     return t;
@@ -298,13 +297,6 @@ export default class TutorialView {
                    'Once it\'s going fast enough, it should lift off the ground and you should',
                    'see its altitude increasing. Meanwhile, read the next step.'
             ].join(' '),
-            parse: (t) => {
-                if (prop.aircraft.list.length <= 0) {
-                    return t;
-                }
-
-                return t.replace('{RUNWAY}', departureAircraft.fms.departureRunwayModel.name);
-            },
             side: 'left',
             position: tutorial_position
         });
@@ -315,13 +307,6 @@ export default class TutorialView {
                    'Each strip has a bar on its left side, colored blue for departures and',
                    'red for arrivals.'
             ].join(' '),
-            parse: (t) => {
-                if (prop.aircraft.list.length <= 0) {
-                    return t;
-                }
-
-                return t.replace('{RUNWAY}', departureAircraft.fms.departureRunwayModel.name);
-            },
             side: 'left',
             position: tutorial_position
         });
@@ -391,13 +376,6 @@ export default class TutorialView {
                    'Remember, just as in real ATC, altitudes are ALWAYS written in hundreds of feet, eg. &lsquo;descend 30&rsquo; for 3,000ft or &lsquo;climb',
                    ' 100&rsquo; for 10,000ft.'
             ].join(' '),
-            parse: (t) => {
-                if (prop.aircraft.list.length <= 0) {
-                    return t;
-                }
-
-                return t.replace('{CALLSIGN}', departureAircraft.callsign);
-            },
             side: 'left',
             position: tutorial_position
         });
@@ -409,8 +387,7 @@ export default class TutorialView {
                    'and dangerous to give a turn in the wrong direction. If the heading is only slightly left or right, to avoid choosing the wrong direction,',
                    'you can tell them to &lsquo;fly heading&rsquo; by typing &lsquo;fh ###&rsquo;, and the aircraft will simply turn the shortest direction',
                    'to face that heading.'
-               ].join(' '),
-            parse: (v) => v,
+            ].join(' '),
             side: 'left',
             position: tutorial_position
         });
@@ -422,13 +399,6 @@ export default class TutorialView {
                    '&lsquo;+&rsquo; and &lsquo;-&rsquo; keys on the numpad, followed by the speed, in knots. Note that this assigned speed is indicated',
                    'airspeed, and our radar scope can only display groundspeed; so, the values may be different.'
             ].join(' '),
-            parse: (t) => {
-                if (prop.aircraft.list.length <= 0) {
-                    return t;
-                }
-
-                return t.replace(/{ANGLE}/g, heading_to_string(departureAircraft.destination));
-            },
             side: 'left',
             position: tutorial_position
         });
@@ -438,14 +408,7 @@ export default class TutorialView {
             text: ['Instead of guiding each aircraft based on heading, you can also clear each aircraft to proceed to a fix or navaid (shown on the map',
                    'as a small triangle). Just use the command &lsquo;route&rsquo; and the name of a fix, and the aircraft will fly to it. Upon passing the',
                    'fix, it will continue flying along its present heading.'
-               ].join(' '),
-            parse: (t) => {
-                if (prop.aircraft.list.length <= 0) {
-                    return t;
-                }
-
-                return t.replace('{CALLSIGN}', departureAircraft.callsign);
-            },
+            ].join(' '),
             side: 'left',
             position: tutorial_position
         });
@@ -454,14 +417,7 @@ export default class TutorialView {
             title: 'Proceed Direct',
             text: ['The proceed direct command &lsquo;pd&rsquo; instructs an aircraft to go directly to a waypoint in the flight plan. For example, if an',
                    'aircraft is flying to fixes [A, B, C], issuing the command &lsquo;pd B&rsquo; will cause the aircraft to go to B, then C.'
-               ].join(' '),
-            parse: (t) => {
-                if (prop.aircraft.list.length <= 0) {
-                    return t;
-                }
-
-                return t.replace('{CALLSIGN}', prop.aircraft.list[0].callsign);
-            },
+            ].join(' '),
             side: 'left',
             position: tutorial_position
         });
@@ -471,8 +427,7 @@ export default class TutorialView {
             text: ['When the aircraft crosses the airspace boundary, it will ',
                    'automatically remove itself from the flight strip bay on the right.',
                    'Congratulations, you\'ve successfully taken off one aircraft.'
-               ].join(' '),
-            parse: (v) => v,
+            ].join(' '),
             side: 'left',
             position: tutorial_position
         });
@@ -484,8 +439,7 @@ export default class TutorialView {
                    'order to guide it to be in front of a runway. Make sure to get the aircraft down to',
                    'around 4,000ft, and 10-15 nautical miles (2-3 range rings) away from the airport.',
                    'While you work the airplane, read the next step.'
-               ].join(' '),
-            parse: (v) => v,
+            ].join(' '),
             side: 'left',
             position: tutorial_position
         });
@@ -496,20 +450,24 @@ export default class TutorialView {
                    'it must be on a heading that will cross the runway\'s extended centerline, that is no more than 30 degrees offset from the',
                    'runway\'s heading. Once we eventually give them an approach clearance, you can expect aircraft to capture the ILS\'s localizer',
                    'once they\'re within a few degrees of the extended centerline.'
-               ].join(' '),
-            parse: (v) => v,
+            ].join(' '),
             side: 'left',
             position: tutorial_position
         });
 
         this.tutorial_step({
             title: 'Approach Clearances, part 2',
-            text: ['When you have the aircraft facing the right direction, just select it and type &lsquo;i &lt;runway&gt;&rsquo;',
+            text: ['When you have the aircraft facing the right direction, just select it and type &lsquo;i {RUNWAY}&rsquo;',
                    'with the runway that\'s in front of it. Once it\'s close enough to capture the localizer, the assigned altitude on its strip',
                    'will change to "ILS locked" (meaning the aircraft is capable of guiding itself down to the runway via',
                    'the Instrument Landing System), and the assigned heading should now show the runway to which it has an approach clearance.'
-               ].join(' '),
-            parse: (v) => v,
+            ].join(' '),
+            parse: (t) => {
+                // This isn't robust. If there are multiple runways in use, or the arrival a/c has filed to land
+                // elsewhere then the tutorial message will not be correct. However, it's not a bad guess, and hopefully
+                // the player hasn't dicked with it too much.
+                return t.replace('{RUNWAY}', AirportController.airport_get().arrivalRunwayModel.name);
+            },
             side: 'left',
             position: tutorial_position
         });
@@ -520,8 +478,7 @@ export default class TutorialView {
                    'they follow an acronym "PTAC" for the four elements of an approach clearance, the "T" and "C" of which',
                    'stand for "Turn" and "Clearance", both of which we entered separately in this tutorial. Though longer, it is both ',
                    'easier and more real-world accurate to enter them together, like this: &lsquo;fh 250 i 28r&rsquo;.'
-               ].join(' '),
-            parse: (v) => v,
+            ].join(' '),
             side: 'left',
             position: tutorial_position
         });
@@ -532,8 +489,7 @@ export default class TutorialView {
                    'the wind is blowing toward. If it\'s pointing straight down, the wind is blowing from the North',
                    'to the South. Aircraft must be assigned to different runways such that they always take off and land into the wind, unless the',
                    'wind is less than 5 knots.'
-               ].join(' '),
-            parse: (v) => v,
+            ].join(' '),
             side: 'left',
             position: tutorial_position
         });
@@ -543,8 +499,7 @@ export default class TutorialView {
             text: ['There are also various commands that can be entered into your "scope" which deal with moving',
                    'aircraft data blocks (labels), transferring control of aircraft, etc. To toggle between aircraft',
                    'commands and scope commands, press the tab key.'
-               ].join(' '),
-            parse: (v) => v,
+            ].join(' '),
             side: 'left',
             position: tutorial_position
         });
@@ -556,8 +511,7 @@ export default class TutorialView {
                    'like directing aircraft to a runway with a strong crosswind/tailwind, losing separation between aircraft, or ignoring an',
                    'aircraft, you will also lose points. If you\'d like, you can just ignore the score; it doesn\'t have any effect',
                    'with the simulation.'
-               ].join(' '),
-            parse: (v) => v,
+            ].join(' '),
             side: 'left',
             position: tutorial_position
         });
@@ -568,8 +522,7 @@ export default class TutorialView {
                    'In the TRACON, minimum separation is 3 miles laterally or 1000 feet vertically. Keep them separated,',
                    'keep them moving, and you\'ll be a controller in no time!',
                    'A full list of commands can be found <a title="openScope Command Reference" href="https://github.com/openscope/openscope/blob/develop/documentation/commands.md">here</a>.'
-               ].join(' '),
-            parse: (v) => v,
+            ].join(' '),
             side: 'left',
             position: tutorial_position
         });

--- a/src/assets/style/landmark/_tutorial.less
+++ b/src/assets/style/landmark/_tutorial.less
@@ -76,3 +76,7 @@
 #tutorial ul {
     margin: 0.5em 2em;
 }
+
+#tutorial a {
+    color: cornflowerblue;
+}

--- a/src/assets/style/landmark/_tutorial.less
+++ b/src/assets/style/landmark/_tutorial.less
@@ -22,8 +22,7 @@
 }
 
 #tutorial h1 {
-    padding-left: 20px;
-    padding-bottom: 5px;
+    padding-bottom: 10px;
     font-size: 120%;
 }
 


### PR DESCRIPTION
Resolves openscope/openscope#727

The purpose of this pull request is to update the tutorial to better match the current simulator features, and to cover topics in more depth than is currently.

The PR comes in a couple of parts - it might be easier to look at the commits alone rather than the accumulated diff.

- [x] Formatting consistency, message construction
- [x] Fix message placeholders
  - [x] `taxi`/`wait` needs a runway
  - [x] `ils` needs a runway
  - [x] Remove surplus find/replaces
- [x] Fact checks
  - [x] Strips 2 - Strip doesn't show assigned speed
  - [x] Strips 2 - Strip doesn't show current activity
  - [x] Approach Clearances 1 - Do a/c actually have to be intercepting? They appear to try and do so themselves.
  - [x] Departure destination - what's the blue dashed line?
- [ ] Improvements
  - [x] Strips 1 - you may need to pull the strips out
  - [x] Windsock - you may need to collapse the strips
  - [ ] SID/STAR routing
  - [ ] General routing/handling demo
  - [x] Radar vectors - mention turn left/right by x degrees, rather than to a heading
  - [x] `<a>` tag colour for Good Job! linking to github
