### PR TITLE
devops/1230 - creates Dockerfile for nginx image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM nginx:stable
+
+COPY public /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf

--- a/documentation/heroku-docker.md
+++ b/documentation/heroku-docker.md
@@ -1,0 +1,13 @@
+# Using Docker with Heroku
+
+You will need the following in order to complete the steps below:
+1) Docker
+1) Heroku cli
+1) Access to Openscope Heroku
+1) Travis-cli gem
+1) Access to Travis-cli
+
+- `heroku container:login`
+- `heroku container:push openscope:nginx --app openscope-dev`
+
+**future notes and how-tos to build, ci and deploy app with nginx via docker containers**

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,13 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        proxy_set_header   X-Real-IP $remote_addr;
+        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Host $server_name;
+        try_files          $uri /index.html;
+    }
+}


### PR DESCRIPTION
resolves openscope/openscope#1230 

- [ ] create `Dockerfile`
- [ ] push container to heroku registry
- [ ] release container to heroku registry
- [ ] add container + image build to travis-ci
- [ ] publish dockerfile to heroku registry via travis-ci mapped to appropriate environment

The steps above may all be moot if we decide to go with the [nginx-buildpack](https://github.com/beanieboi/nginx-buildpack), but really what's the fun in that?

This gets a `Dockerfile` and basic `nginx.conf` out there.  Still some work to do here yet.

@felixscheffer do you have any experience with deploying a standalone `nginx` container on heroku?  The biggest thing I'm getting tripped up on is the variable port number.  Not really sure how I can both pass that correctly to configuration *_and_* test it locally.