### PR TITLE
enhancement/1275

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 - [#727](https://github.com/openscope/openscope/issues/727) &[#1265](https://github.com/openscope/openscope/issues/1265) - Updates to the tutorial
 - [#1238](https://github.com/openscope/openscope/issues/1238) - Grant IFR clearance when any type of route amendment is issued
 - [#1232](https://github.com/openscope/openscope/issues/1232) - Require proper application of separation with same-runway subsequent departures
+- [#1275](https://github.com/openscope/openscope/issues/1275) - Updates `buildMarkup` task to output date and time when generating the `index.html` file
+
 
 
 # 6.8.0 (December 1, 2018)

--- a/src/templates/layout.hbs
+++ b/src/templates/layout.hbs
@@ -2,7 +2,7 @@
 <!--
     Build information
     Version: {{version}}
-    Date: {{date}}
+    Build Date: {{buildDate}}
 -->
 <html>
     <head>

--- a/tools/tasks/buildMarkup.js
+++ b/tools/tasks/buildMarkup.js
@@ -22,10 +22,10 @@ function buildMarkup() {
             .helpers(handlebarsLayouts)
             .data({
                 version: pkg.version,
-                date: new Date().toISOString()
+                buildDate: new Date().toUTCString()
             })
         )
-        .pipe(rename(path => { path.extname = '.html'; }))
+        .pipe(rename((path) => { path.extname = '.html'; }))
         .pipe(gulp.dest(paths.DIR.DIST));
 }
 


### PR DESCRIPTION
Resolves #1275 

Updates `buildMarkup` task to output date and time when generating the `index.html` file
