### PR TITLE
Add Pull Reminders badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/openscope/openscope/badge.svg?branch=develop)](https://coveralls.io/github/openscope/openscope?branch=develop)
 [![Slack Status](http://slack.openscope.co/badge.svg)](http://slack.openscope.co)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE.md)
+[![pullreminders](https://pullreminders.com/badge.svg)](https://pullreminders.com?ref=badge)
 
 # openScope Air Traffic Control Simulator
 


### PR DESCRIPTION
Hi everyone!

The purpose of the README badge is to drive some traffic back to [Pull Reminders](http://pullreminders.com) so that we can continue to sustainably provide free accounts for open-source organizations like yours. To date, over 500 open-source orgs use Pull Reminders for free. We are also working on creating embeddable charts of open-source metrics if that'd be preferred over the badge. Here's the page explaining our badge program: https://pullreminders.com/badge

Let me know if you have any concerns about adding this!