### PR TITLE
bugfix/1341 - fix CID number generation bug in cases of CID collision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bugfixes
 - [#1335](https://github.com/openscope/openscope/issues/1335) - Fix inconsistent state of control buttons when window loses and regains focus.
+- [#1341](https://github.com/openscope/openscope/issues/1341) - Fix CID number generation bug in cases of CID collision
 
 
 ### Enhancements & Refactors

--- a/src/assets/scripts/client/aircraft/StripView/StripViewController.js
+++ b/src/assets/scripts/client/aircraft/StripView/StripViewController.js
@@ -329,7 +329,7 @@ export default class StripViewController {
         const nextCid = _random(1, CID_UPPER_BOUND);
 
         if (this._cidNumbersInUse.indexOf(nextCid) !== INVALID_INDEX) {
-            this._generateCidNumber();
+            return this._generateCidNumber();
         }
 
         this._cidNumbersInUse.push(nextCid);


### PR DESCRIPTION
Resolves #1341

The purpose of this pull request is to fix CID number generation bug so that in cases of CID collision the re-rolled CID is used rather than the one that collides with an existing acft strip.
