### PR TITLE
bugfix/1351 - Fix turn right 5 degrees not useable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 
 
 ### Bugfixes
-- [#1363](https://github.com/openscope/openscope/issues/1363) - Fix aircraft Not Squawking Assigned Code
+- [#1363](https://github.com/openscope/openscope/issues/1363) - Fix aircraft not squawking assigned code
+- [#1351](https://github.com/openscope/openscope/issues/1351) - Fix turn command with incremental turns of less than 10 degrees
 
 
 ### Enhancements & Refactors

--- a/src/assets/scripts/client/parsers/aircraftCommandParser/argumentParsers.js
+++ b/src/assets/scripts/client/parsers/aircraftCommandParser/argumentParsers.js
@@ -93,7 +93,7 @@ export const headingParser = (args) => {
 
             return [direction, heading, isIncremental];
         case 2:
-            isIncremental = args[1].length === 2;
+            isIncremental = args[1].length === 2 || args[1].length === 1;
             direction = directionNormalizer(args[0]);
             heading = convertStringToNumber(args[1]);
 

--- a/test/aircraft/Pilot/Pilot.spec.js
+++ b/test/aircraft/Pilot/Pilot.spec.js
@@ -1048,7 +1048,7 @@ ava('.maintainHeading() returns a success message when incremental is true and d
     t.deepEqual(result, expectedResult);
 });
 
-ava('.maintainHeading() returns a success message when incremental is true and direction is right', (t) => {
+ava('.maintainHeading() returns a success message when incremental is true, direction is right, and a 2-digit numeral is used for the increment', (t) => {
     const directionMock = 'right';
     const expectedResult = [
         true,
@@ -1062,6 +1062,21 @@ ava('.maintainHeading() returns a success message when incremental is true and d
 
     t.deepEqual(result, expectedResult);
 });
+
+ava('.maintainHeading() returns a success message when incremental is true and direction is right, and a 1-digit numeral is used for the increment', (t) => {
+    const directionMock = 'right';
+    const expectedResult = [
+        true,
+        {
+            log: 'turn 5 degrees right',
+            say: 'turn 5 degrees right'
+        }
+    ];
+    const aircraftModel = new AircraftModel(ARRIVAL_AIRCRAFT_INIT_PROPS_MOCK);
+    const result = aircraftModel.pilot.maintainHeading(aircraftModel, 5, directionMock, true);
+
+    t.deepEqual(result, expectedResult);
+});    
 
 ava('.maintainHeading() returns a success message when incremental is false and direction is provided', (t) => {
     const directionMock = 'right';

--- a/test/aircraft/Pilot/Pilot.spec.js
+++ b/test/aircraft/Pilot/Pilot.spec.js
@@ -1076,7 +1076,7 @@ ava('.maintainHeading() returns a success message when incremental is true and d
     const result = aircraftModel.pilot.maintainHeading(aircraftModel, 5, directionMock, true);
 
     t.deepEqual(result, expectedResult);
-});    
+});
 
 ava('.maintainHeading() returns a success message when incremental is false and direction is provided', (t) => {
     const directionMock = 'right';


### PR DESCRIPTION
Resolves #1351 

The purpose of this pull request is to re-enable the `t r` or `t l` commands to use 1-digit increments
