### PR TITLE
bugfix/1420 - Prespawned aircraft spawn with heading 360

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
-# 6.14.0 (September 1, 2019)
+# 6.14.0 (October 1, 2019)
 ### New Features
 
 
 ### Bugfixes
 - [#1418](https://github.com/openscope/openscope/issues/1418) - Fix error from EDDF spawn pattern
 - [#1395](https://github.com/openscope/openscope/issues/1395) - Fix aircraft's wind correction angle math (which was causing go-arounds)
+- [#1420](https://github.com/openscope/openscope/issues/1420) - Spawn pre-spawned aircraft on correct heading instead of 360 heading
 
 
 ### Enhancements & Refactors

--- a/src/assets/scripts/client/trafficGenerator/buildPreSpawnAircraft.js
+++ b/src/assets/scripts/client/trafficGenerator/buildPreSpawnAircraft.js
@@ -194,7 +194,12 @@ function _calculateSpawnPositionsAndAltitudes(
     for (let i = 0; i < spawnOffsets.length; i++) {
         const spawnOffset = spawnOffsets[i];
         const nextWaypointIndex = _findIndex(waypointOffsetMap, (distanceToWaypoint) => {
-            return distanceToWaypoint >= spawnOffset;
+            // Purposefully using strict comparison:
+            // If we return true here when distanceToWaypoint is equal to spawnOffset,
+            // the previousWaypointModel and the nextWaypointModel will be the same for
+            // the last item (the spawn point) resulting in the incapacity to compute a
+            // heading.
+            return distanceToWaypoint > spawnOffset;
         });
         const nextWaypointModel = waypointModelList[nextWaypointIndex];
         const previousWaypointIndex = Math.max(0, nextWaypointIndex - 1);


### PR DESCRIPTION
Resolves #1420

Fix a condition that was used to find the next waypoint from a prespawn position.
The non-strict condition resulted in computing a heading from and to the same point, thus returning an incorrect arbitrary value.