### PR TITLE
bugfix/1432 - Aircraft exiting hold on their own (on develop)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#1418](https://github.com/openscope/openscope/issues/1418) - Fix error from EDDF spawn pattern
 - [#1395](https://github.com/openscope/openscope/issues/1395) - Fix aircraft's wind correction angle math (which was causing go-arounds)
 - [#1420](https://github.com/openscope/openscope/issues/1420) - Spawn pre-spawned aircraft on correct heading instead of 360 heading
+- [#1432](https://github.com/openscope/openscope/issues/1432) - Prevent aircraft from leaving their holding patterns
 
 
 ### Enhancements & Refactors

--- a/src/assets/scripts/client/aircraft/AircraftModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftModel.js
@@ -1983,6 +1983,7 @@ export default class AircraftModel {
 
         const { inboundHeading } = holdParameters;
         const outboundHeading = radians_normalize(inboundHeading + Math.PI);
+        const groundTrack = radians_normalize(this.groundTrack);
         const offset = getOffset(this, waypointRelativePosition, inboundHeading);
         const holdLegDurationInMinutes = holdParameters.legLength.replace('min', '');
         const holdLegDurationInSeconds = holdLegDurationInMinutes * TIME.ONE_MINUTE_IN_SECONDS;
@@ -2001,7 +2002,7 @@ export default class AircraftModel {
 
         let nextTargetHeading = outboundHeading;
 
-        if (this.heading === outboundHeading && !isTimerSet) {
+        if (abs(groundTrack - outboundHeading) < PERFORMANCE.MAXIMUM_ANGLE_CONSIDERED_ESTABLISHED_ON_HOLD_COURSE && !isTimerSet) {
             currentWaypoint.setHoldTimer(gameTime + holdLegDurationInSeconds);
         }
 

--- a/src/assets/scripts/client/constants/aircraftConstants.js
+++ b/src/assets/scripts/client/constants/aircraftConstants.js
@@ -193,7 +193,7 @@ export const PERFORMANCE = {
     MAXIMUM_DISTANCE_CONSIDERED_ESTABLISHED_ON_APPROACH_COURSE_NM: 0.0822894, // appx. 500 feet
 
     /**
-     * Maximum angular differce from the approach course heading to consider the aircraft close
+     * Maximum angular difference from the approach course heading to consider the aircraft close
      * to be "established on the approach course", which is an important condition for applying
      * rules of separation.
      *
@@ -202,6 +202,16 @@ export const PERFORMANCE = {
      * @final
      */
     MAXIMUM_ANGLE_CONSIDERED_ESTABLISHED_ON_APPROACH_COURSE: 0.0872665, // appx. 5 degrees
+
+    /**
+     * Maximum angular difference from the hold inbound heading to consider the aircraft close
+     * to be "established on the hold course".
+     *
+     * @property MAXIMUM_ANGLE_CONSIDERED_ESTABLISHED_ON_HOLD_COURSE
+     * @type {number}
+     * @final
+     */
+    MAXIMUM_ANGLE_CONSIDERED_ESTABLISHED_ON_HOLD_COURSE: 0.000017453, // appx. 0.001 degrees
 
     /**
      * Altitude above the runway to which aircraft may descend on an instrument approach.

--- a/src/assets/scripts/client/constants/aircraftConstants.js
+++ b/src/assets/scripts/client/constants/aircraftConstants.js
@@ -204,14 +204,14 @@ export const PERFORMANCE = {
     MAXIMUM_ANGLE_CONSIDERED_ESTABLISHED_ON_APPROACH_COURSE: 0.0872665, // appx. 5 degrees
 
     /**
-     * Maximum angular difference from the hold inbound heading to consider the aircraft close
+     * Maximum angular difference from the hold outbound heading to consider the aircraft close
      * to be "established on the hold course".
      *
      * @property MAXIMUM_ANGLE_CONSIDERED_ESTABLISHED_ON_HOLD_COURSE
      * @type {number}
      * @final
      */
-    MAXIMUM_ANGLE_CONSIDERED_ESTABLISHED_ON_HOLD_COURSE: 0.000017453, // appx. 0.001 degrees
+    MAXIMUM_ANGLE_CONSIDERED_ESTABLISHED_ON_HOLD_COURSE: 0.0017453, // appx. 0.1 degrees
 
     /**
      * Altitude above the runway to which aircraft may descend on an instrument approach.

--- a/test/aircraft/AircraftModel.spec.js
+++ b/test/aircraft/AircraftModel.spec.js
@@ -25,7 +25,6 @@ import {
     PERFORMANCE
 } from '../../src/assets/scripts/client/constants/aircraftConstants';
 import { AIRPORT_CONSTANTS } from '../../src/assets/scripts/client/constants/airportConstants';
-import { TIME } from '../../src/assets/scripts/client/constants/globalConstants';
 import { DEFAULT_HOLD_PARAMETERS } from '../../src/assets/scripts/client/constants/waypointConstants';
 
 let sandbox; // using the sinon sandbox ensures stubs are restored after each test


### PR DESCRIPTION
Resolves #1432

Fixes issue where aircraft never turned back to the hold fix, thereby
exiting the hold. Uses the ground track instead of heading so wind
doesn't affect the tests.