### PR TITLE
enhancement/1231 - Draw STAR label to the left

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [#1387](https://github.com/openscope/openscope/issues/1387) - Update EDDF to AIRAC 1906
 - [#1327](https://github.com/openscope/openscope/issues/1327) - Airport Revival: San Francisco International Airport
 - [#1390](https://github.com/openscope/openscope/issues/1390) - Update KAUS to AIRAC 1909
+- [#1231](https://github.com/openscope/openscope/issues/1231) - Draw STAR labels left of fix to prevent text overlap with SID labels
 
 
 # 6.13.0 (June 1, 2019)

--- a/src/assets/scripts/client/canvas/CanvasController.js
+++ b/src/assets/scripts/client/canvas/CanvasController.js
@@ -793,6 +793,7 @@ export default class CanvasController {
         cc.fillStyle = this.theme.SCOPE.STAR;
         cc.setLineDash([1, 10]);
         cc.font = 'italic 14px monoOne, monospace';
+        cc.textAlign = 'right';
 
         for (let i = 0; i < starLines.length; i++) {
             const star = starLines[i];
@@ -858,10 +859,11 @@ export default class CanvasController {
      */
     _drawText(cc, position, labels) {
         const positionInPx = CanvasStageModel.translatePostionModelToRoundedCanvasPosition(position);
+        const dx = cc.textAlign === 'right' ? -10 : 10;
 
         for (let k = 0; k < labels.length; k++) {
             const textItem = labels[k];
-            const positionX = positionInPx.x + 10;
+            const positionX = positionInPx.x + dx;
             const positionY = positionInPx.y + (15 * k);
 
             cc.fillText(textItem, positionX, positionY);


### PR DESCRIPTION
Resolves #1231

The purpose of this pull request is to
Align STAR labels right, and draw them 10px to the left of the point
so that they don't overlap with SID labels

![image](https://user-images.githubusercontent.com/3430117/64600966-f4223500-d3b3-11e9-9ae8-4fb712aadd00.png)
