### PR TITLE
bugfix/23 - Ensure focus is on the command input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [#1420](https://github.com/openscope/openscope/issues/1420) - Spawn pre-spawned aircraft on correct heading instead of 360 heading
 - [#1432](https://github.com/openscope/openscope/issues/1432) - Prevent aircraft from leaving their holding patterns
 - [#1440](https://github.com/openscope/openscope/issues/1440) - Add missing "b738"-fleet to TUI Airways
+- [#23](https://github.com/openscope/openscope/issues/23) - Ensure focus remains on the text input box in MS Edge
 
 
 ### Enhancements & Refactors

--- a/src/assets/scripts/client/InputController.js
+++ b/src/assets/scripts/client/InputController.js
@@ -307,6 +307,9 @@ export default class InputController {
         this.input.callsign = aircraftModel.callsign;
         this.input.command = '';
         this.$commandInput.val(`${aircraftModel.callsign} `);
+        if (!this.$commandInput.is(':focus')) {
+            this.$commandInput.focus();
+        }
         this._eventBus.trigger(EVENT.SELECT_STRIP_VIEW_FROM_DATA_BLOCK, aircraftModel);
     };
 

--- a/src/assets/scripts/client/InputController.js
+++ b/src/assets/scripts/client/InputController.js
@@ -307,9 +307,11 @@ export default class InputController {
         this.input.callsign = aircraftModel.callsign;
         this.input.command = '';
         this.$commandInput.val(`${aircraftModel.callsign} `);
+
         if (!this.$commandInput.is(':focus')) {
             this.$commandInput.focus();
         }
+
         this._eventBus.trigger(EVENT.SELECT_STRIP_VIEW_FROM_DATA_BLOCK, aircraftModel);
     };
 


### PR DESCRIPTION
Resolves #23 

The purpose of this pull request is to ensure that the command input textbox has focus after an aircraft is selected.
