### PR TITLE
bugfix/1446 - Normalise aircraft heading in "say heading" read-back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [#1440](https://github.com/openscope/openscope/issues/1440) - Add missing "b738"-fleet to TUI Airways
 - [#23](https://github.com/openscope/openscope/issues/23) - Ensure focus remains on the text input box in MS Edge
 - [#1448](https://github.com/openscope/openscope/issues/1448) - Lower spawn altitudes of KSFO arrivals so can comply with STAR restrictions
+- [#1446](https://github.com/openscope/openscope/issues/1446) - Ensure `sh`/`sah` commands return headings within 001-360
 
 
 ### Enhancements & Refactors

--- a/src/assets/scripts/client/aircraft/AircraftCommander.js
+++ b/src/assets/scripts/client/aircraft/AircraftCommander.js
@@ -12,7 +12,6 @@ import {
     FLIGHT_PHASE
 } from '../constants/aircraftConstants';
 import { EVENT } from '../constants/eventNames';
-import { degrees_normalize } from '../math/circle';
 import { round } from '../math/core';
 import { AIRCRAFT_COMMAND_MAP } from '../parsers/aircraftCommandParser/aircraftCommandMap';
 import { speech_say } from '../speech';
@@ -22,7 +21,7 @@ import {
     radio_heading,
     radio_altitude
 } from '../utilities/radioUtilities';
-import { radiansToDegrees } from '../utilities/unitConverters';
+import { heading_to_string, radiansToDegrees } from '../utilities/unitConverters';
 
 /**
  *
@@ -524,7 +523,7 @@ export default class AircraftCommander {
      * @return {array} [success of operation, readback]
      */
     runSayHeading(aircraft) {
-        const heading = degrees_normalize(_round(radiansToDegrees(aircraft.heading)));
+        const heading = heading_to_string(aircraft.heading);
         const readback = {};
 
         readback.log = `heading ${heading}`;
@@ -544,7 +543,7 @@ export default class AircraftCommander {
             return [false, 'we haven\'t been assigned a heading'];
         }
 
-        const heading = degrees_normalize(_round(radiansToDegrees(aircraft.mcp.heading)));
+        const heading = heading_to_string(aircraft.mcp.heading);
         const readback = {};
 
         readback.log = `assigned heading ${heading}`;

--- a/src/assets/scripts/client/aircraft/AircraftCommander.js
+++ b/src/assets/scripts/client/aircraft/AircraftCommander.js
@@ -12,6 +12,7 @@ import {
     FLIGHT_PHASE
 } from '../constants/aircraftConstants';
 import { EVENT } from '../constants/eventNames';
+import { degrees_normalize } from '../math/circle';
 import { round } from '../math/core';
 import { AIRCRAFT_COMMAND_MAP } from '../parsers/aircraftCommandParser/aircraftCommandMap';
 import { speech_say } from '../speech';
@@ -523,7 +524,7 @@ export default class AircraftCommander {
      * @return {array} [success of operation, readback]
      */
     runSayHeading(aircraft) {
-        const heading = _round(radiansToDegrees(aircraft.heading));
+        const heading = degrees_normalize(_round(radiansToDegrees(aircraft.heading)));
         const readback = {};
 
         readback.log = `heading ${heading}`;
@@ -543,7 +544,7 @@ export default class AircraftCommander {
             return [false, 'we haven\'t been assigned a heading'];
         }
 
-        const heading = _round(radiansToDegrees(aircraft.mcp.heading));
+        const heading = degrees_normalize(_round(radiansToDegrees(aircraft.mcp.heading)));
         const readback = {};
 
         readback.log = `assigned heading ${heading}`;

--- a/test/aircraft/AircraftCommander.spec.js
+++ b/test/aircraft/AircraftCommander.spec.js
@@ -1,0 +1,24 @@
+import ava from 'ava';
+import AircraftCommander from '../../src/assets/scripts/client/aircraft/AircraftCommander';
+import AircraftModel from '../../src/assets/scripts/client/aircraft/AircraftModel';
+import {
+    AIRCRAFT_MOCK_WITH_POSITIVE_HEADING,
+    AIRCRAFT_MOCK_WITH_NEGATIVE_HEADING,
+    RUN_SAY_HEADING_RESULT
+} from './_mocks/aircraftCommanderMocks';
+
+ava('.runSayHeading() returns correct when heading is positive', (t) => {
+    const commander = new AircraftCommander();
+    const aircraft = new AircraftModel(AIRCRAFT_MOCK_WITH_POSITIVE_HEADING);
+    const result = commander.runSayHeading(aircraft);
+
+    t.deepEqual(result, RUN_SAY_HEADING_RESULT);
+});
+
+ava('.runSayHeading() returns correct when heading is negative', (t) => {
+    const commander = new AircraftCommander();
+    const aircraft = new AircraftModel(AIRCRAFT_MOCK_WITH_NEGATIVE_HEADING);
+    const result = commander.runSayHeading(aircraft);
+
+    t.deepEqual(result, RUN_SAY_HEADING_RESULT);
+});

--- a/test/aircraft/AircraftCommander.spec.js
+++ b/test/aircraft/AircraftCommander.spec.js
@@ -2,23 +2,43 @@ import ava from 'ava';
 import AircraftCommander from '../../src/assets/scripts/client/aircraft/AircraftCommander';
 import AircraftModel from '../../src/assets/scripts/client/aircraft/AircraftModel';
 import {
-    AIRCRAFT_MOCK_WITH_POSITIVE_HEADING,
-    AIRCRAFT_MOCK_WITH_NEGATIVE_HEADING,
-    RUN_SAY_HEADING_RESULT
+    AIRCRAFT_MOCK_WITH_NE_HEADING,
+    AIRCRAFT_MOCK_WITH_NORTH_HEADING,
+    AIRCRAFT_MOCK_WITH_POSITIVE_SW_HEADING,
+    AIRCRAFT_MOCK_WITH_NEGATIVE_SW_HEADING,
+    RUN_SAY_HEADING_RESULT_NE,
+    RUN_SAY_HEADING_RESULT_NORTH,
+    RUN_SAY_HEADING_RESULT_SW
 } from './_mocks/aircraftCommanderMocks';
+
+ava('.runSayHeading() returns correct when heading north', (t) => {
+    const commander = new AircraftCommander();
+    const aircraft = new AircraftModel(AIRCRAFT_MOCK_WITH_NORTH_HEADING);
+    const result = commander.runSayHeading(aircraft);
+
+    t.deepEqual(result, RUN_SAY_HEADING_RESULT_NORTH);
+});
+
+ava('.runSayHeading() returns correct when heading has two digits', (t) => {
+    const commander = new AircraftCommander();
+    const aircraft = new AircraftModel(AIRCRAFT_MOCK_WITH_NE_HEADING);
+    const result = commander.runSayHeading(aircraft);
+
+    t.deepEqual(result, RUN_SAY_HEADING_RESULT_NE);
+});
 
 ava('.runSayHeading() returns correct when heading is positive', (t) => {
     const commander = new AircraftCommander();
-    const aircraft = new AircraftModel(AIRCRAFT_MOCK_WITH_POSITIVE_HEADING);
+    const aircraft = new AircraftModel(AIRCRAFT_MOCK_WITH_POSITIVE_SW_HEADING);
     const result = commander.runSayHeading(aircraft);
 
-    t.deepEqual(result, RUN_SAY_HEADING_RESULT);
+    t.deepEqual(result, RUN_SAY_HEADING_RESULT_SW);
 });
 
 ava('.runSayHeading() returns correct when heading is negative', (t) => {
     const commander = new AircraftCommander();
-    const aircraft = new AircraftModel(AIRCRAFT_MOCK_WITH_NEGATIVE_HEADING);
+    const aircraft = new AircraftModel(AIRCRAFT_MOCK_WITH_NEGATIVE_SW_HEADING);
     const result = commander.runSayHeading(aircraft);
 
-    t.deepEqual(result, RUN_SAY_HEADING_RESULT);
+    t.deepEqual(result, RUN_SAY_HEADING_RESULT_SW);
 });

--- a/test/aircraft/_mocks/aircraftCommanderMocks.js
+++ b/test/aircraft/_mocks/aircraftCommanderMocks.js
@@ -1,0 +1,36 @@
+import { AIRCRAFT_DEFINITION_MOCK } from './aircraftMocks';
+import { POSITION_MODEL_MOCK } from '../../base/_mocks/positionMocks';
+
+export const AIRCRAFT_MOCK_BASE = {
+    transponderCode: 3377,
+    callsign: '1567',
+    destination: '',
+    origin: 'KLAS',
+    fleet: 'default',
+    airline: 'ual',
+    airlineCallsign: 'speedbird',
+    altitude: 28000,
+    speed: 320,
+    category: 'departure',
+    icao: 'b737',
+    // TODO: this may need to be a fixture for `AircraftTypeDefinitionModel`
+    model: AIRCRAFT_DEFINITION_MOCK,
+    positionModel: POSITION_MODEL_MOCK,
+    routeString: 'KLAS07R.COWBY6.GUP'
+};
+
+export const AIRCRAFT_MOCK_WITH_POSITIVE_HEADING = Object.assign({}, AIRCRAFT_MOCK_BASE, {
+    heading: 5.7596
+});
+
+export const AIRCRAFT_MOCK_WITH_NEGATIVE_HEADING = Object.assign({}, AIRCRAFT_MOCK_BASE, {
+    heading: -0.5236
+});
+
+export const RUN_SAY_HEADING_RESULT = [
+    true,
+    {
+        log: 'heading 330',
+        say: 'heading three three zero'
+    }
+];

--- a/test/aircraft/_mocks/aircraftCommanderMocks.js
+++ b/test/aircraft/_mocks/aircraftCommanderMocks.js
@@ -19,18 +19,45 @@ export const AIRCRAFT_MOCK_BASE = {
     routeString: 'KLAS07R.COWBY6.GUP'
 };
 
-export const AIRCRAFT_MOCK_WITH_POSITIVE_HEADING = Object.assign({}, AIRCRAFT_MOCK_BASE, {
-    heading: 5.7596
+// Directly north
+export const AIRCRAFT_MOCK_WITH_NORTH_HEADING = Object.assign({}, AIRCRAFT_MOCK_BASE, {
+    heading: 0
 });
 
-export const AIRCRAFT_MOCK_WITH_NEGATIVE_HEADING = Object.assign({}, AIRCRAFT_MOCK_BASE, {
-    heading: -0.5236
+// North easterly (45)
+export const AIRCRAFT_MOCK_WITH_NE_HEADING = Object.assign({}, AIRCRAFT_MOCK_BASE, {
+    heading: 0.7854
 });
 
-export const RUN_SAY_HEADING_RESULT = [
+// South westerly (225)
+export const AIRCRAFT_MOCK_WITH_POSITIVE_SW_HEADING = Object.assign({}, AIRCRAFT_MOCK_BASE, {
+    heading: 3.9270
+});
+
+// South westerly (-135)
+export const AIRCRAFT_MOCK_WITH_NEGATIVE_SW_HEADING = Object.assign({}, AIRCRAFT_MOCK_BASE, {
+    heading: -2.3562
+});
+
+export const RUN_SAY_HEADING_RESULT_NORTH = [
     true,
     {
-        log: 'heading 330',
-        say: 'heading three three zero'
+        log: 'heading 360',
+        say: 'heading three six zero'
+    }
+];
+
+export const RUN_SAY_HEADING_RESULT_NE = [
+    true,
+    {
+        log: 'heading 045',
+        say: 'heading zero four five'
+    }
+];
+export const RUN_SAY_HEADING_RESULT_SW = [
+    true,
+    {
+        log: 'heading 225',
+        say: 'heading two two five'
     }
 ];


### PR DESCRIPTION
Resolves #1446 

The purpose of this pull request is to ensure that heading returned by the `runSayHeading` and `runSayAssignedHeading` read-backs are normalised to 0° and 360°