### PR TITLE
enhancement/1402 - Prevent assignment of reserved or nondiscrete beacon codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - <a href="https://github.com/openscope/openscope/issues/1451" target="_blank">#1451</a> - Add ability to specify the radial with the `hold` command
 - <a href="https://github.com/openscope/openscope/issues/1458" target="_blank">#1458</a> - Add support for holding patterns with distance-based legs
 - <a href="https://github.com/openscope/openscope/issues/1431" target="_blank">#1431</a> - Expand capabilities for predefined holding patterns in airport files
+- <a href="https://github.com/openscope/openscope/issues/1402" target="_blank">#1402</a> - Prevent assignment of reserved/nondiscrete beacon codes
 
 # 6.14.2 (October 17, 2019)
 ### Hotfixes

--- a/src/assets/scripts/client/aircraft/AircraftController.js
+++ b/src/assets/scripts/client/aircraft/AircraftController.js
@@ -13,51 +13,18 @@ import StripViewController from './StripView/StripViewController';
 import GameController, { GAME_EVENTS } from '../game/GameController';
 import { airlineNameAndFleetHelper } from '../airline/airlineHelpers';
 import { convertStaticPositionToDynamic } from '../base/staticPositionToDynamicPositionHelper';
-import {
-    abs,
-    generateRandomOctalWithLength
-} from '../math/core';
+import { abs } from '../math/core';
 import { distance2d } from '../math/distance';
 import { speech_say } from '../speech';
+import { generateTransponderCode, isDiscreteTransponderCode, isValidTransponderCode } from '../utilities/transponderUtilities';
 import { km } from '../utilities/unitConverters';
 import { isEmptyOrNotArray } from '../utilities/validatorUtilities';
 import { FLIGHT_CATEGORY } from '../constants/aircraftConstants';
 import { EVENT, AIRCRAFT_EVENT } from '../constants/eventNames';
-import {
-    INVALID_INDEX,
-    REGEX
-} from '../constants/globalConstants';
+import { INVALID_INDEX } from '../constants/globalConstants';
 
 // Temporary const declaration here to attach to the window AND use as internal property
 const aircraft = {};
-
-/**
- * List of transponder codes that are invalid for random assignment
- *
- * This enum should be used only during the generation of
- * `AircraftModel` objects.
- *
- * The codes listed should still be assignable at the
- * controler's discretion
- *
- * @property RESERVED_SQUAWK_CODES
- * @type {array<number>}
- * @final
- */
-const RESERVED_SQUAWK_CODES = [
-    // VFR
-    1200,
-    // gliders
-    1202,
-    // hijack
-    7500,
-    // communication failure
-    7600,
-    // emergency
-    7700,
-    // military
-    7777
-];
 
 /**
  *
@@ -131,7 +98,7 @@ export default class AircraftController {
          * so we can know which codes are active.
          *
          * @property _transponderCodesInUse
-         * @type {array<number>}
+         * @type {array<string>}
          * @private
          */
         this._transponderCodesInUse = [];
@@ -546,7 +513,7 @@ export default class AircraftController {
      * @return {boolean}
      */
     onRequestToChangeTransponderCode = (transponderCode, aircraftModel) => {
-        if (!this._isValidTransponderCode(transponderCode) || this._isTransponderCodeInUse(transponderCode)) {
+        if (!isValidTransponderCode(transponderCode) || this._isTransponderCodeInUse(transponderCode)) {
             return false;
         }
 
@@ -658,18 +625,19 @@ export default class AircraftController {
      *
      * @for AircraftController
      * @method _generateUniqueTransponderCode
-     * @return {number}
+     * @return {string}
      * @private
      */
     _generateUniqueTransponderCode() {
-        const transponderCode = generateRandomOctalWithLength(4);
+        let transponderCode = generateTransponderCode();
+        const { icao } = AirportController.airport_get();
 
-        if (!this._isDiscreteTransponderCode(transponderCode) || this._isTransponderCodeInUse(transponderCode)) {
+        if (!isDiscreteTransponderCode(icao, transponderCode) || this._isTransponderCodeInUse(transponderCode)) {
             // the value generated is already in use, recurse back through this method and try again
-            this._generateUniqueTransponderCode();
+            transponderCode = this._generateUniqueTransponderCode();
+        } else {
+            this._addTransponderCodeToInUse(transponderCode);
         }
-
-        this._addTransponderCodeToInUse(transponderCode);
 
         return transponderCode;
     }
@@ -679,7 +647,7 @@ export default class AircraftController {
      *
      * @for AircraftController
      * @method _addTransponderCodeToInUse
-     * @param transponderCode {number}
+     * @param transponderCode {string}
      */
     _addTransponderCodeToInUse(transponderCode) {
         this._transponderCodesInUse.push(transponderCode);
@@ -690,7 +658,7 @@ export default class AircraftController {
      *
      * @for AircraftController
      * @method _removeTransponderCodeFromUse
-     * @param transponderCode {number}
+     * @param transponderCode {string}
      */
     _removeTransponderCodeFromUse({ transponderCode }) {
         this._transponderCodesInUse = _without(this._transponderCodesInUse, transponderCode);
@@ -702,40 +670,11 @@ export default class AircraftController {
      *
      * @for AircraftController
      * @method _isTransponderCodeInUse
-     * @param transponderCode {number}
+     * @param transponderCode {string}
      * @return {booelean}
      */
     _isTransponderCodeInUse(transponderCode) {
         return this._transponderCodesInUse.indexOf(transponderCode) !== INVALID_INDEX;
-    }
-
-    /**
-     * Boolean helper used to determine if a given `transponderCode` is both
-     * the correct length and an octal number.
-     *
-     * @for AircraftController
-     * @method _isValidTransponderCode
-     * @param transponderCode {number}
-     * @return {boolean}
-     */
-    _isValidTransponderCode(transponderCode) {
-        return REGEX.TRANSPONDER_CODE.test(transponderCode);
-    }
-
-    /**
-     * Helper used to determine if a given `transponderCode` is both
-     * valid and not in use.
-     *
-     * @for AircraftController
-     * @method _isDiscreteTransponderCode
-     * @param transponderCode {number}
-     * @return {boolean}
-     */
-    _isDiscreteTransponderCode(transponderCode) {
-        const isValidCode = this._isValidTransponderCode(transponderCode);
-        const isReservedCode = RESERVED_SQUAWK_CODES.indexOf(transponderCode) !== INVALID_INDEX;
-
-        return isValidCode && !isReservedCode;
     }
 
     /**

--- a/src/assets/scripts/client/aircraft/AircraftController.js
+++ b/src/assets/scripts/client/aircraft/AircraftController.js
@@ -577,7 +577,7 @@ export default class AircraftController {
         }
 
         const dynamicPositionModel = convertStaticPositionToDynamic(spawnPatternModel.positionModel);
-        const transponderCode = this._generateUniqueTransponderCode();
+        const transponderCode = this._generateUniqueTransponderCode(AirportController.airport_get().icao);
 
         return {
             fleet,
@@ -621,23 +621,24 @@ export default class AircraftController {
      * Generate a unique `transponderCode`
      *
      * This method should only be run while building props for a
-     * soon-to-be-instantiated `AircraftModel`
+     * soon-to-be-instantiated `AircraftModel` at the specified
+     * `icao` airport code
      *
      * @for AircraftController
      * @method _generateUniqueTransponderCode
+     * @param icao {sting}
      * @return {string}
      * @private
      */
-    _generateUniqueTransponderCode() {
-        let transponderCode = generateTransponderCode();
-        const { icao } = AirportController.airport_get();
+    _generateUniqueTransponderCode(icao) {
+        const transponderCode = generateTransponderCode();
 
         if (!isDiscreteTransponderCode(icao, transponderCode) || this._isTransponderCodeInUse(transponderCode)) {
-            // the value generated is already in use, recurse back through this method and try again
-            transponderCode = this._generateUniqueTransponderCode();
-        } else {
-            this._addTransponderCodeToInUse(transponderCode);
+            // the value generated isn't valid or is already in use, recurse back through this method and try again
+            return this._generateUniqueTransponderCode(icao);
         }
+
+        this._addTransponderCodeToInUse(transponderCode);
 
         return transponderCode;
     }

--- a/src/assets/scripts/client/utilities/transponderUtilities.js
+++ b/src/assets/scripts/client/utilities/transponderUtilities.js
@@ -21,6 +21,8 @@ const MAX_TRANSPONDER_CODE = 4095;
  * The codes listed should still be assignable at the
  * controler's discretion
  *
+ * Source: https://en.wikipedia.org/wiki/List_of_transponder_codes
+ *
  * @property TRANSPONDER_CODES
  * @type {array<object>}
  * @final
@@ -48,7 +50,9 @@ const TRANSPONDER_CODES = [
         // Belgium
         prefix: /^eb/,
         reserved: [
-            /^00(4[1-6]|5[0-7])$/,
+            // Assigned for VFR traffic under Flight Information Services (BXL FIC)
+            // 0041–0057
+            /^00(4[1-7]|5[0-7])$/,
             // For testing stations
             '7777'
         ]
@@ -76,7 +80,11 @@ const TRANSPONDER_CODES = [
         prefix: /^eg/,
         reserved: [
             // Parachute drop
-            '0033'
+            '0033',
+            // Sudden military climb out from low-level operations
+            '7001',
+            // Aerobatic & displays
+            '7004'
         ]
     },
     {
@@ -85,14 +93,48 @@ const TRANSPONDER_CODES = [
         reserved: [
             // VFR - 12xx
             /^12[0-7][0-7]$/,
+            // Reserved for use by SR-71, YF-12, U-2 and B-57, pressure suit flights,
+            // and aircraft operations above FL600. And many others
+            // 4400–4477
+            /^44[0-7]{2}$/,
+            // Reserved for use by Continental NORAD Region (CONR)
+            // 7501–7577
+            /^75(0[1-7]|[1-7][0-7])$/,
+            // Reserved for special use by FAA
+            // 7601–7607, 7701–7707
+            /^7[67]0[1-7]$/,
+            // External ARTCC subsets (Discrete codes of blocks only except for first primary
+            // block, which is used as the ARTCC's non-discrete code if all discrete codes are assigned)
+            // Not reserved as it implies they are useable
+            // 7610–7676, 7710–7776
+            // /^7[67]([1-6][0-7]|7[1-6])$/,
             // Military & for testing stations
             '7777'
+        ]
+    },
+    // {
+    //     // Washington DC
+    //     prefix: /^k/,
+    //     reserved: [
+    //         // Reserved for special use by Potomac TRACON
+    //         // 5061–5062
+    //         /^506[12]$/
+    //     ]
+    // },
+    {
+        // France
+        prefix: /^lf/,
+        reserved: [
+            // VFR
+            '7001'
         ]
     },
     {
         // Australia
         prefix: /^y/,
         reserved: [
+            // Civil flights engaged in littoral surveillance
+            '7615'
         ]
     }
 ];

--- a/src/assets/scripts/client/utilities/transponderUtilities.js
+++ b/src/assets/scripts/client/utilities/transponderUtilities.js
@@ -123,6 +123,7 @@ const TRANSPONDER_CODES = [
  * @method _getCodes
  * @param icao {string}
  * @returns {array}
+ * @private
  */
 function _getCodes(icao) {
     return TRANSPONDER_CODES.filter((item) => {
@@ -136,6 +137,7 @@ function _getCodes(icao) {
  *
  * @param transponderCode {string}
  * @param testAgainst {string|RegExp}
+ * @private
  */
 function _isMatch(transponderCode, testAgainst) {
     if (testAgainst instanceof RegExp) {
@@ -150,16 +152,6 @@ function _isMatch(transponderCode, testAgainst) {
 }
 
 /**
- * Helper used to generate a new 4 digit octal transponder code
- *
- * @returns {string}
- */
-export const generateTransponderCode = () => {
-    const code = randint(0, MAX_TRANSPONDER_CODE).toString(8);
-    return leftPad(code, 4);
-};
-
-/**
  * Helper used to determine if a given `transponderCode` is reserved
  * in the country or region of the specified `icao` airport code
  *
@@ -167,11 +159,22 @@ export const generateTransponderCode = () => {
  * @param icao {string}
  * @param transponderCode {string}
  * @returns {boolean}
+ * @private
  */
-export const isReserved = (icao, transponderCode) => {
+function _isReserved(icao, transponderCode) {
     return _getCodes(icao).some((item) => {
         return item.reserved.some((test) => _isMatch(transponderCode, test));
     });
+}
+
+/**
+ * Helper used to generate a new 4 digit octal transponder code
+ *
+ * @returns {string}
+ */
+export const generateTransponderCode = () => {
+    const code = randint(0, MAX_TRANSPONDER_CODE).toString(8);
+    return leftPad(code, 4);
 };
 
 /**
@@ -205,5 +208,5 @@ export const isDiscreteTransponderCode = (icao, transponderCode) => {
         return false;
     }
 
-    return !isReserved(icao, transponderCode);
+    return !_isReserved(icao, transponderCode);
 };

--- a/src/assets/scripts/client/utilities/transponderUtilities.js
+++ b/src/assets/scripts/client/utilities/transponderUtilities.js
@@ -3,6 +3,16 @@ import { randint } from '../math/core';
 import { REGEX } from '../constants/globalConstants';
 
 /**
+ * The highest decimal value allowed for a 4-digit
+ * octal transponder code
+ *
+ * @property MAX_TRANSPONDER_CODE
+ * @type {number}
+ * @final
+ */
+const MAX_TRANSPONDER_CODE = 4095;
+
+/**
  * List of transponder codes that are reserved
  *
  * This enum should be used only during the generation of
@@ -11,11 +21,11 @@ import { REGEX } from '../constants/globalConstants';
  * The codes listed should still be assignable at the
  * controler's discretion
  *
- * @property SQUAWK_CODES
+ * @property TRANSPONDER_CODES
  * @type {array<object>}
  * @final
  */
-const SQUAWK_CODES = [
+const TRANSPONDER_CODES = [
     {
         // ICAO
         prefix: null,
@@ -115,7 +125,7 @@ const SQUAWK_CODES = [
  * @returns {array}
  */
 function _getCodes(icao) {
-    return SQUAWK_CODES.filter((item) => {
+    return TRANSPONDER_CODES.filter((item) => {
         return item.prefix === null || item.prefix.test(icao);
     });
 }
@@ -145,7 +155,7 @@ function _isMatch(transponderCode, testAgainst) {
  * @returns {string}
  */
 export const generateTransponderCode = () => {
-    const code = randint(0, 4095).toString(8);
+    const code = randint(0, MAX_TRANSPONDER_CODE).toString(8);
     return leftPad(code, 4);
 };
 

--- a/src/assets/scripts/client/utilities/transponderUtilities.js
+++ b/src/assets/scripts/client/utilities/transponderUtilities.js
@@ -1,0 +1,185 @@
+import { REGEX } from '../constants/globalConstants';
+
+/**
+ * List of transponder codes that are reserved
+ *
+ * This enum should be used only during the generation of
+ * `AircraftModel` objects.
+ *
+ * The codes listed should still be assignable at the
+ * controler's discretion
+ *
+ * @property SQUAWK_CODES
+ * @type {array<object>}
+ * @final
+ */
+const SQUAWK_CODES = [
+    {
+        // ICAO
+        prefix: null,
+        reserved: [
+            // Use in Mode S environment
+            '1000',
+            // When entering SSR area from non-SSR as uncontrolled IFR
+            '2000',
+            // VFR when no other code has been assigned (eg 1200 is used in the USA)
+            '7000',
+            // hijack
+            '7500',
+            // communication failure
+            '7600',
+            // emergency
+            '7700'
+        ]
+    },
+    {
+        // Europe
+        prefix: /^([elb])/,
+        reserved: [
+            '0000'
+        ]
+    },
+    {
+        // Canda
+        prefix: /^c/,
+        reserved: [
+
+        ]
+    },
+    {
+        // Belgium
+        prefix: /^eb/,
+        reserved: [
+            /^00(4[1-6]|5[0-7])$/,
+            // For testing stations
+            '7777'
+        ]
+    },
+    {
+        // Germany
+        prefix: /^e[dt]/,
+        reserved: [
+            // Parachute dropping
+            '0025',
+            // For testing stations
+            '7777'
+        ]
+    },
+    {
+        // Netherlands
+        prefix: /^eh/,
+        reserved: [
+            // For testing stations
+            '7777'
+        ]
+    },
+    {
+        // UK
+        prefix: /^eg/,
+        reserved: [
+            // Parachute drop
+            '0033'
+        ]
+    },
+    {
+        // USA
+        prefix: /^k/,
+        reserved: [
+            // Military intercept
+            '0000',
+            // VFR - 12xx
+            /^12[0-7][0-7]$/,
+            // Military & for testing stations
+            '7777'
+        ]
+    },
+    {
+        // Australia
+        prefix: /^y/,
+        reserved: [
+            // Flights operating at aerodromes (in lieu of codes 1200, 2000 or 3000 when assigned by ATC or noted in the Enroute Supplement)
+            '0100'
+        ]
+    }
+];
+
+/**
+ * Gets the array of squawk code objects that match the specifed ICAO airport code
+ *
+ * @method _getCodes
+ * @param icao {string}
+ * @returns {array}
+ */
+function _getCodes(icao) {
+    return SQUAWK_CODES.filter((item) => {
+        return item.prefix === null || item.prefix.test(icao);
+    });
+}
+
+/**
+ * Helper used to test if the `transponderCode` matches the
+ * String or RegExp in `against`
+ *
+ * @param transponderCode {string}
+ * @param testAgainst {string|RegExp}
+ */
+function _isMatch(transponderCode, testAgainst) {
+    if (testAgainst instanceof RegExp) {
+        return testAgainst.test(transponderCode);
+    } else if (typeof testAgainst === 'string') {
+        return transponderCode === testAgainst;
+    }
+
+    throw new TypeError(
+        `Invalid parameter for testAgainst, expected string or RegExp, but got ${typeof testAgainst}`
+    );
+}
+
+/**
+ * Helper used to determine if a given `transponderCode` is reserved
+ * in the country or region of the specified `icao` airport code
+ *
+ * @method _isReserved
+ * @param icao {string}
+ * @param transponderCode {string}
+ * @returns {boolean}
+ */
+export const isReserved = (icao, transponderCode) => {
+    return _getCodes(icao).some((item) => {
+        return item.reserved.some((test) => _isMatch(transponderCode, test));
+    });
+};
+
+/**
+ * Boolean helper used to determine if a given `transponderCode` is both
+ * the correct length and an octal number.
+ *
+ * @method isValidTransponderCode
+ * @param transponderCode {string}
+ * @return {boolean}
+ */
+export const isValidTransponderCode = (transponderCode) => {
+    return REGEX.TRANSPONDER_CODE.test(transponderCode);
+};
+
+/**
+ * Helper used to determine if a given `transponderCode` is both
+ * valid and not in reserved in the country or region of the
+ * specified `icao` airport code
+ *
+ * @method isDiscreteTransponderCode
+ * @param icao {string}
+ * @param transponderCode {string}
+ * @return {boolean}
+ */
+export const isDiscreteTransponderCode = (icao, transponderCode) => {
+    if (!isValidTransponderCode(transponderCode)) {
+        return false;
+    }
+
+    if (transponderCode.endsWith('00')) {
+        return false;
+    }
+
+    return !isReserved(icao, transponderCode);
+};

--- a/src/assets/scripts/client/utilities/transponderUtilities.js
+++ b/src/assets/scripts/client/utilities/transponderUtilities.js
@@ -30,33 +30,18 @@ const TRANSPONDER_CODES = [
         // ICAO
         prefix: null,
         reserved: [
-            // Use in Mode S environment
-            '1000',
-            // When entering SSR area from non-SSR as uncontrolled IFR
-            '2000',
-            // VFR when no other code has been assigned (eg 1200 is used in the USA)
-            '7000',
-            // hijack
-            '7500',
-            // communication failure
-            '7600',
-            // emergency
-            '7700'
         ]
     },
     {
         // Europe
         prefix: /^([elb])/,
         reserved: [
-            '0000'
         ]
     },
     {
         // Canda
         prefix: /^c/,
         reserved: [
-            // VFR
-            '1200'
         ]
     },
     {
@@ -98,8 +83,6 @@ const TRANSPONDER_CODES = [
         // USA
         prefix: /^k/,
         reserved: [
-            // Military intercept
-            '0000',
             // VFR - 12xx
             /^12[0-7][0-7]$/,
             // Military & for testing stations
@@ -110,9 +93,6 @@ const TRANSPONDER_CODES = [
         // Australia
         prefix: /^y/,
         reserved: [
-            // Flights operating at aerodromes (in lieu of codes 1200, 2000 or 3000 when assigned
-            // by ATC or noted in the Enroute Supplement)
-            '0100'
         ]
     }
 ];
@@ -127,7 +107,8 @@ const TRANSPONDER_CODES = [
  */
 function _getCodes(icao) {
     return TRANSPONDER_CODES.filter((item) => {
-        return item.prefix === null || item.prefix.test(icao);
+        return (item.prefix === null || item.prefix.test(icao)) &&
+            item.reserved.length !== 0;
     });
 }
 

--- a/src/assets/scripts/client/utilities/transponderUtilities.js
+++ b/src/assets/scripts/client/utilities/transponderUtilities.js
@@ -1,3 +1,5 @@
+import { leftPad } from './generalUtilities';
+import { randint } from '../math/core';
 import { REGEX } from '../constants/globalConstants';
 
 /**
@@ -43,7 +45,8 @@ const SQUAWK_CODES = [
         // Canda
         prefix: /^c/,
         reserved: [
-
+            // VFR
+            '1200'
         ]
     },
     {
@@ -97,7 +100,8 @@ const SQUAWK_CODES = [
         // Australia
         prefix: /^y/,
         reserved: [
-            // Flights operating at aerodromes (in lieu of codes 1200, 2000 or 3000 when assigned by ATC or noted in the Enroute Supplement)
+            // Flights operating at aerodromes (in lieu of codes 1200, 2000 or 3000 when assigned
+            // by ATC or noted in the Enroute Supplement)
             '0100'
         ]
     }
@@ -136,6 +140,16 @@ function _isMatch(transponderCode, testAgainst) {
 }
 
 /**
+ * Helper used to generate a new 4 digit octal transponder code
+ *
+ * @returns {string}
+ */
+export const generateTransponderCode = () => {
+    const code = randint(0, 4095).toString(8);
+    return leftPad(code, 4);
+};
+
+/**
  * Helper used to determine if a given `transponderCode` is reserved
  * in the country or region of the specified `icao` airport code
  *
@@ -164,7 +178,7 @@ export const isValidTransponderCode = (transponderCode) => {
 
 /**
  * Helper used to determine if a given `transponderCode` is both
- * valid and not in reserved in the country or region of the
+ * valid and not reserved in the country or region of the
  * specified `icao` airport code
  *
  * @method isDiscreteTransponderCode

--- a/test/utilities/transponderUtilities.spec.js
+++ b/test/utilities/transponderUtilities.spec.js
@@ -1,11 +1,16 @@
 import ava from 'ava';
 import {
-    isDiscreteTransponderCode
+    generateTransponderCode, isDiscreteTransponderCode, isValidTransponderCode
 } from '../../src/assets/scripts/client/utilities/transponderUtilities';
 
 const USA_ICAO = 'klax';
 const UK_ICAO = 'egll';
-const GERMAN_ICAO = 'eddf';
+
+ava('generateTransponderCode returns a valid transponder code', (t) => {
+    // This is basically pointless, as we're testing random output...
+    const code = generateTransponderCode();
+    t.true(isValidTransponderCode(code));
+});
 
 ava('isDiscreteTransponderCode returns false for invalid squawk code', (t) => {
     t.false(isDiscreteTransponderCode(USA_ICAO, '1239'));
@@ -29,4 +34,14 @@ ava('isDiscreteTransponderCode returns false when given VFR codes', (t) => {
 
     t.true(isDiscreteTransponderCode(UK_ICAO, '1201')); // 1201 is allowed in the UK
     t.false(isDiscreteTransponderCode(UK_ICAO, '7000'));
+});
+
+ava('isValidTransponderCode returns true when given a valid transponder code', (t) => {
+    t.true(isValidTransponderCode('0000'));
+    t.true(isValidTransponderCode('7777'));
+});
+
+ava('isValidTransponderCode returns false when given a invalid transponder code', (t) => {
+    t.false(isValidTransponderCode('777'));
+    t.false(isValidTransponderCode('7778'));
 });

--- a/test/utilities/transponderUtilities.spec.js
+++ b/test/utilities/transponderUtilities.spec.js
@@ -1,0 +1,32 @@
+import ava from 'ava';
+import {
+    isDiscreteTransponderCode
+} from '../../src/assets/scripts/client/utilities/transponderUtilities';
+
+const USA_ICAO = 'klax';
+const UK_ICAO = 'egll';
+const GERMAN_ICAO = 'eddf';
+
+ava('isDiscreteTransponderCode returns false for invalid squawk code', (t) => {
+    t.false(isDiscreteTransponderCode(USA_ICAO, '1239'));
+});
+
+ava('isDiscreteTransponderCode returns false when given a non-discrete squawk', (t) => {
+    t.false(isDiscreteTransponderCode(UK_ICAO, '3600'));
+});
+
+ava('isDiscreteTransponderCode returns false when given restricted squawks for the USA', (t) => {
+    t.false(isDiscreteTransponderCode(USA_ICAO, '7500'));
+    t.false(isDiscreteTransponderCode(USA_ICAO, '7600'));
+    t.false(isDiscreteTransponderCode(USA_ICAO, '7700'));
+    t.false(isDiscreteTransponderCode(USA_ICAO, '7777'));
+});
+
+ava('isDiscreteTransponderCode returns false when given VFR codes', (t) => {
+    t.false(isDiscreteTransponderCode(USA_ICAO, '1200'));
+    t.false(isDiscreteTransponderCode(USA_ICAO, '1202'));
+    t.false(isDiscreteTransponderCode(USA_ICAO, '1277'));
+
+    t.true(isDiscreteTransponderCode(UK_ICAO, '1201')); // 1201 is allowed in the UK
+    t.false(isDiscreteTransponderCode(UK_ICAO, '7000'));
+});

--- a/test/utilities/transponderUtilities.spec.js
+++ b/test/utilities/transponderUtilities.spec.js
@@ -6,6 +6,16 @@ import {
 const USA_ICAO = 'klax';
 const UK_ICAO = 'egll';
 
+ava('isDiscreteTransponderCode returns false for all non-discrete codes', (t) => {
+    // Loops are not ideal, but it saves writing 64 identical tests!
+    for (let i = 0; i < 8; i++) {
+        for (let j = 0; j < 8; j++) {
+            const squawk = `${i}${j}00`;
+            t.false(isDiscreteTransponderCode(squawk));
+        }
+    }
+});
+
 ava('generateTransponderCode returns a valid transponder code', (t) => {
     // This is basically pointless, as we're testing random output...
     const code = generateTransponderCode();


### PR DESCRIPTION
Resolves #1402 

The purpose of this pull request is to fix the following:
1. Fix invalid or duplicate transponder codes being added into `_transponderCodesInUse` due to incorrect recursion
2. Fix issue with transponder codes not being compared correctly to the reserved list (string vs number)
3. Add region specific restricted transponder codes, eg. 1202 is reserved for VFR in the USA but not in the UK. ~~**Incomplete**~~

This slightly duplicates the work done in #1350 but as that's been orphaned it might we worth revisiting that later - implementing the Cid lookup as suggested by Erik.