### PR TITLE
bugfix/1448 - Lower KSFO arrival spawn altitudes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#1432](https://github.com/openscope/openscope/issues/1432) - Prevent aircraft from leaving their holding patterns
 - [#1440](https://github.com/openscope/openscope/issues/1440) - Add missing "b738"-fleet to TUI Airways
 - [#23](https://github.com/openscope/openscope/issues/23) - Ensure focus remains on the text input box in MS Edge
+- [#1448](https://github.com/openscope/openscope/issues/1448) - Lower spawn altitudes of KSFO arrivals so can comply with STAR restrictions
 
 
 ### Enhancements & Refactors

--- a/assets/airports/ksfo.json
+++ b/assets/airports/ksfo.json
@@ -1229,8 +1229,8 @@
             "destination": "KSFO",
             "category": "arrival",
             "route": "AMAKR.BDEGA3.KSFO28L",
-            "altitude": [37000, 41000],
-            "speed": 320,
+            "altitude": 33000,
+            "speed": 300,
             "method": "random",
             "rate": 10,
             "airlines": [
@@ -1265,8 +1265,8 @@
             "destination": "KSFO",
             "category": "arrival",
             "route": "INYOE.DYAMD5.KSFO28R",
-            "altitude": [30000, 40000],
-            "speed": 320,
+            "altitude": 34000,
+            "speed": 300,
             "method": "random",
             "rate": 12,
             "airlines": [
@@ -1290,8 +1290,8 @@
             "destination": "KSFO",
             "category": "arrival",
             "route": "PAINT.PIRAT2.KSFO28L",
-            "altitude": [24000, 32000],
-            "speed": 320,
+            "altitude": 31000,
+            "speed": 300,
             "method": "random",
             "rate": 5,
             "airlines": [
@@ -1313,8 +1313,8 @@
             "destination": "KSFO",
             "category": "arrival",
             "route": "SERFR.SERFR3.KSFO28R",
-            "altitude": [24000, 32000],
-            "speed": 320,
+            "altitude": 26000,
+            "speed": 300,
             "method": "random",
             "rate": 8,
             "airlines": [


### PR DESCRIPTION
Resolves #1448.

Lower spawn altitudes of KSFO arrivals so can comply with STAR restrictions
