### PR TITLE
enhancement/1451 - Add ability to specify the radial for a hold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Bugfixes
 
 ### Enhancements & Refactors
-
+- [#1451](https://github.com/openscope/openscope/issues/1451) - Add ability to specify the radial with the `hold` command
 
 # 6.14.2 (October 17, 2019)
 ### Hotfixes

--- a/documentation/aircraft-commands.md
+++ b/documentation/aircraft-commands.md
@@ -175,14 +175,14 @@ pattern until further notice. The direction (left/right) may be specified,
 as well as the leg length (in minutes), as well as the fix to hold over.
 But you may also omit those specifications, in which case, the aircraft
 will enter a standard holding pattern over their present position (right
-turns, 1 minute legs, using the current bearing to the fix as the inbound
+turns, 1 minute legs, using the reciprocal bearing to the fix as the outbound
 radial). To clear the aircraft out of the hold, either clear it direct to
 a fix or assign it a new heading.
 
 _Parameters -_ Specify the direction of turns during the hold with `right`
 or `left`, the leg length, with `[time]min`, the fix to hold over
 with simply `[fixname]` and the `radial` (a 3-digit course, eg. 009) which
-defines the inbound leg. Any combination of these arguments provided in any
+defines the outbound leg. Any combination of these arguments provided in any
 order is acceptable, as long as the command `hold` comes first.
 
 _Syntax -_ `AAL123 hold [fixname] [left|right] [leg_time]min [radial]` or `AAL123 hold`

--- a/documentation/aircraft-commands.md
+++ b/documentation/aircraft-commands.md
@@ -175,15 +175,17 @@ pattern until further notice. The direction (left/right) may be specified,
 as well as the leg length (in minutes), as well as the fix to hold over.
 But you may also omit those specifications, in which case, the aircraft
 will enter a standard holding pattern over their present position (right
-turns, 1 minute legs). To clear the aircraft out of the hold, either
-clear it direct to a fix or assign it a new heading.
+turns, 1 minute legs, using the current bearing to the fix as the inbound
+radial). To clear the aircraft out of the hold, either clear it direct to
+a fix or assign it a new heading.
 
 _Parameters -_ Specify the direction of turns during the hold with `right`
-or `left`, the leg length, with `[time]min`, and the fix to hold over
-with simply `[fixname]`. Any combination of these arguments provided in
-any order is acceptable, as long as the command `hold` comes first.
+or `left`, the leg length, with `[time]min`, the fix to hold over
+with simply `[fixname]` and the `radial` (a 3-digit course, eg. 009) which
+defines the inbound leg. Any combination of these arguments provided in any
+order is acceptable, as long as the command `hold` comes first.
 
-_Syntax -_ `AAL123 hold [fixname] [left|right] [leg_time]min` or `AAL123 hold`
+_Syntax -_ `AAL123 hold [fixname] [left|right] [leg_time]min [radial]` or `AAL123 hold`
 
 ### Exit Hold
 

--- a/documentation/aircraft-commands.md
+++ b/documentation/aircraft-commands.md
@@ -181,7 +181,7 @@ a fix or assign it a new heading.
 
 _Parameters -_ Specify the direction of turns during the hold with `right`
 or `left`, the leg length, with `[time]min`, the fix to hold over
-with simply `[fixname]` and the `radial` (a 3-digit course, eg. 009) which
+with simply `[fixname]` and the `radial` (a 3-digit course, eg. 001 to 360) which
 defines the outbound leg. Any combination of these arguments provided in any
 order is acceptable, as long as the command `hold` comes first.
 

--- a/src/assets/scripts/client/aircraft/AircraftCommander.js
+++ b/src/assets/scripts/client/aircraft/AircraftCommander.js
@@ -308,15 +308,17 @@ export default class AircraftCommander {
             return [false, `unable to hold at unknown fix ${fixName}`];
         }
 
+        let inboundHeading = fixModel.positionModel.bearingFromPosition(aircraft.positionModel);
+
         // Radial is given as the outbound course, so it needs to be inverted
-        const inboundHeading = radial === null ?
-            fixModel.positionModel.bearingFromPosition(aircraft.positionModel) :
-            radians_normalize(degreesToRadians(radial) + Math.PI);
+        if (radial !== null) {
+            inboundHeading = radians_normalize(degreesToRadians(radial) + Math.PI);
+        }
 
         const holdParameters = {
             turnDirection,
             legLength,
-            inboundHeading: inboundHeading
+            inboundHeading
         };
 
         return aircraft.pilot.initiateHoldingPattern(fixName, holdParameters);

--- a/src/assets/scripts/client/aircraft/AircraftCommander.js
+++ b/src/assets/scripts/client/aircraft/AircraftCommander.js
@@ -21,7 +21,7 @@ import {
     radio_heading,
     radio_altitude
 } from '../utilities/radioUtilities';
-import { heading_to_string, radiansToDegrees } from '../utilities/unitConverters';
+import { heading_to_string, radiansToDegrees, degreesToRadians } from '../utilities/unitConverters';
 
 /**
  *
@@ -300,9 +300,7 @@ export default class AircraftCommander {
      * @return {array} [success of operation, readback]
      */
     runHold(aircraft, data) {
-        const turnDirection = data[0];
-        const legLength = data[1];
-        const fixName = data[2];
+        const [turnDirection, legLength, fixName, inboundHeading] = data;
         const fixModel = NavigationLibrary.findFixByName(fixName);
 
         if (!fixModel) {
@@ -312,7 +310,9 @@ export default class AircraftCommander {
         const holdParameters = {
             turnDirection,
             legLength,
-            inboundHeading: fixModel.positionModel.bearingFromPosition(aircraft.positionModel)
+            inboundHeading: inboundHeading === null ?
+                fixModel.positionModel.bearingFromPosition(aircraft.positionModel) :
+                degreesToRadians(inboundHeading)
         };
 
         return aircraft.pilot.initiateHoldingPattern(fixName, holdParameters);

--- a/src/assets/scripts/client/aircraft/Pilot/Pilot.js
+++ b/src/assets/scripts/client/aircraft/Pilot/Pilot.js
@@ -757,6 +757,7 @@ export default class Pilot {
      * @return {array} [success of operation, readback]
      */
     initiateHoldingPattern(fixName, holdParameters) {
+        const radial = heading_to_string(holdParameters.inboundHeading);
         const cardinalDirectionFromFix = getRadioCardinalDirectionNameForHeading(holdParameters.inboundHeading);
         const problematicResponse = this._fms.activateHoldForWaypointName(fixName, holdParameters);
 
@@ -765,11 +766,13 @@ export default class Pilot {
         }
 
         const holdParametersReadback = `${holdParameters.turnDirection} turns, ${holdParameters.legLength} legs`;
+        const radialReadbackLog = `on the ${radial} radial`;
+        const radialReadbackSay = `on the ${radio_heading(radial)} radial`;
 
         // force lower-case in verbal readback to get speech synthesis to pronounce the fix instead of spelling it
         return [true, {
-            log: `hold ${cardinalDirectionFromFix} of ${fixName.toUpperCase()}, ${holdParametersReadback}`,
-            say: `hold ${cardinalDirectionFromFix} of ${fixName.toLowerCase()}, ${holdParametersReadback}`
+            log: `hold ${cardinalDirectionFromFix} of ${fixName.toUpperCase()} ${radialReadbackLog}, ${holdParametersReadback}`,
+            say: `hold ${cardinalDirectionFromFix} of ${fixName.toLowerCase()} ${radialReadbackSay}, ${holdParametersReadback}`
         }];
     }
 

--- a/src/assets/scripts/client/aircraft/Pilot/Pilot.js
+++ b/src/assets/scripts/client/aircraft/Pilot/Pilot.js
@@ -757,7 +757,7 @@ export default class Pilot {
      * @return {array} [success of operation, readback]
      */
     initiateHoldingPattern(fixName, holdParameters) {
-        const radial = heading_to_string(holdParameters.inboundHeading);
+        const radial = heading_to_string(holdParameters.inboundHeading + Math.PI);
         const cardinalDirectionFromFix = getRadioCardinalDirectionNameForHeading(holdParameters.inboundHeading);
         const problematicResponse = this._fms.activateHoldForWaypointName(fixName, holdParameters);
 

--- a/src/assets/scripts/client/aircraft/Pilot/Pilot.js
+++ b/src/assets/scripts/client/aircraft/Pilot/Pilot.js
@@ -757,7 +757,7 @@ export default class Pilot {
      * @return {array} [success of operation, readback]
      */
     initiateHoldingPattern(fixName, holdParameters) {
-        const radial = heading_to_string(holdParameters.inboundHeading + Math.PI);
+        const radialText = heading_to_string(holdParameters.inboundHeading + Math.PI);
         const cardinalDirectionFromFix = getRadioCardinalDirectionNameForHeading(holdParameters.inboundHeading);
         const problematicResponse = this._fms.activateHoldForWaypointName(fixName, holdParameters);
 
@@ -766,8 +766,8 @@ export default class Pilot {
         }
 
         const holdParametersReadback = `${holdParameters.turnDirection} turns, ${holdParameters.legLength} legs`;
-        const radialReadbackLog = `on the ${radial} radial`;
-        const radialReadbackSay = `on the ${radio_heading(radial)} radial`;
+        const radialReadbackLog = `on the ${radialText} radial`;
+        const radialReadbackSay = `on the ${radio_heading(radialText)} radial`;
 
         // force lower-case in verbal readback to get speech synthesis to pronounce the fix instead of spelling it
         return [true, {

--- a/src/assets/scripts/client/constants/globalConstants.js
+++ b/src/assets/scripts/client/constants/globalConstants.js
@@ -33,6 +33,7 @@ export const REGEX = {
     LAT_LONG: /^([NESW])(\d+(\.\d+)?)([d °](\d+(\.\d+)?))?([m '](\d+(\.\d+)?))?$/,
     SW: /[SW]/,
     SINGLE_DOT: /\./g,
+    THREE_DIGIT_NUMBER: /^[0-9]{3}$/,
     TRANSPONDER_CODE: /^[0-7][0-7][0-7][0-7]$/,
     UNICODE: /[^\u0000-\u00ff]/,
     WHITESPACE: /\s/g

--- a/src/assets/scripts/client/parsers/aircraftCommandParser/aircraftCommandParserMessages.js
+++ b/src/assets/scripts/client/parsers/aircraftCommandParser/aircraftCommandParserMessages.js
@@ -27,6 +27,7 @@ export const ERROR_MESSAGE = {
     THREE_ARG_LENGTH: `${INVALID_ARG_LENGTH}. Expected exactly three arguments`,
     ZERO_OR_ONE_ARG_LENGTH: `${INVALID_ARG_LENGTH}. Expected zero or one argument`,
     ZERO_TO_THREE_ARG_LENGTH: `${INVALID_ARG_LENGTH}. Expected zero to three arguments`,
+    ZERO_TO_FOUR_ARG_LENGTH: `${INVALID_ARG_LENGTH}. Expected zero to four arguments`,
     ONE_OR_MORE_ARG_LENGTH: `${INVALID_ARG_LENGTH}. Expected one or more arguments`,
     ONE_OR_TWO_ARG_LENGTH: `${INVALID_ARG_LENGTH}. Expected one or two arguments`,
     ONE_TO_THREE_ARG_LENGTH: `${INVALID_ARG_LENGTH}. Expected one, two, or three arguments`,

--- a/src/assets/scripts/client/parsers/aircraftCommandParser/argumentParsers.js
+++ b/src/assets/scripts/client/parsers/aircraftCommandParser/argumentParsers.js
@@ -1,5 +1,5 @@
 import _defaultTo from 'lodash/defaultTo';
-import { isValidDirectionString } from './argumentValidators';
+import { isValidCourseString, isValidDirectionString } from './argumentValidators';
 import { INVALID_INDEX } from '../../constants/globalConstants';
 import {
     convertToThousands,
@@ -19,7 +19,8 @@ import {
 const HOLD_COMMAND_ARG_NAMES = {
     TURN_DIRECTION: 'turnDirection',
     LEG_LENGTH: 'legLength',
-    FIX_NAME: 'fixName'
+    FIX_NAME: 'fixName',
+    INBOUND_HEADING: 'inboundHeading'
 };
 
 /**
@@ -154,6 +155,12 @@ export const findHoldCommandByType = (type, args) => {
                 }
 
                 return arg;
+            case HOLD_COMMAND_ARG_NAMES.INBOUND_HEADING:
+                if (!isValidCourseString(arg)) {
+                    continue;
+                }
+
+                return convertStringToNumber(arg);
             default:
                 return null;
         }
@@ -184,8 +191,12 @@ export const holdParser = (args) => {
         findHoldCommandByType(HOLD_COMMAND_ARG_NAMES.LEG_LENGTH, args),
         '1min'
     );
+    const inboundHeading = _defaultTo(
+        findHoldCommandByType(HOLD_COMMAND_ARG_NAMES.INBOUND_HEADING, args),
+        null
+    );
 
-    return [turnDirection, legLength, fixName];
+    return [turnDirection, legLength, fixName, inboundHeading];
 };
 
 /**

--- a/src/assets/scripts/client/parsers/aircraftCommandParser/argumentParsers.js
+++ b/src/assets/scripts/client/parsers/aircraftCommandParser/argumentParsers.js
@@ -20,7 +20,7 @@ const HOLD_COMMAND_ARG_NAMES = {
     TURN_DIRECTION: 'turnDirection',
     LEG_LENGTH: 'legLength',
     FIX_NAME: 'fixName',
-    INBOUND_HEADING: 'inboundHeading'
+    RADIAL: 'radial'
 };
 
 /**
@@ -155,7 +155,7 @@ export const findHoldCommandByType = (type, args) => {
                 }
 
                 return arg;
-            case HOLD_COMMAND_ARG_NAMES.INBOUND_HEADING:
+            case HOLD_COMMAND_ARG_NAMES.RADIAL:
                 if (!isValidCourseString(arg)) {
                     continue;
                 }
@@ -191,12 +191,12 @@ export const holdParser = (args) => {
         findHoldCommandByType(HOLD_COMMAND_ARG_NAMES.LEG_LENGTH, args),
         '1min'
     );
-    const inboundHeading = _defaultTo(
-        findHoldCommandByType(HOLD_COMMAND_ARG_NAMES.INBOUND_HEADING, args),
+    const radial = _defaultTo(
+        findHoldCommandByType(HOLD_COMMAND_ARG_NAMES.RADIAL, args),
         null
     );
 
-    return [turnDirection, legLength, fixName, inboundHeading];
+    return [turnDirection, legLength, fixName, radial];
 };
 
 /**

--- a/src/assets/scripts/client/parsers/aircraftCommandParser/argumentValidators.js
+++ b/src/assets/scripts/client/parsers/aircraftCommandParser/argumentValidators.js
@@ -170,7 +170,7 @@ export const fixValidator = (args = []) => {
 
 /**
  * Tests if value is exactly a 3 digit decimal number
- * between 000 and 360
+ * between 001 and 360
  *
  * @function isValidCourseString
  * @param value {string}
@@ -184,7 +184,7 @@ export const isValidCourseString = (value) => {
 
     const course = convertStringToNumber(value);
 
-    return course >= 0 && course <= 360;
+    return course >= 1 && course <= 360;
 };
 
 /**

--- a/src/assets/scripts/client/parsers/aircraftCommandParser/argumentValidators.js
+++ b/src/assets/scripts/client/parsers/aircraftCommandParser/argumentValidators.js
@@ -169,6 +169,23 @@ export const fixValidator = (args = []) => {
 };
 
 /**
+ * Returns true if the value is exactly a 3 digit decimal number
+ *
+ * @function isValidCourseString
+ * @param value {string}
+ * @returns {boolean}
+ */
+export const isValidCourseString = (value) => {
+    // Can't rely on parseInt/convertStringToNumber as it'll parse 1min => 1
+    if (!/^[0-9]{3}$/.test(value)) {
+        return false;
+    }
+
+    const course = convertStringToNumber(value);
+    return course >= 0 && course <= 360;
+};
+
+/**
  * Returns true if value is one of `left / l / right / r`
  *
  * @function isValidDirectionString
@@ -245,6 +262,7 @@ export const headingValidator = (args = []) => {
  * - ['dumba', 'left', '2nm']
  * - ['dumba', 'right', '2min']
  * - ['dumba', 'right', '2nm']
+ * - ['dumba', 'right', '2nm', '265']
  * ```
  *
  * @function holdValidator
@@ -252,8 +270,8 @@ export const headingValidator = (args = []) => {
  * @return {array<string>}
  */
 export const holdValidator = (args = []) => {
-    if (args.length > 3) {
-        return ERROR_MESSAGE.ZERO_TO_THREE_ARG_LENGTH;
+    if (args.length > 4) {
+        return ERROR_MESSAGE.ZERO_TO_FOUR_ARG_LENGTH;
     }
 
     for (let i = 0; i < args.length; i++) {

--- a/src/assets/scripts/client/parsers/aircraftCommandParser/argumentValidators.js
+++ b/src/assets/scripts/client/parsers/aircraftCommandParser/argumentValidators.js
@@ -169,7 +169,8 @@ export const fixValidator = (args = []) => {
 };
 
 /**
- * Returns true if the value is exactly a 3 digit decimal number
+ * Tests if value is exactly a 3 digit decimal number
+ * between 000 and 360
  *
  * @function isValidCourseString
  * @param value {string}
@@ -177,11 +178,12 @@ export const fixValidator = (args = []) => {
  */
 export const isValidCourseString = (value) => {
     // Can't rely on parseInt/convertStringToNumber as it'll parse 1min => 1
-    if (!/^[0-9]{3}$/.test(value)) {
+    if (!REGEX.THREE_DIGIT_NUMBER.test(value)) {
         return false;
     }
 
     const course = convertStringToNumber(value);
+
     return course >= 0 && course <= 360;
 };
 

--- a/test/aircraft/Pilot/Pilot.spec.js
+++ b/test/aircraft/Pilot/Pilot.spec.js
@@ -847,8 +847,8 @@ ava('.initiateHoldingPattern() returns error response when specified fix is not 
 ava('.initiateHoldingPattern() returns correct readback when hold implemented successfully', (t) => {
     const pilot = createPilotFixture();
     const expectedResult = [true, {
-        log: 'hold east of KEPEC, right turns, 1min legs',
-        say: 'hold east of kepec, right turns, 1min legs'
+        log: 'hold east of KEPEC on the 267 radial, right turns, 1min legs',
+        say: 'hold east of kepec on the two six seven radial, right turns, 1min legs'
     }];
     const result = pilot.initiateHoldingPattern('KEPEC', holdParametersMock);
 

--- a/test/aircraft/Pilot/Pilot.spec.js
+++ b/test/aircraft/Pilot/Pilot.spec.js
@@ -847,8 +847,8 @@ ava('.initiateHoldingPattern() returns error response when specified fix is not 
 ava('.initiateHoldingPattern() returns correct readback when hold implemented successfully', (t) => {
     const pilot = createPilotFixture();
     const expectedResult = [true, {
-        log: 'hold east of KEPEC on the 267 radial, right turns, 1min legs',
-        say: 'hold east of kepec on the two six seven radial, right turns, 1min legs'
+        log: 'hold east of KEPEC on the 087 radial, right turns, 1min legs',
+        say: 'hold east of kepec on the zero eight seven radial, right turns, 1min legs'
     }];
     const result = pilot.initiateHoldingPattern('KEPEC', holdParametersMock);
 

--- a/test/parsers/aircraftCommandParser/argumentParser.spec.js
+++ b/test/parsers/aircraftCommandParser/argumentParser.spec.js
@@ -1,6 +1,5 @@
-/* eslint-disable arrow-parens, max-len, import/no-extraneous-dependencies*/
+/* eslint-disable arrow-parens, max-len, import/no-extraneous-dependencies */
 import ava from 'ava';
-import _isEqual from 'lodash/isEqual';
 
 import {
     altitudeParser,
@@ -98,53 +97,71 @@ ava('.headingParser() parses three digit heading as a generic heading', t => {
 
 ava('.findHoldCommandByType() returns a turnDirection when passed a variation of left or right', (t) => {
     const argsMock = ['dumba', 'l', '3nm'];
-    t.true(findHoldCommandByType('turnDirection', argsMock) === 'left');
+    t.is(findHoldCommandByType('turnDirection', argsMock), 'left');
 });
 
 ava('.findHoldCommandByType() returns a legLength when passed a valid legLength in min', (t) => {
     const argsMock = ['dumba', 'l', '3min'];
-    t.true(findHoldCommandByType('legLength', argsMock) === '3min');
+    t.is(findHoldCommandByType('legLength', argsMock), '3min');
 });
 
 ava('.findHoldCommandByType() returns a legLength when passed a valid legLength in nm', (t) => {
     const argsMock = ['dumba', 'l', '3nm'];
-    t.true(findHoldCommandByType('legLength', argsMock) === '3nm');
+    t.is(findHoldCommandByType('legLength', argsMock), '3nm');
 });
 
 ava('.findHoldCommandByType() returns a fixName when passed a valid fixName', (t) => {
     const argsMock = ['dumba', 'l', '3nm'];
-    t.true(findHoldCommandByType('fixName', argsMock) === 'dumba');
+    t.is(findHoldCommandByType('fixName', argsMock), 'dumba');
 });
 
-ava('.holdParser() returns an array of length 3 when passed a fixname as the only argument', t => {
-    const expectedResult = ['right', '1min', 'dumba'];
+ava('.holdParser() returns an array of length 4 when passed a fixname as the only argument', t => {
+    const expectedResult = ['right', '1min', 'dumba', null];
     const result = holdParser(['dumba']);
 
-    t.true(_isEqual(result, expectedResult));
+    t.deepEqual(result, expectedResult);
 });
 
-ava('.holdParser() returns an array of length 3 when passed a direction and fixname as arguments', t => {
-    const expectedResult = ['left', '1min', 'dumba'];
+ava('.holdParser() returns an array of length 4 when passed a direction and fixname as arguments', t => {
+    const expectedResult = ['left', '1min', 'dumba', null];
     let result = holdParser(['dumba', 'left']);
-    t.true(_isEqual(result, expectedResult));
+    t.deepEqual(result, expectedResult);
 
     result = holdParser(['left', 'dumba']);
-    t.true(_isEqual(result, expectedResult));
+    t.deepEqual(result, expectedResult);
 });
 
-ava('.holdParser() returns an array of length 3 when passed a direction, legLength and fixname as arguments', t => {
-    const expectedResult = ['left', '1min', 'dumba'];
+ava('.holdParser() returns an array of length 4 when passed a direction, legLength and fixname as arguments', t => {
+    const expectedResult = ['left', '1min', 'dumba', null];
     let result = holdParser(['dumba', 'left', '1min']);
-    t.true(_isEqual(result, expectedResult));
+    t.deepEqual(result, expectedResult);
 
     result = holdParser(['left', '1min', 'dumba']);
-    t.true(_isEqual(result, expectedResult));
+    t.deepEqual(result, expectedResult);
 
     result = holdParser(['1min', 'left', 'dumba']);
-    t.true(_isEqual(result, expectedResult));
+    t.deepEqual(result, expectedResult);
 
     result = holdParser(['left', 'dumba', '1min']);
-    t.true(_isEqual(result, expectedResult));
+    t.deepEqual(result, expectedResult);
+});
+
+ava('.holdParser() returns an array of length 4 when passed a direction, legLength, fixname and radial as arguments', t => {
+    const expectedResult = ['left', '1min', 'dumba', 7];
+    let result = holdParser(['dumba', 'left', '1min', '007']);
+    t.deepEqual(result, expectedResult);
+
+    result = holdParser(['left', '1min', 'dumba', '007']);
+    t.deepEqual(result, expectedResult);
+
+    result = holdParser(['1min', 'left', 'dumba', '007']);
+    t.deepEqual(result, expectedResult);
+
+    result = holdParser(['left', 'dumba', '1min', '007']);
+    t.deepEqual(result, expectedResult);
+
+    result = holdParser(['left', 'dumba', '007', '1min']);
+    t.deepEqual(result, expectedResult);
 });
 
 ava('.timewarpParser() returns an array with 0 as a value when provided no args', (t) => {

--- a/test/parsers/aircraftCommandParser/argumentValidator.spec.js
+++ b/test/parsers/aircraftCommandParser/argumentValidator.spec.js
@@ -212,8 +212,8 @@ ava('.headingValidator() returns undefined when passed a string and a number as 
 });
 
 ava('.holdValidator() returns a string when passed the wrong number of arguments', t => {
-    const result = holdValidator(['', 'left', 1, '']);
-    t.true(result === 'Invalid argument length. Expected zero to three arguments');
+    const result = holdValidator(['', 'left', 1, '', '']);
+    t.true(result === 'Invalid argument length. Expected zero to four arguments');
 });
 
 ava('.holdValidator() returns undefined when passed zero arguments', t => {

--- a/test/parsers/aircraftCommandParser/argumentValidator.spec.js
+++ b/test/parsers/aircraftCommandParser/argumentValidator.spec.js
@@ -290,12 +290,13 @@ ava('.holdValidator() returns undefined when passed four strings as arguments', 
 });
 
 ava('.isValidCourseString() returns true when passed a 3 digit course', (t) => {
-    t.true(isValidCourseString('000'));
+    t.true(isValidCourseString('001'));
     t.true(isValidCourseString('090'));
     t.true(isValidCourseString('360'));
 });
 
 ava('.isValidCourseString() returns false when passed an invalid course', (t) => {
+    t.false(isValidCourseString('000'));
     t.false(isValidCourseString('1min'));
     t.false(isValidCourseString('5'));
     t.false(isValidCourseString('50'));

--- a/test/parsers/aircraftCommandParser/argumentValidator.spec.js
+++ b/test/parsers/aircraftCommandParser/argumentValidator.spec.js
@@ -12,6 +12,7 @@ import {
     fixValidator,
     headingValidator,
     holdValidator,
+    isValidCourseString,
     squawkValidator,
     optionalAltitudeValidator,
     crossingValidator
@@ -226,9 +227,10 @@ ava('.holdValidator() returns undefined when passed zero arguments', t => {
 
 ava('.holdValidator() returns a string when passed the wrong type of arguments', t => {
     t.true(holdValidator([false]) === 'Invalid argument. Must be a string');
-    t.true(holdValidator([false, '42', '1min']) === 'Invalid argument. Must be a string');
-    t.true(holdValidator(['42', false, '1min']) === 'Invalid argument. Must be a string');
-    t.true(holdValidator(['42', 'left', false]) === 'Invalid argument. Must be a string');
+    t.true(holdValidator([false, '42', '1min', '090']) === 'Invalid argument. Must be a string');
+    t.true(holdValidator(['42', false, '1min', '090']) === 'Invalid argument. Must be a string');
+    t.true(holdValidator(['42', 'left', false, '090']) === 'Invalid argument. Must be a string');
+    t.true(holdValidator(['42', 'left', '1min', false]) === 'Invalid argument. Must be a string');
 });
 
 ava('.holdValidator() returns undefined when passed a string as an argument', t => {
@@ -245,6 +247,9 @@ ava('.holdValidator() returns undefined when two strings as arguments', t => {
 
     result = holdValidator(['l', 'dumba']);
     t.true(typeof result === 'undefined');
+
+    result = holdValidator(['090', 'dumba']);
+    t.true(typeof result === 'undefined');
 });
 
 ava('.holdValidator() returns undefined when passed three strings as arguments', t => {
@@ -259,6 +264,44 @@ ava('.holdValidator() returns undefined when passed three strings as arguments',
 
     result = holdValidator(['dumba', 'right', '1nm']);
     t.true(typeof result === 'undefined');
+
+    result = holdValidator(['dumba', 'right', '090']);
+    t.true(typeof result === 'undefined');
+
+    result = holdValidator(['dumba', '1min', '090']);
+    t.true(typeof result === 'undefined');
+
+    result = holdValidator(['dumba', '1nm', '090']);
+    t.true(typeof result === 'undefined');
+});
+
+ava('.holdValidator() returns undefined when passed four strings as arguments', t => {
+    let result = holdValidator(['dumba', 'left', '1min', '090']);
+    t.true(typeof result === 'undefined');
+
+    result = holdValidator(['dumba', 'right', '1nm', '090']);
+    t.true(typeof result === 'undefined');
+
+    result = holdValidator(['dumba', 'right', '1min', '090']);
+    t.true(typeof result === 'undefined');
+
+    result = holdValidator(['dumba', 'right', '1nm', '090']);
+    t.true(typeof result === 'undefined');
+});
+
+ava('.isValidCourseString() returns true when passed a 3 digit course', (t) => {
+    t.true(isValidCourseString('000'));
+    t.true(isValidCourseString('090'));
+    t.true(isValidCourseString('360'));
+});
+
+ava('.isValidCourseString() returns false when passed an invalid course', (t) => {
+    t.false(isValidCourseString('1min'));
+    t.false(isValidCourseString('5'));
+    t.false(isValidCourseString('50'));
+    t.false(isValidCourseString('370'));
+    t.false(isValidCourseString('-10'));
+    t.false(isValidCourseString('1000'));
 });
 
 ava('.squawkValidator() returns undefined when passed a valid squawk', t => {


### PR DESCRIPTION
Resolves #1451.

The purpose of this pull request is to add ability to specify the radial for a hold. While we're hammering out the ~finer~ coarser points of #1431 I _accidentally_ implemented this as I needed a method of commanding a hold direction easily.

* Add the optional `radial` parameter (a 3-digit decimal number) to the hold command which sets the inboundHeading when executing a hold
* Use `WZZ36EX hold abbot 265`
With readback _WZZ36EX, hold east of ABBOT on the 265 radial, right turns, 1min legs_
* Updates tests to deal with the extra parameter
* Update documentation

Entering ABBOT hold from different directions
![image](https://user-images.githubusercontent.com/3430117/65784916-21f4d100-e14b-11e9-87b2-8294d7736168.png)

Both holding at ABBOT
![image](https://user-images.githubusercontent.com/3430117/65785084-75ffb580-e14b-11e9-9590-7f2d14d7e523.png)

