### PR TITLE
enhancement/1458 - handle distance based holds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ### Enhancements & Refactors
 - [#1451](https://github.com/openscope/openscope/issues/1451) - Add ability to specify the radial with the `hold` command
+- [#1458](https://github.com/openscope/openscope/issues/1458) - Add support for holding patterns with distance-based legs
+
 
 # 6.14.2 (October 17, 2019)
 ### Hotfixes

--- a/src/assets/scripts/client/aircraft/AircraftModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftModel.js
@@ -1989,16 +1989,6 @@ export default class AircraftModel {
         const isPastFix = offset[1] < 1 && offset[2] < 2;
         const isTimerSet = holdParameters.timer !== INVALID_NUMBER;
         const isTimerExpired = isTimerSet && gameTime > holdParameters.timer;
-        let holdLegDurationInSeconds;
-
-        if (legLength.indexOf('min') !== -1) {
-            const holdLegDurationInMinutes = legLength.replace('min', '');
-            holdLegDurationInSeconds = holdLegDurationInMinutes * TIME.ONE_MINUTE_IN_SECONDS;
-        } else {
-            // Leg is a distance, use the ground speed to determine the duration
-            const holdLegDistance = legLength.replace('nm', '');
-            holdLegDurationInSeconds = (holdLegDistance / this.groundSpeed) * TIME.ONE_HOUR_IN_SECONDS;
-        }
 
         if (isPastFix && !this._isEstablishedOnHoldingPattern) {
             this._isEstablishedOnHoldingPattern = true;
@@ -2011,6 +2001,17 @@ export default class AircraftModel {
         let nextTargetHeading = outboundHeading;
 
         if (abs(groundTrack - outboundHeading) < PERFORMANCE.MAXIMUM_ANGLE_CONSIDERED_ESTABLISHED_ON_HOLD_COURSE && !isTimerSet) {
+            let holdLegDurationInSeconds;
+
+            if (legLength.indexOf('min') !== -1) {
+                const holdLegDurationInMinutes = legLength.replace('min', '');
+                holdLegDurationInSeconds = holdLegDurationInMinutes * TIME.ONE_MINUTE_IN_SECONDS;
+            } else {
+                // Leg is a distance, use the ground speed to determine the duration
+                const holdLegDistance = legLength.replace('nm', '');
+                holdLegDurationInSeconds = (holdLegDistance / this.groundSpeed) * TIME.ONE_HOUR_IN_SECONDS;
+            }
+
             currentWaypoint.setHoldTimer(gameTime + holdLegDurationInSeconds);
         }
 

--- a/src/assets/scripts/client/aircraft/AircraftModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftModel.js
@@ -1989,14 +1989,12 @@ export default class AircraftModel {
         const isPastFix = offset[1] < 1 && offset[2] < 2;
         const isTimerSet = holdParameters.timer !== INVALID_NUMBER;
         const isTimerExpired = isTimerSet && gameTime > holdParameters.timer;
-
         let holdLegDurationInSeconds;
+
         if (legLength.indexOf('min') !== -1) {
             const holdLegDurationInMinutes = legLength.replace('min', '');
             holdLegDurationInSeconds = holdLegDurationInMinutes * TIME.ONE_MINUTE_IN_SECONDS;
         } else {
-            // TODO: I've been told to use GS, but should we be using the mcp speed? In theory, the
-            // a/c should have slowed to maximum speed for the hold at this stage so it should be irrelevent
             // Leg is a distance, use the ground speed to determine the duration
             const holdLegDistance = legLength.replace('nm', '');
             holdLegDurationInSeconds = (holdLegDistance / this.groundSpeed) * TIME.ONE_HOUR_IN_SECONDS;


### PR DESCRIPTION
Resolves #1458.

The purpose of this pull request is to implement holds where the leg length is a distance.

As the sim uses a timer to determine when the return leg of a hold should be initiated, this estimates the time based on the length of the leg (as specified by the player) and the aircraft's current ground speed.

Edit: (Sorry Erik, but this is another hold-based PR. I can't help myself)