### PR TITLE
hotfix/1463 - Fix travis build notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,6 @@
 sudo: false
 language: node_js
-node_js:
-- '11'
-
-# must specify this for allow_failures to work on env key
-# https://docs.travis-ci.com/user/customizing-the-build#rows-that-are-allowed-to-fail
-env:
-
+node_js: '11.3'
 git:
   depth: 3
 cache:
@@ -19,29 +13,17 @@ notifications:
     rooms:
       - secure: "Xti6UQw2kAqVJ6STI1I1VFadPv6Z+7KRHk+7UF9eVtiXks2fkKtl07svpMh81wTkRRMcbpCUb7i8AujcuFOBBMmv4A0HnMM8oOOH0hTsxacs5waYlfvDfXhliJKYjuTIHg55li5VqJYoZsQqJ9gSuegE5f9oQ3fmUAgfDXkwChNoinSEs4IIhMkGYV77PniYRdL4Sj92yQhlhu4YTz4EbOoAggdLAp11m8ALpnxShDAJUsPJQum0ZtYBr+yTacdQIAjncZknuhNkeJvblZkUDDun57uL/Wv6uJlfEBxclD+FD4YOKSoiXla5N5IMhzwJIO8umd2CGy109frZO04Fcwq/fEXcj0N38mOkCluP8IXx3b7G8DdMD9MMkv2Mac/EC9gTIB7zcMmugBigGB7kFhttdmDGvTsjAKVugfWjSu+AUXRHxmR4uohGKaUi1G6gKdOZDITh1gRi5j0S+yypE15uRypMgjex4ZqfcydPrc3pAmAS3j2YTVbIfbBP4jUMj3Av2bNdEh3moFcGh+2O/FGsOmzHYBw1YNhu5b+FesFShtxoKKSJi/DaLd9nODrbPU0gbJ+xBuDDMPUMwNwqEk2aMd7hUbLqST8ss237u816aG4KiK9Ipgp+hqcKHYne20dQYt7SX0KV8suoxcYqgcs6/igl8cPtgUrgzOE21i4="
     template:
-      - Build %{result} - %{author} on <https://www.github.com/openscope/openscope/%{branch}|%{branch}>
-      - <%{build_url}|#%{build_number}> (<%{compare_url}|%{commit}>) %{result} in %{duration}
+      - <%{compare_url}|Pull Request> Build <%{build_url}|#%{build_number}> by %{author}
+      - Build %{result} in %{duration}
       - "%{commit_subject}"
-after_success:
-  - npm run coveralls
 
-branches:
-  only:
-  - develop
-  - master
 jobs:
-  fast_finish: true
-  allow_failures:
-      # lint errors should not fail the whole build
-    - env: LINT=TRUE
-  include:
-    - name: "lint-diff"
-      if: type = pull_request
-      script: npm run lint-diff -- $TRAVIS_COMMIT_RANGE
-      after_success:
-      env: LINT=TRUE
-    - name: "eslint"
-      if: type = push AND branch = master
-      script: npm run lint
-      after_success:
-      env: LINT=TRUE
+    include:
+        - name: 'Build'
+          script: npm run build
+        - name: 'Test'
+          script:
+            - npm run test
+            - npm run coveralls
+        - name: 'Lint'
+          script: npm run lint-diff -- $TRAVIS_COMMIT_RANGE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 6.14.2 (October 17, 2019)
+### Hotfixes
+- [#1463](https://github.com/openscope/openscope/issues/1463) - Fix travis build notifications
+
+
 # 6.14.0 (October 1, 2019)
 ### New Features
 - [#1436](https://github.com/openscope/openscope/issues/1436) - Add support for multiple video maps (no toggling yet)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "openscope",
-  "version": "6.14.0",
+  "version": "6.14.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openscope",
-  "version": "6.14.0",
+  "version": "6.14.1",
   "description": "An ATC simulator in HTML5",
   "engines": {
     "node": "11.3.0",


### PR DESCRIPTION
Resolves #1463.
Blocks #1454 (a high priority hotfix).

Fix travis build notifications.

---

We have been migrated to the new travis-ci.com from the older travis-ci.org, and some things work differently under the new one. For one, Travis is now a GitHub App installed for the org, rather than using webhooks (or whatever other stuff I know nothing about that the legacy system used). Since making the switch, new pushes to all branches have only been running lint-diff, and not even the build/tests themselves 😬.

It's worth noting that, due to the way travis differentiates between a "PR Build" and a "Branch Build", it's apparently not currently possible to have both:
- slack notifications display the branch name that a build was run on, AND...
    - PR Build: `%{branch}` is the _target_ branch, eg `develop` or `master`
    - Branch Build: `%{branch}` is the branch the build is run on, eg `feature/123`
- ...have all builds on a given PR run coveralls or lint-diff on the _entire_ diff range of that PR
    - PR Build: $TRAVIS_COMMIT_RANGE includes all commits the PR has that the target branch does not have
    - Branch Build: $TRAVIS_COMMIT_RANGE includes only the commits _since the commit for which travis ran a build_ (so commit, push, commit, push, the first build may fail some tests, but the next build will pass since it only tests the second commit and not both)

As such, I elected to give up the former to keep the latter. See the below references on this:
- https://graysonkoonce.com/getting-the-current-branch-name-during-a-pull-request-in-travis-ci/
- https://github.com/gajus/gitdown/issues/36

Example of the notification for the most recent push of this PR:
https://openscopeatc.slack.com/archives/C3L3A2MD0/p1571419579006700

![image](https://user-images.githubusercontent.com/5103735/67115206-ad420f00-f1ab-11e9-8610-ff15521039c7.png)
