### PR TITLE
feature/45 - Implement *T tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # 6.15.0 (November 1, 2019)
 ### New Features
 - <a href="https://github.com/openscope/openscope/issues/1105" target="_blank">#1105</a> - Add in-sim Airport Guide accessible via footer button
-- <a href="https://github.com/openscope/openscope/issues/1191" target="_blank">#1105</a> - Consolidate command bar buttons
+- <a href="https://github.com/openscope/openscope/issues/1191" target="_blank">#1191</a> - Consolidate command bar buttons
+- <a href="https://github.com/openscope/openscope/issues/45" target="_blank">#45</a> - Add range/bearing measurement tool via Control button
 
 ### Bugfixes
 - <a href="https://github.com/openscope/openscope/issues/1456" target="_blank">#1456</a> - Only allow headings between 001 and 360

--- a/src/assets/scripts/client/InputController.js
+++ b/src/assets/scripts/client/InputController.js
@@ -10,6 +10,8 @@ import UiController from './ui/UiController';
 import AircraftCommandParser from './parsers/aircraftCommandParser/AircraftCommandParser';
 import ScopeCommandModel from './parsers/scopeCommandParser/ScopeCommandModel';
 import EventTracker from './EventTracker';
+import MeasureTool from './measurement/MeasureTool';
+import FixCollection from './navigationLibrary/FixCollection';
 import { clamp } from './math/core';
 import { EVENT } from './constants/eventNames';
 import { GAME_OPTION_NAMES } from './constants/gameOptionConstants';
@@ -61,6 +63,7 @@ export default class InputController {
         this._mouseDelta = [0, 0];
         this._mouseDownScreenPosition = [0, 0];
         this.input.isMouseDown = false;
+        this.input.measureTool = new MeasureTool();
         this.commandBarContext = COMMAND_CONTEXT.AIRCRAFT;
 
         this._init();
@@ -85,6 +88,7 @@ export default class InputController {
      */
     setupHandlers() {
         this.onKeydownHandler = this._onKeydown.bind(this);
+        this.onKeyupHandler = this._onKeyup.bind(this);
         this.onCommandInputChangeHandler = this._onCommandInputChange.bind(this);
         this.onMouseScrollHandler = this._onMouseScroll.bind(this);
         this.onMouseClickAndDragHandler = this._onMouseClickAndDrag.bind(this);
@@ -102,6 +106,7 @@ export default class InputController {
      */
     enable() {
         this.$window.on('keydown', this.onKeydownHandler);
+        this.$window.on('keyup', this.onKeyupHandler);
         this.$commandInput.on('input', this.onCommandInputChangeHandler);
         // TODO: these are non-standard events and will be deprecated soon. this should be moved
         // over to the `wheel` event. This should also be moved over to `.on()` instead of `.bind()`
@@ -127,6 +132,7 @@ export default class InputController {
      */
     disable() {
         this.$window.off('keydown', this.onKeydownHandler);
+        this.$window.off('keyup', this.onKeyupHandler);
         this.$commandInput.off('input', this.onCommandInputChangeHandler);
         // uncomment only after `.on()` for this event has been implemented.
         // this.$commandInput.off('DOMMouseScroll mousewheel', this.onMouseScrollHandler);
@@ -161,6 +167,7 @@ export default class InputController {
         this._mouseDelta = [0, 0];
         this._mouseDownScreenPosition = [0, 0];
         this.input.isMouseDown = false;
+        this.input.measureTool = null;
 
         return this;
     }
@@ -207,6 +214,91 @@ export default class InputController {
     }
 
     /**
+     * Adds a point to the measuring tool
+     *
+     * @for InputController
+     * @method _addMeasurePoint
+     * @param event {jquery Event}
+     * @param doReplaceLast {boolean} Indicates whether this will replace the last point
+     * @private
+     */
+    _addMeasurePoint(event, doReplaceLast = false) {
+        const currentMousePosition = CanvasStageModel.translateMousePositionToCanvasPosition(
+            event.pageX, event.pageY
+        );
+        const { x, y } = currentMousePosition;
+        const { measureTool } = this.input;
+        const [aircraftModel, distanceFromAircraft] = this._findClosestAircraftAndDistanceToMousePosition(x, y);
+        const [fixModel, distanceFromFix] = this._findClosestFixAndDistanceToMousePosition(x, y);
+        let distance;
+        let modelToUse;
+
+        // Which model is closest
+        if (distanceFromFix < distanceFromAircraft) {
+            distance = distanceFromFix;
+            modelToUse = fixModel;
+        } else {
+            distance = distanceFromAircraft;
+            modelToUse = aircraftModel;
+        }
+
+        if (distance > CanvasStageModel.translatePixelsToKilometers(20)) {
+            // Nothing's near the cursor, so we'll use the cursor point
+            modelToUse = this._translatePointToKilometers(x, y);
+        }
+
+        if (!measureTool.hasStarted) {
+            measureTool.startMeasuring(modelToUse);
+        } else if (doReplaceLast) {
+            measureTool.updateLastPoint(modelToUse);
+        } else {
+            measureTool.addPoint(modelToUse);
+        }
+
+        // Mark for shallow render so the draw motion is smooth
+        this._eventBus.trigger(EVENT.MARK_SHALLOW_RENDER);
+    }
+
+    /**
+     * Removes the last point in the measuring tool
+     *
+     * @for InputController
+     * @method _removeLastMeasurePoint
+     * @private
+     */
+    _removeLastMeasurePoint() {
+        this.input.measureTool.removeLastPoint();
+
+        // Mark for shallow render so the feedback is immediate
+        this._eventBus.trigger(EVENT.MARK_SHALLOW_RENDER);
+    }
+
+    /**
+     * Starts the measuring tool
+     *
+     * @for InputController
+     * @method _startMeasuring
+     * @private
+     */
+    _startMeasuring() {
+        this.input.measureTool.isMeasuring = true;
+    }
+
+    /**
+     * Stops the measuring tool
+     *
+     * @for InputController
+     * @method _stopMeasuring
+     * @private
+     */
+    _stopMeasuring() {
+        this.input.measureTool.reset();
+
+        // Mark for shallow render so the feedback is immediate
+        this._eventBus.trigger(EVENT.MARK_SHALLOW_RENDER);
+    }
+
+    /**
      * @for InputController
      * @method _onMouseScroll
      * @param event {jquery Event}
@@ -227,6 +319,13 @@ export default class InputController {
      * @param event {jquery Event}
      */
     _onMouseClickAndDrag(event) {
+        const { measureTool } = this.input;
+
+        if (measureTool.isMeasuring && measureTool.hasStarted) {
+            this._addMeasurePoint(event, true);
+            return this;
+        }
+
         if (!this.input.isMouseDown) {
             return this;
         }
@@ -351,6 +450,11 @@ export default class InputController {
 
         // TODO: this swtich can be simplified, there is a lot of repetition here
         switch (code) {
+            case KEY_CODES.SHIFT_LEFT:
+            case KEY_CODES.SHIFT_RIGHT:
+                this._startMeasuring();
+
+                break;
             case KEY_CODES.BAT_TICK:
             case LEGACY_KEY_CODES.BAT_TICK:
                 this.$commandInput.val(`${currentCommandInputValue}\` `);
@@ -499,6 +603,31 @@ export default class InputController {
                 break;
             default:
                 this.$commandInput.focus();
+        }
+    }
+
+
+    /**
+     * @for InputController
+     * @method _onKeydown
+     * @param event {jquery Event}
+     * @private
+     */
+    _onKeyup(event) {
+        let { code } = event.originalEvent;
+
+        if (code === undefined) {
+            // fallback for legacy browsers like IE/Edge
+            code = event.originalEvent.keyCode;
+        }
+
+        switch (code) {
+            case KEY_CODES.SHIFT_LEFT:
+            case KEY_CODES.SHIFT_RIGHT:
+                this._stopMeasuring();
+
+                break;
+            default:
         }
     }
 
@@ -828,10 +957,27 @@ export default class InputController {
      * @private
      */
     _findClosestAircraftAndDistanceToMousePosition(x, y) {
-        return this._aircraftController.aircraft_get_nearest([
-            CanvasStageModel.translatePixelsToKilometers(x - CanvasStageModel._panX),
-            CanvasStageModel.translatePixelsToKilometers(y + CanvasStageModel._panY)
-        ]);
+        return this._aircraftController.aircraft_get_nearest(
+            this._translatePointToKilometers(x, y)
+        );
+    }
+
+    /**
+     * Facade for `FixCollection.getNearest`
+     *
+     * Accepts current mouse position in canvas coordinates x, y
+     *
+     * @for InputController
+     * @method _findClosestFixAndDistanceToMousePosition
+     * @param x {number}
+     * @param y {number}
+     * @returns [FixModel, number]
+     * @private
+     */
+    _findClosestFixAndDistanceToMousePosition(x, y) {
+        return FixCollection.getNearestFix(
+            this._translatePointToKilometers(x, y)
+        );
     }
 
     /**
@@ -842,7 +988,11 @@ export default class InputController {
      * @private
      */
     _onRightMousePress(event) {
-        this._markMousePressed(event, MOUSE_BUTTON_NAMES.RIGHT);
+        if (this.input.measureTool.isMeasuring) {
+            this._removeLastMeasurePoint();
+        } else {
+            this._markMousePressed(event, MOUSE_BUTTON_NAMES.RIGHT);
+        }
     }
 
     /**
@@ -858,6 +1008,12 @@ export default class InputController {
      * @private
      */
     _onLeftMouseButtonPress(event) {
+        if (this.input.measureTool.isMeasuring) {
+            this._addMeasurePoint(event);
+
+            return;
+        }
+
         const currentMousePosition = CanvasStageModel.translateMousePositionToCanvasPosition(event.pageX, event.pageY);
         const [aircraftModel, distanceFromPosition] = this._findClosestAircraftAndDistanceToMousePosition(
             currentMousePosition.x,
@@ -904,5 +1060,22 @@ export default class InputController {
             mousePositionY
         ];
         this.input.isMouseDown = true;
+    }
+
+    /**
+     * Translate the specified x, y pixel coordinates to map kilometers
+     *
+     * @for InputController
+     * @method _translatePointToKilometers
+     * @param x {number}
+     * @param y {number}
+     * @returns {array<number>}
+     * @private
+     */
+    _translatePointToKilometers(x, y) {
+        return [
+            CanvasStageModel.translatePixelsToKilometers(x - CanvasStageModel._panX),
+            CanvasStageModel.translatePixelsToKilometers(y + CanvasStageModel._panY)
+        ];
     }
 }

--- a/src/assets/scripts/client/InputController.js
+++ b/src/assets/scripts/client/InputController.js
@@ -244,9 +244,7 @@ export default class InputController {
             modelToUse = this._translatePointToKilometers(x, y);
         }
 
-        if (!MeasureTool.hasStarted) {
-            MeasureTool.startMeasuring(modelToUse);
-        } else if (shouldReplaceLastPoint) {
+        if (MeasureTool.hasStarted && shouldReplaceLastPoint) {
             MeasureTool.updateLastPoint(modelToUse);
         } else {
             MeasureTool.addPoint(modelToUse);

--- a/src/assets/scripts/client/InputController.js
+++ b/src/assets/scripts/client/InputController.js
@@ -217,10 +217,10 @@ export default class InputController {
      * @for InputController
      * @method _addMeasurePoint
      * @param event {jquery Event}
-     * @param doReplaceLast {boolean} Indicates whether this will replace the last point
+     * @param shouldReplaceLastPoint {boolean} Indicates whether this will replace the last point
      * @private
      */
-    _addMeasurePoint(event, doReplaceLast = false) {
+    _addMeasurePoint(event, shouldReplaceLastPoint = false) {
         const currentMousePosition = CanvasStageModel.translateMousePositionToCanvasPosition(
             event.pageX, event.pageY
         );
@@ -246,7 +246,7 @@ export default class InputController {
 
         if (!MeasureTool.hasStarted) {
             MeasureTool.startMeasuring(modelToUse);
-        } else if (doReplaceLast) {
+        } else if (shouldReplaceLastPoint) {
             MeasureTool.updateLastPoint(modelToUse);
         } else {
             MeasureTool.addPoint(modelToUse);
@@ -318,6 +318,7 @@ export default class InputController {
     _onMouseClickAndDrag(event) {
         if (MeasureTool.isMeasuring && MeasureTool.hasStarted) {
             this._addMeasurePoint(event, true);
+
             return this;
         }
 
@@ -436,9 +437,9 @@ export default class InputController {
 
         const currentCommandInputValue = this.$commandInput.val();
 
-        let code = event.originalEvent.code;
+        let { code } = event.originalEvent;
 
-        if (code === undefined) {
+        if (code == null) {
             // fallback for legacy browsers like IE/Edge
             code = event.originalEvent.keyCode;
         }
@@ -611,7 +612,7 @@ export default class InputController {
     _onKeyup(event) {
         let { code } = event.originalEvent;
 
-        if (code === undefined) {
+        if (code == null) {
             // fallback for legacy browsers like IE/Edge
             code = event.originalEvent.keyCode;
         }

--- a/src/assets/scripts/client/InputController.js
+++ b/src/assets/scripts/client/InputController.js
@@ -642,6 +642,7 @@ export default class InputController {
             case KEY_CODES.CONTROL_LEFT:
             case KEY_CODES.CONTROL_RIGHT:
                 this._stopMeasuring();
+                this._eventBus.trigger(EVENT.MARK_SHALLOW_RENDER);
 
                 break;
             default:

--- a/src/assets/scripts/client/InputController.js
+++ b/src/assets/scripts/client/InputController.js
@@ -63,7 +63,6 @@ export default class InputController {
         this._mouseDelta = [0, 0];
         this._mouseDownScreenPosition = [0, 0];
         this.input.isMouseDown = false;
-        this.input.measureTool = new MeasureTool();
         this.commandBarContext = COMMAND_CONTEXT.AIRCRAFT;
 
         this._init();
@@ -167,7 +166,6 @@ export default class InputController {
         this._mouseDelta = [0, 0];
         this._mouseDownScreenPosition = [0, 0];
         this.input.isMouseDown = false;
-        this.input.measureTool = null;
 
         return this;
     }
@@ -227,7 +225,6 @@ export default class InputController {
             event.pageX, event.pageY
         );
         const { x, y } = currentMousePosition;
-        const { measureTool } = this.input;
         const [aircraftModel, distanceFromAircraft] = this._findClosestAircraftAndDistanceToMousePosition(x, y);
         const [fixModel, distanceFromFix] = this._findClosestFixAndDistanceToMousePosition(x, y);
         let distance;
@@ -247,12 +244,12 @@ export default class InputController {
             modelToUse = this._translatePointToKilometers(x, y);
         }
 
-        if (!measureTool.hasStarted) {
-            measureTool.startMeasuring(modelToUse);
+        if (!MeasureTool.hasStarted) {
+            MeasureTool.startMeasuring(modelToUse);
         } else if (doReplaceLast) {
-            measureTool.updateLastPoint(modelToUse);
+            MeasureTool.updateLastPoint(modelToUse);
         } else {
-            measureTool.addPoint(modelToUse);
+            MeasureTool.addPoint(modelToUse);
         }
 
         // Mark for shallow render so the draw motion is smooth
@@ -267,7 +264,7 @@ export default class InputController {
      * @private
      */
     _removeLastMeasurePoint() {
-        this.input.measureTool.removeLastPoint();
+        MeasureTool.removeLastPoint();
 
         // Mark for shallow render so the feedback is immediate
         this._eventBus.trigger(EVENT.MARK_SHALLOW_RENDER);
@@ -281,7 +278,7 @@ export default class InputController {
      * @private
      */
     _startMeasuring() {
-        this.input.measureTool.isMeasuring = true;
+        MeasureTool.isMeasuring = true;
     }
 
     /**
@@ -292,7 +289,7 @@ export default class InputController {
      * @private
      */
     _stopMeasuring() {
-        this.input.measureTool.reset();
+        MeasureTool.reset();
 
         // Mark for shallow render so the feedback is immediate
         this._eventBus.trigger(EVENT.MARK_SHALLOW_RENDER);
@@ -319,9 +316,7 @@ export default class InputController {
      * @param event {jquery Event}
      */
     _onMouseClickAndDrag(event) {
-        const { measureTool } = this.input;
-
-        if (measureTool.isMeasuring && measureTool.hasStarted) {
+        if (MeasureTool.isMeasuring && MeasureTool.hasStarted) {
             this._addMeasurePoint(event, true);
             return this;
         }
@@ -988,7 +983,7 @@ export default class InputController {
      * @private
      */
     _onRightMousePress(event) {
-        if (this.input.measureTool.isMeasuring) {
+        if (MeasureTool.isMeasuring) {
             this._removeLastMeasurePoint();
         } else {
             this._markMousePressed(event, MOUSE_BUTTON_NAMES.RIGHT);
@@ -1008,7 +1003,7 @@ export default class InputController {
      * @private
      */
     _onLeftMouseButtonPress(event) {
-        if (this.input.measureTool.isMeasuring) {
+        if (MeasureTool.isMeasuring) {
             this._addMeasurePoint(event);
 
             return;

--- a/src/assets/scripts/client/InputController.js
+++ b/src/assets/scripts/client/InputController.js
@@ -263,11 +263,11 @@ export default class InputController {
      * Removes the last point in the measuring tool
      *
      * @for InputController
-     * @method _removeLastMeasurePoint
+     * @method _removePreviousMeasurePoint
      * @private
      */
-    _removeLastMeasurePoint() {
-        MeasureTool.removeLastPoint();
+    _removePreviousMeasurePoint() {
+        MeasureTool.removePreviousPoint();
 
         // Mark for shallow render so the feedback is immediate
         this._eventBus.trigger(EVENT.MARK_SHALLOW_RENDER);
@@ -1006,7 +1006,7 @@ export default class InputController {
      */
     _onRightMousePress(event) {
         if (MeasureTool.isMeasuring) {
-            this._removeLastMeasurePoint();
+            this._removePreviousMeasurePoint();
 
             return;
         }

--- a/src/assets/scripts/client/InputController.js
+++ b/src/assets/scripts/client/InputController.js
@@ -225,23 +225,28 @@ export default class InputController {
             event.pageX, event.pageY
         );
         const { x, y } = currentMousePosition;
-        const [aircraftModel, distanceFromAircraft] = this._findClosestAircraftAndDistanceToMousePosition(x, y);
-        const [fixModel, distanceFromFix] = this._findClosestFixAndDistanceToMousePosition(x, y);
-        let distance;
-        let modelToUse;
+        let modelToUse = this._translatePointToKilometers(x, y);
 
-        // Which model is closest
-        if (distanceFromFix < distanceFromAircraft) {
-            distance = distanceFromFix;
-            modelToUse = fixModel;
-        } else {
-            distance = distanceFromAircraft;
-            modelToUse = aircraftModel;
-        }
+        // Snapping should only be done when the shift key is depressed
+        if (event.originalEvent.shiftKey) {
+            const [aircraftModel, distanceFromAircraft] = this._findClosestAircraftAndDistanceToMousePosition(x, y);
+            const [fixModel, distanceFromFix] = this._findClosestFixAndDistanceToMousePosition(x, y);
+            let distance;
+            let nearestModel;
 
-        if (distance > CanvasStageModel.translatePixelsToKilometers(20)) {
-            // Nothing's near the cursor, so we'll use the cursor point
-            modelToUse = this._translatePointToKilometers(x, y);
+            // Which model is closest
+            if (distanceFromFix < distanceFromAircraft) {
+                distance = distanceFromFix;
+                nearestModel = fixModel;
+            } else {
+                distance = distanceFromAircraft;
+                nearestModel = aircraftModel;
+            }
+
+            // Only snap if the distance is with 50px, otherwise the behaviour is jarring
+            if (distance < CanvasStageModel.translatePixelsToKilometers(50)) {
+                modelToUse = nearestModel;
+            }
         }
 
         if (MeasureTool.hasStarted && shouldReplaceLastPoint) {
@@ -444,8 +449,8 @@ export default class InputController {
 
         // TODO: this swtich can be simplified, there is a lot of repetition here
         switch (code) {
-            case KEY_CODES.SHIFT_LEFT:
-            case KEY_CODES.SHIFT_RIGHT:
+            case KEY_CODES.CONTROL_LEFT:
+            case KEY_CODES.CONTROL_RIGHT:
                 this._startMeasuring();
 
                 break;
@@ -616,8 +621,8 @@ export default class InputController {
         }
 
         switch (code) {
-            case KEY_CODES.SHIFT_LEFT:
-            case KEY_CODES.SHIFT_RIGHT:
+            case KEY_CODES.CONTROL_LEFT:
+            case KEY_CODES.CONTROL_RIGHT:
                 this._stopMeasuring();
 
                 break;

--- a/src/assets/scripts/client/InputController.js
+++ b/src/assets/scripts/client/InputController.js
@@ -299,6 +299,10 @@ export default class InputController {
      * @private
      */
     _startMeasuring() {
+        if (MeasureTool.isMeasuring) {
+            return;
+        }
+
         MeasureTool.startNewPath();
     }
 

--- a/src/assets/scripts/client/aircraft/AircraftController.js
+++ b/src/assets/scripts/client/aircraft/AircraftController.js
@@ -279,7 +279,7 @@ export default class AircraftController {
     /**
      * @for AircraftController
      * @method aircraft_get_nearest
-     * @param position {StaticPositionModel}
+     * @param position {array<number>} These are x, y canvas units (km)
      */
     aircraft_get_nearest(position) {
         let nearest = null;

--- a/src/assets/scripts/client/canvas/CanvasController.js
+++ b/src/assets/scripts/client/canvas/CanvasController.js
@@ -1274,8 +1274,9 @@ export default class CanvasController {
             leg = leg.next;
         }
 
+        // TODO: Create its own color in theme
         // Label backgrounds
-        cc.fillStyle = this.theme.DATA_BLOCK.BACKGROUND_SELECTED;
+        cc.fillStyle = this.theme.SCOPE.RUNWAY_EXTENDED_CENTERLINE;
 
         values.forEach((item) => {
             const { x, y, labels } = item;
@@ -1285,8 +1286,9 @@ export default class CanvasController {
             cc.fillRect(x, y, width, height);
         });
 
+        // TODO: Add to theme customization
         // Label text
-        cc.fillStyle = 'orange';
+        cc.fillStyle = 'white';
         cc.font = '10px monoOne, monospace';
 
         values.forEach((item) => {
@@ -1316,7 +1318,7 @@ export default class CanvasController {
         const firstMidPoint = CanvasStageModel.translatePostionModelToPreciseCanvasPosition(leg.midPoint);
 
         // TODO: Colours should be move to themes
-        cc.strokeStyle = 'orange';
+        cc.strokeStyle = 'rgba(64, 127, 143, 1.0)';
 
         cc.beginPath();
 

--- a/src/assets/scripts/client/canvas/CanvasController.js
+++ b/src/assets/scripts/client/canvas/CanvasController.js
@@ -1232,7 +1232,7 @@ export default class CanvasController {
             return;
         }
 
-        const pathInfo = MeasureTool.getPathInfo();
+        const pathInfo = MeasureTool.buildPathInfo();
 
         this._drawMeasureToolPath(cc, pathInfo);
         this._drawMeasureToolLabels(cc, pathInfo);
@@ -1255,11 +1255,11 @@ export default class CanvasController {
 
         // This way the points are translated only once
         while (leg != null) {
-            const p = CanvasStageModel.translatePostionModelToPreciseCanvasPosition(leg.midPoint);
+            const position = CanvasStageModel.translatePostionModelToPreciseCanvasPosition(leg.midPoint);
 
             values.push({
-                x: p.x,
-                y: p.y,
+                x: position.x,
+                y: position.y,
                 labels: leg.labels
             });
 
@@ -1321,11 +1321,11 @@ export default class CanvasController {
             const {
                 isRHT, center, entryAngle, exitAngle, turnRadius
             } = initialTurn;
-            const p = CanvasStageModel.translatePostionModelToPreciseCanvasPosition(center);
+            const position = CanvasStageModel.translatePostionModelToPreciseCanvasPosition(center);
             const radius = CanvasStageModel.translateKilometersToPixels(turnRadius);
 
             // The angles calculated in the `MeasureTool` are magnetic, and have to be shifted CCW 90°
-            cc.arc(p.x, p.y, radius, entryAngle - Math.PI / 2, exitAngle - Math.PI / 2, !isRHT);
+            cc.arc(position.x, position.y, radius, entryAngle - Math.PI / 2, exitAngle - Math.PI / 2, !isRHT);
         }
 
         // Draw up to the first midpoint
@@ -1336,17 +1336,17 @@ export default class CanvasController {
         while (leg != null) {
             const { next } = leg;
             const radius = CanvasStageModel.translateKilometersToPixels(leg.radius);
-            const p0 = CanvasStageModel.translatePostionModelToPreciseCanvasPosition(leg.endPoint);
+            const position1 = CanvasStageModel.translatePostionModelToPreciseCanvasPosition(leg.endPoint);
 
             if (next === null) {
                 // This is the last leg, so simply draw to the end point
-                cc.lineTo(p0.x, p0.y);
+                cc.lineTo(position1.x, position1.y);
             } else {
                 // Draw an arc'd line to the next midpoint
-                const p1 = CanvasStageModel.translatePostionModelToPreciseCanvasPosition(next.midPoint);
+                const position2 = CanvasStageModel.translatePostionModelToPreciseCanvasPosition(next.midPoint);
 
-                cc.arcTo(p0.x, p0.y, p1.x, p1.y, radius);
-                cc.lineTo(p1.x, p1.y);
+                cc.arcTo(position1.x, position1.y, position2.x, position2.y, radius);
+                cc.lineTo(position2.x, position2.y);
             }
 
             leg = next;

--- a/src/assets/scripts/client/canvas/CanvasController.js
+++ b/src/assets/scripts/client/canvas/CanvasController.js
@@ -1228,14 +1228,19 @@ export default class CanvasController {
      * @private
      */
     _drawMeasureTool(cc) {
-        if (!MeasureTool.hasLegs) {
+        if (!MeasureTool.hasPaths) {
             return;
         }
 
-        const pathInfo = MeasureTool.buildPathInfo();
+        const pathInfoList = MeasureTool.buildPathInfo();
 
-        this._drawMeasureToolPath(cc, pathInfo);
-        this._drawMeasureToolLabels(cc, pathInfo);
+        cc.save();
+        cc.translate(CanvasStageModel.halfWidth, CanvasStageModel.halfHeight);
+
+        pathInfoList.forEach((pathInfo) => {
+            this._drawMeasureToolPath(cc, pathInfo);
+            this._drawMeasureToolLabels(cc, pathInfo);
+        });
 
         cc.restore();
     }
@@ -1255,13 +1260,16 @@ export default class CanvasController {
 
         // This way the points are translated only once
         while (leg != null) {
-            const position = CanvasStageModel.translatePostionModelToPreciseCanvasPosition(leg.midPoint);
+            // Ignore empty labels
+            if (leg.labels !== null && leg.labels.length !== 0) {
+                const position = CanvasStageModel.translatePostionModelToPreciseCanvasPosition(leg.midPoint);
 
-            values.push({
-                x: position.x,
-                y: position.y,
-                labels: leg.labels
-            });
+                values.push({
+                    x: position.x,
+                    y: position.y,
+                    labels: leg.labels
+                });
+            }
 
             leg = leg.next;
         }
@@ -1306,9 +1314,6 @@ export default class CanvasController {
         let leg = firstLeg.next; // We start enumerating from the 2nd leg (the first complete leg)
         const firstPoint = CanvasStageModel.translatePostionModelToPreciseCanvasPosition(firstLeg.endPoint);
         const firstMidPoint = CanvasStageModel.translatePostionModelToPreciseCanvasPosition(leg.midPoint);
-
-        cc.save();
-        cc.translate(CanvasStageModel.halfWidth, CanvasStageModel.halfHeight);
 
         // TODO: Colours should be move to themes
         cc.strokeStyle = 'orange';

--- a/src/assets/scripts/client/canvas/CanvasController.js
+++ b/src/assets/scripts/client/canvas/CanvasController.js
@@ -7,6 +7,7 @@ import AirportController from '../airport/AirportController';
 import CanvasStageModel from './CanvasStageModel';
 import EventBus from '../lib/EventBus';
 import GameController from '../game/GameController';
+import MeasureTool from '../measurement/MeasureTool';
 import NavigationLibrary from '../navigationLibrary/NavigationLibrary';
 import TimeKeeper from '../engine/TimeKeeper';
 import { tau } from '../math/circle';
@@ -1227,13 +1228,11 @@ export default class CanvasController {
      * @private
      */
     _drawMeasureTool(cc) {
-        const { measureTool } = prop.input;
-
-        if (!measureTool.hasLegs) {
+        if (!MeasureTool.hasLegs) {
             return;
         }
 
-        const pathInfo = measureTool.getPathInfo();
+        const pathInfo = MeasureTool.getPathInfo();
 
         this._drawMeasureToolPath(cc, pathInfo);
         this._drawMeasureToolLabels(cc, pathInfo);

--- a/src/assets/scripts/client/canvas/CanvasController.js
+++ b/src/assets/scripts/client/canvas/CanvasController.js
@@ -1255,7 +1255,7 @@ export default class CanvasController {
      * @private
      */
     _drawMeasureToolLabels(cc, pathInfo) {
-        let leg = pathInfo.firstLeg.next;
+        let leg = pathInfo.firstLeg;
         const values = [];
 
         // This way the points are translated only once
@@ -1310,9 +1310,9 @@ export default class CanvasController {
      * @private
      */
     _drawMeasureToolPath(cc, pathInfo) {
-        const { initialTurn, firstLeg } = pathInfo;
-        let leg = firstLeg.next; // We start enumerating from the 2nd leg (the first complete leg)
-        const firstPoint = CanvasStageModel.translatePostionModelToPreciseCanvasPosition(firstLeg.endPoint);
+        const { initialTurn } = pathInfo;
+        let leg = pathInfo.firstLeg;
+        const firstPoint = CanvasStageModel.translatePostionModelToPreciseCanvasPosition(leg.startPoint);
         const firstMidPoint = CanvasStageModel.translatePostionModelToPreciseCanvasPosition(leg.midPoint);
 
         cc.strokeStyle = this.theme.SCOPE.MEASURE_LINE;

--- a/src/assets/scripts/client/canvas/CanvasController.js
+++ b/src/assets/scripts/client/canvas/CanvasController.js
@@ -1274,9 +1274,8 @@ export default class CanvasController {
             leg = leg.next;
         }
 
-        // TODO: Create its own color in theme
         // Label backgrounds
-        cc.fillStyle = this.theme.SCOPE.RUNWAY_EXTENDED_CENTERLINE;
+        cc.fillStyle = this.theme.SCOPE.MEASURE_BACKGROUND;
 
         values.forEach((item) => {
             const { x, y, labels } = item;
@@ -1286,10 +1285,9 @@ export default class CanvasController {
             cc.fillRect(x, y, width, height);
         });
 
-        // TODO: Add to theme customization
         // Label text
-        cc.fillStyle = 'white';
-        cc.font = '10px monoOne, monospace';
+        cc.fillStyle = this.theme.SCOPE.MEASURE_TEXT;
+        cc.font = this.theme.DATA_BLOCK.TEXT_FONT;
 
         values.forEach((item) => {
             const { labels } = item;
@@ -1317,8 +1315,7 @@ export default class CanvasController {
         const firstPoint = CanvasStageModel.translatePostionModelToPreciseCanvasPosition(firstLeg.endPoint);
         const firstMidPoint = CanvasStageModel.translatePostionModelToPreciseCanvasPosition(leg.midPoint);
 
-        // TODO: Colours should be move to themes
-        cc.strokeStyle = 'rgba(64, 127, 143, 1.0)';
+        cc.strokeStyle = this.theme.SCOPE.MEASURE_LINE;
 
         cc.beginPath();
 

--- a/src/assets/scripts/client/canvas/CanvasController.js
+++ b/src/assets/scripts/client/canvas/CanvasController.js
@@ -1257,6 +1257,7 @@ export default class CanvasController {
     _drawMeasureToolLabels(cc, pathInfo) {
         let leg = pathInfo.firstLeg;
         const values = [];
+        const labelPadding = 5;
 
         // This way the points are translated only once
         while (leg != null) {
@@ -1274,24 +1275,34 @@ export default class CanvasController {
             leg = leg.next;
         }
 
+        // Shortcut if there are no labels (line is too short)
+        if (values.length === 0) {
+            return;
+        }
+
         // Label backgrounds
         cc.fillStyle = this.theme.SCOPE.MEASURE_BACKGROUND;
+        cc.font = this.theme.DATA_BLOCK.TEXT_FONT;
 
         values.forEach((item) => {
             const { x, y, labels } = item;
-            const height = 10 + (12 * labels.length);
-            const width = 150;
+            const height = (2 * labelPadding) + (12 * labels.length);
+            const maxLabelWidth = labels.reduce((lastWidth, label) => {
+                const newWidth = cc.measureText(label).width;
+
+                return Math.max(lastWidth, newWidth);
+            }, 0);
+            const width = (2 * labelPadding) + maxLabelWidth;
 
             cc.fillRect(x, y, width, height);
         });
 
         // Label text
         cc.fillStyle = this.theme.SCOPE.MEASURE_TEXT;
-        cc.font = this.theme.DATA_BLOCK.TEXT_FONT;
 
         values.forEach((item) => {
             const { labels } = item;
-            const x = item.x + 5;
+            const x = item.x + labelPadding;
             const y = item.y + 15;
 
             labels.forEach((line, index) => {

--- a/src/assets/scripts/client/constants/eventNames.js
+++ b/src/assets/scripts/client/constants/eventNames.js
@@ -254,6 +254,13 @@ export const EVENT = {
     RANGE_RINGS_CHANGE: 'range-rings-change',
 
     /**
+     * @memberof EVENT
+     * @property MEASURE_TOOL_STYLE_CHANGE
+     * @type {string}
+     */
+    MEASURE_TOOL_STYLE_CHANGE: 'measure-tool-style-change',
+
+    /**
      * A click has been registered in the unpause button shown within the
      * screen overlay whil the app is paused
      *

--- a/src/assets/scripts/client/constants/gameOptionConstants.js
+++ b/src/assets/scripts/client/constants/gameOptionConstants.js
@@ -1,4 +1,5 @@
 import { EVENT } from './eventNames';
+import { MEASURE_TOOL_STYLE } from './inputConstants';
 
 /* eslint-disable max-len, import/prefer-default-export */
 /**
@@ -9,15 +10,15 @@ import { EVENT } from './eventNames';
  * @final
  */
 export const GAME_OPTION_NAMES = {
-    THEME: 'theme',
     CONTROL_METHOD: 'controlMethod',
-    PROJECTED_TRACK_LINE_LENGTHS: 'ptlLengths',
     DRAW_PROJECTED_PATHS: 'drawProjectedPaths',
-    SOFT_CEILING: 'softCeiling',
     DRAW_ILS_DISTANCE_SEPARATOR: 'drawIlsDistanceSeparator',
+    MEASURE_TOOL_PATH: 'measureToolPath',
     MOUSE_CLICK_DRAG: 'mouseClickDrag',
+    PROJECTED_TRACK_LINE_LENGTHS: 'ptlLengths',
     RANGE_RINGS: 'rangeRings',
-    MEASURE_TOOL_PATH: 'measureToolPath'
+    SOFT_CEILING: 'softCeiling',
+    THEME: 'theme'
 };
 
 /**
@@ -210,21 +211,21 @@ export const GAME_OPTION_VALUES = [
         name: GAME_OPTION_NAMES.MEASURE_TOOL_PATH,
         defaultValue: '0',
         description: 'Measure path style',
-        help: 'How the path is rendered when measuring vectors',
+        help: 'How the path is rendered when using the range/bearing measuring tool',
         type: 'select',
         onChangeEventHandler: EVENT.MEASURE_TOOL_STYLE_CHANGE,
         optionList: [
             {
-                displayLabel: 'Straight Lines',
-                value: 0
+                displayLabel: 'Straight lines only',
+                value: MEASURE_TOOL_STYLE.STRAIGHT
             },
             {
-                displayLabel: 'Straight with initial turn',
-                value: 1
+                displayLabel: 'Arc to next fix, then straight',
+                value: MEASURE_TOOL_STYLE.ARC_TO_NEXT
             },
             {
-                displayLabel: 'Arced with initial turn',
-                value: 3
+                displayLabel: 'All lines arced',
+                value: MEASURE_TOOL_STYLE.ALL_ARCED
             }
         ]
     }

--- a/src/assets/scripts/client/constants/gameOptionConstants.js
+++ b/src/assets/scripts/client/constants/gameOptionConstants.js
@@ -16,7 +16,8 @@ export const GAME_OPTION_NAMES = {
     SOFT_CEILING: 'softCeiling',
     DRAW_ILS_DISTANCE_SEPARATOR: 'drawIlsDistanceSeparator',
     MOUSE_CLICK_DRAG: 'mouseClickDrag',
-    RANGE_RINGS: 'rangeRings'
+    RANGE_RINGS: 'rangeRings',
+    MEASURE_TOOL_PATH: 'measureToolPath'
 };
 
 /**
@@ -202,6 +203,28 @@ export const GAME_OPTION_VALUES = [
             {
                 displayLabel: '20 nm',
                 value: 20
+            }
+        ]
+    },
+    {
+        name: GAME_OPTION_NAMES.MEASURE_TOOL_PATH,
+        defaultValue: '0',
+        description: 'Measure path style',
+        help: 'How the path is rendered when measuring vectors',
+        type: 'select',
+        onChangeEventHandler: EVENT.MEASURE_TOOL_STYLE_CHANGE,
+        optionList: [
+            {
+                displayLabel: 'Straight Lines',
+                value: 0
+            },
+            {
+                displayLabel: 'Straight with initial turn',
+                value: 1
+            },
+            {
+                displayLabel: 'Arced with initial turn',
+                value: 3
             }
         ]
     }

--- a/src/assets/scripts/client/constants/inputConstants.js
+++ b/src/assets/scripts/client/constants/inputConstants.js
@@ -20,6 +20,10 @@ export const COMMAND_CONTEXT = {
  */
 export const KEY_CODES = {
 
+    CONTROL_LEFT: 'ControlLeft',
+    CONTROL_RIGHT: 'ControlRight',
+    SHIFT_LEFT: 'ShiftLeft',
+    SHIFT_RIGHT: 'ShiftRight',
     ENTER: 'Enter',
     ESCAPE: 'Escape',
     TAB: 'Tab',

--- a/src/assets/scripts/client/constants/inputConstants.js
+++ b/src/assets/scripts/client/constants/inputConstants.js
@@ -99,6 +99,15 @@ export const LEGACY_KEY_CODES = {
 };
 
 /**
+ * Enumeration of the render styles used by `MeasureTool`
+ */
+export const MEASURE_TOOL_STYLE = {
+    STRAIGHT: 'straight',
+    ARC_TO_NEXT: 'initial_turn',
+    ALL_ARCED: 'arced'
+};
+
+/**
  * Enumeration of the mouse button names
  *
  * @property MOUSE_BUTTON_NAMES

--- a/src/assets/scripts/client/constants/themes/classic/modules/scope.js
+++ b/src/assets/scripts/client/constants/themes/classic/modules/scope.js
@@ -11,6 +11,31 @@ export const SCOPE_THEME = {
     FIX_TEXT: COLOR.WHITE_05,
     HALO_DEFAULT_RADIUS_NM: 3,
     HALO_MAX_RADIUS_NM: 20,
+
+    /**
+     * Color to use for the background on the `MeasureTool` labels
+     *
+     * @memberof SCOPE_THEME
+     * @property MEASURE_BACKGROUND
+     */
+    MEASURE_BACKGROUND: COLOR.GREEN_MEDIUM,
+
+    /**
+     * Color to use for the text on the `MeasureTool` line
+     *
+     * @memberof SCOPE_THEME
+     * @property MEASURE_LINE
+     */
+    MEASURE_LINE: COLOR.GREEN_LIGHT,
+
+    /**
+     * Color to use for the text on the `MeasureTool` labels
+     *
+     * @memberof SCOPE_THEME
+     * @property MEASURE_TEXT
+     */
+    MEASURE_TEXT: COLOR.WHITE,
+
     RANGE_RING_COLOR: COLOR.GREEN_LIGHT_PALE_01,
     RESTRICTED_AIRSPACE: COLOR.BLUE_LIGHT_SOFT_03,
     RUNWAY_EXTENDED_CENTERLINE: COLOR.GREEN_MEDIUM,

--- a/src/assets/scripts/client/constants/themes/default/modules/scope.js
+++ b/src/assets/scripts/client/constants/themes/default/modules/scope.js
@@ -93,6 +93,30 @@ export const SCOPE_THEME = {
     HALO_MAX_RADIUS_NM: 20,
 
     /**
+     * Color to use for the background on the `MeasureTool` labels
+     *
+     * @memberof SCOPE_THEME
+     * @property MEASURE_BACKGROUND
+     */
+    MEASURE_BACKGROUND: COLOR.BLUE_MEDIUM_DARK,
+
+    /**
+     * Color to use for the text on the `MeasureTool` line
+     *
+     * @memberof SCOPE_THEME
+     * @property MEASURE_LINE
+     */
+    MEASURE_LINE: COLOR.BLUE_VERY_LIGHT,
+
+    /**
+     * Color to use for the labels on the `MeasureTool` labels
+     *
+     * @memberof SCOPE_THEME
+     * @property MEASURE_TEXT
+     */
+    MEASURE_TEXT: COLOR.WHITE,
+
+    /**
      * Color of the range rings shown on the scope around the airport
      *
      * @memberof SCOPE_THEME

--- a/src/assets/scripts/client/measurement/MeasureLegModel.js
+++ b/src/assets/scripts/client/measurement/MeasureLegModel.js
@@ -165,7 +165,7 @@ export default class MeasureLegModel {
      * The turn radius (in km)
      *
      * @for MeasureLegModel
-     * @property _radius
+     * @property radius
      * @type {number}
      */
     get radius() {
@@ -183,7 +183,7 @@ export default class MeasureLegModel {
      * The start point of this leg
      *
      * @for MeasureLegModel
-     * @property midPoint
+     * @property startPoint
      * @type {array<number>|null}
      */
     get startPoint() {

--- a/src/assets/scripts/client/measurement/MeasureLegModel.js
+++ b/src/assets/scripts/client/measurement/MeasureLegModel.js
@@ -169,14 +169,14 @@ export default class MeasureLegModel {
      * @type {number}
      */
     get radius() {
-        const response = this._radius;
+        const radius = this._radius;
 
-        // No point in validating if the radius isn't present
-        if (response === 0) {
-            return response;
+        // No point in validating if the radius is empty
+        if (radius === 0) {
+            return radius;
         }
 
-        return this._hasValidRadius() ? response : 0;
+        return this._hasValidRadius() ? radius : 0;
     }
 
     /**

--- a/src/assets/scripts/client/measurement/MeasureLegModel.js
+++ b/src/assets/scripts/client/measurement/MeasureLegModel.js
@@ -1,0 +1,277 @@
+import { angle_offset } from '../math/circle';
+import { bearingToPoint } from '../math/flightMath';
+import { distance2d } from '../math/distance';
+
+/**
+ * Describes a single leg of a path being measured, used by the
+ * `MeasureTool` to draw the path on the `CanvasController`
+ *
+ * These form a doubly linked list, that allows each leg to reference
+ * the `#previous` and `#next` legs.
+ */
+export default class MeasureLegModel {
+    /**
+     * @for MeasureLeg
+     * @constructor
+     * @param endPoint {array<number>}
+     * @param previousLeg {MeasureLegModel|null}
+     */
+    constructor(endPoint, radius = 0, previousLeg = null) {
+        /**
+         * The bearing along the leg (in radians)
+         *
+         * @for MeasureLegModel
+         * @property _bearing
+         * @type {number}
+         * @default null
+         * @private
+         */
+        this._bearing = null;
+
+        /**
+         * The end point of the leg
+         *
+         * @for MeasureLegModel
+         * @property endPoint
+         * @type {array<number>}
+         * @default endPoint
+         */
+        this.endPoint = endPoint;
+
+        /**
+         * The length of the leg (in km)
+         *
+         * @for MeasureLegModel
+         * @property _distance
+         * @type {number}
+         * @default null
+         * @private
+         */
+        this._distance = null;
+
+        /**
+         * The list of text labels to be displayed
+         *
+         * @for MeasureLegModel
+         * @property labels
+         * @type {labels}
+         * @default null;
+         */
+        this.labels = null;
+
+        /**
+         * The end point of the leg
+         *
+         * @for MeasureLegModel
+         * @property _midPoint
+         * @type {array<number>|null}
+         * @default null
+         * @private
+         */
+        this._midPoint = null;
+
+        /**
+         * The midpoint of this leg
+         *
+         * @for MeasureLegModel
+         * @property _next
+         * @type {MeasureLegModel}
+         * @default null;
+         * @private
+         */
+        this._next = null;
+
+        /**
+         * The previous leg
+         *
+         * @for MeasureLegModel
+         * @property _previous
+         * @type {MeasureLegModel}
+         * @default previousLeg
+         * @private
+         */
+        this._previous = previousLeg;
+
+        /**
+         * The turn radius (in km)
+         *
+         * @for MeasureLegModel
+         * @property _radius
+         * @type {number}
+         * @default radius
+         * @private
+         */
+        this._radius = radius;
+
+        this._init(previousLeg);
+    }
+
+    /**
+     * The bearing along the leg (in radians)
+     *
+     * @for MeasureLegModel
+     * @property bearing
+     * @type {number}
+     */
+    get bearing() {
+        return this._bearing;
+    }
+
+    /**
+     * The length of the leg (in km)
+     *
+     * @for MeasureLegModel
+     * @property distance
+     * @type {number}
+     */
+    get distance() {
+        return this._distance;
+    }
+
+    /**
+     * The midpoint of this leg
+     *
+     * @for MeasureLegModel
+     * @property midPoint
+     * @type {array<number>|null}
+     */
+    get midPoint() {
+        return this._midPoint;
+    }
+
+    /**
+     * The next leg
+     *
+     * @for MeasureLegModel
+     * @property next
+     * @type {MeasureLegModel}
+     */
+    get next() {
+        return this._next;
+    }
+
+    /**
+     * The previous leg
+     *
+     * @for MeasureLegModel
+     * @property next
+     * @type {MeasureLegModel}
+     */
+    get previous() {
+        return this._previous;
+    }
+
+    /**
+     * The turn radius (in km)
+     *
+     * @for MeasureLegModel
+     * @property _radius
+     * @type {number}
+     */
+    get radius() {
+        const response = this._radius;
+
+        // No point in validating if the radius isn't present
+        if (response === 0) {
+            return response;
+        }
+
+        return this._hasValidRadius() ? response : 0;
+    }
+
+    /**
+     * The start point of this leg
+     *
+     * @for MeasureLegModel
+     * @property midPoint
+     * @type {array<number>|null}
+     */
+    get startPoint() {
+        return this._previous === null ? null : this._previous.endPoint;
+    }
+
+    // ------------------------------ LIFECYCLE ------------------------------
+
+    /**
+     * @for MeasureLegModel
+     * @method _init
+     * @param previousLeg {MeasureLegModel|null}
+     * @private
+     */
+    _init(previousLeg) {
+        if (previousLeg !== null) {
+            previousLeg._next = this;
+
+            this._calculateLegParameters();
+        }
+    }
+
+    // ------------------------------ PUBLIC ------------------------------
+
+    // ------------------------------ PRIVATE ------------------------------
+
+    /**
+     * Calculates the metrics of the leg, `#_midPoint`, `#_distance`, `#_bearing`
+     *
+     * @for MeasureLegTool
+     * @method _calculateLegParameters
+     * @private
+     */
+    _calculateLegParameters() {
+        const start = this.startPoint;
+        const end = this.endPoint;
+
+        this._midPoint = [
+            (start[0] + end[0]) / 2,
+            (start[1] + end[1]) / 2
+        ];
+        this._bearing = bearingToPoint(start, end);
+        this._distance = distance2d(start, end);
+    }
+
+    /**
+     * Returns a flag that indicates whether the radius is valid for this leg
+     *
+     * @for MeasureLegMode
+     * @method _hasValidRadius
+     * @returns {boolean}
+     * @private
+     */
+    _hasValidRadius() {
+        const nextLeg = this.next;
+
+        if (nextLeg === null) {
+            return false;
+        }
+
+        // The arcTo command gives strange results when the relative radius is too large
+        // TODO: This isn't working fully, it still passes some geometries
+        // Granted they're not realistic ones, but still...
+
+        // A quick check to see if the angle is too acute (< 30°), before calculating
+        // distances, which is more expensive
+        const a1 = this.bearing;
+        const a2 = this.next.bearing + Math.PI;
+        const angularDifference = Math.abs(angle_offset(a1, a2));
+        const minAngle = Math.PI / 6;
+
+        if (angularDifference < minAngle) {
+            return false;
+        }
+
+        // The simplest method is to ensure that the diameter of the turning circle is less
+        // than the following:
+        // * distance between any midpoints and control points
+        // * the length either of the legs
+        const diameter = this._radius * 2;
+        const minLength = Math.min(
+            distance2d(this.midPoint, nextLeg.midPoint),
+            distance2d(this.midPoint, nextLeg.endPoint),
+            distance2d(this.startPoint, nextLeg.midPoint),
+            this.distance,
+            nextLeg.distance
+        );
+
+        return minLength >= diameter;
+    }
+}

--- a/src/assets/scripts/client/measurement/MeasurePath.js
+++ b/src/assets/scripts/client/measurement/MeasurePath.js
@@ -1,0 +1,439 @@
+import _round from 'lodash/round';
+import { radians_normalize } from '../math/circle';
+import { bearingToPoint } from '../math/flightMath';
+import { distance2d } from '../math/distance';
+import {
+    heading_to_string,
+    km,
+    nm
+} from '../utilities/unitConverters';
+import MeasureLegModel from './MeasureLegModel';
+import AircraftModel from '../aircraft/AircraftModel';
+import FixModel from '../navigationLibrary/FixModel';
+import { MEASURE_TOOL_STYLE } from '../constants/inputConstants';
+import { TIME } from '../constants/globalConstants';
+
+/**
+ * Defines a `MeasurePath`
+ *
+ * The `MeasurePath` is used by the `MeasureTool` to keep
+ * track of the points in a path being meaured and to
+ * generate a path to be drawn by the `CanvasController`
+ *
+ * A `MeasurePath` is designed to only be used internally
+ * by the `MeasureTool`
+ */
+export default class MeasurePath {
+    /**
+     * @for MeasurePath
+     * @constructor
+     * @param startPoint {AircraftModel|FixModel|array<number>}
+     * @param style {MEASURE_TOOL_STYLE}
+     */
+    constructor(style) {
+        /**
+         * The list of points that make up the path being measured
+         * This can be an object with a `#relativePosition` property,
+         * or a array of numbers that represent a `relativePosition`
+         *
+         * @for MeasurePath
+         * @property _points
+         * @type {AircraftModel|FixModel|array<number>}
+         * @default []
+         * @private
+         */
+        this._points = [];
+
+        /**
+         * The style of how the path is rendered
+         *
+         * @for MeasurePath
+         * @property style
+         * @type {MEASURE_TOOL_STYLE}
+         * @default null;
+         * @private
+         */
+        this._style = style;
+
+        this._init();
+    }
+
+    /** Gets the aircraft at the beginning of the path
+     *
+     * @for MeasurePath
+     * @property aircraft
+     * @type {AircraftModel|null}
+     */
+    get aircraft() {
+        if (!this.hasStarted || !(this._points[0] instanceof AircraftModel)) {
+            return null;
+        }
+
+        return this._points[0];
+    }
+
+    /**
+     * Indicates whether there are any valid legs
+     *
+     * @for MeasurePath
+     * @property hasLegs
+     * @type {boolean}
+     */
+    get hasLegs() {
+        return this._points.length > 1;
+    }
+
+    /**
+     * Indicates the `MeasurePath` has started measuring
+     * eg. the path has at least one point
+     *
+     * @for MeasurePath
+     * @property hasLegs
+     * @type {boolean}
+     */
+    get hasStarted() {
+        return this._points.length !== 0;
+    }
+
+    /**
+     * Gets a flag indicating whether the '#style' indicates that
+     * the initial turn should be used when building the path
+     *
+     * @for MeasurePath
+     * @property hasStyleInitialTurn
+     * @returns {boolean}
+     */
+    get hasStyleInitialTurn() {
+        return this._style === MEASURE_TOOL_STYLE.ARC_TO_NEXT ||
+            this._style === MEASURE_TOOL_STYLE.ALL_ARCED;
+    }
+
+    /**
+     * Gets a flag indicating whether the '#style' indicates that
+     * the arcs should be used when building the path
+     *
+     * @for MeasurePath
+     * @property hasStyleArced
+     * @returns {boolean}
+     */
+    get hasStyleArced() {
+        return this._style === MEASURE_TOOL_STYLE.ALL_ARCED;
+    }
+
+    // ------------------------------ LIFECYCLE ------------------------------
+
+    /**
+     * @for MeasurePath
+     * @method _init
+     * @private
+     */
+    _init() {
+    }
+
+    // ------------------------------ PUBLIC ------------------------------
+
+    /**
+     * Adds a point to the path being measured
+     *
+     * The value can be an object with a `#relativePosition` property,
+     * or a array of numbers that represent a `relativePosition`
+     *
+     * @for MeasurePath
+     * @method addPoint
+     * @param value {AircraftModel|FixModel|array<number>}
+     */
+    addPoint(value) {
+        this._throwIfPointInvalid(value);
+
+        this._points.push(value);
+    }
+
+    /**
+     * Gets the information for the path that should be drawn on the `CanvasController`
+     *
+     * @for MeasurePath
+     * @method buildPathInfo
+     * @returns {object}
+     */
+    buildPathInfo() {
+        if (!this.hasLegs) {
+            return null;
+        }
+
+        // Ground speed is only known if the first point is an AircraftModel
+        const { aircraft } = this;
+        const groundSpeed = aircraft === null ? null : aircraft.groundSpeed;
+        const initialTurn = this._buildInitialTurnParameters();
+        const pointsList = [...this._points]; // Shallow copy as the first point may be replaced
+        let radius = 0;
+
+        if (initialTurn !== null && this.hasStyleArced) {
+            radius = initialTurn.turnRadius;
+        }
+
+        // These are the values used when reducing the points array
+        const initialValues = {
+            previousLeg: null,
+            totalDistance: 0,
+            totalDuration: 0
+        };
+
+        // If there is an initialTurn (eg. a turn onto the first leg), then the exit point is used
+        // as the first point in the path
+        // We also calculate the distance and time take to fly the turn
+        if (initialTurn !== null) {
+            const { exitPoint, arcLength } = initialTurn;
+            const distance = nm(arcLength);
+            const duration = _round((distance / groundSpeed) * TIME.ONE_HOUR_IN_MINUTES, 1);
+
+            initialValues.lastPoint = exitPoint;
+            initialValues.totalDistance = distance;
+            initialValues.totalDuration = duration;
+
+            pointsList[0] = exitPoint;
+        }
+
+        // The first leg is just an end point
+        const firstPoint = this._getRelativePosition(pointsList.shift());
+        const firstLeg = new MeasureLegModel(firstPoint);
+        initialValues.previousLeg = firstLeg;
+
+        pointsList.reduce((lastValues, point) => {
+            const { previousLeg } = lastValues;
+            let { totalDistance, totalDuration } = lastValues;
+            const leg = new MeasureLegModel(
+                this._getRelativePosition(point),
+                radius,
+                previousLeg
+            );
+            const distance = nm(leg.distance);
+            const bearing = heading_to_string(leg.bearing);
+            let duration = 0;
+
+            if (groundSpeed !== null) {
+                duration = _round((distance / groundSpeed) * TIME.ONE_HOUR_IN_MINUTES, 1);
+            }
+
+            // We only want labels that have a distance
+            if (distance > 1) {
+                const labels = [
+                    this._buildLabel(distance, duration, bearing)
+                ];
+
+                totalDistance += distance;
+                totalDuration = _round(totalDuration + duration, 1);
+
+                if (totalDistance !== distance) {
+                    labels.push(this._buildLabel(totalDistance, totalDuration));
+                }
+
+                leg.labels = labels;
+            }
+
+            return {
+                previousLeg: leg,
+                totalDistance,
+                totalDuration
+            };
+        }, initialValues);
+
+        return {
+            initialTurn,
+            firstLeg
+        };
+    }
+
+    /**
+     * Removes the last point from the path
+     *
+     * @for MeasurePath
+     * @method removeLastPoint
+     */
+    removeLastPoint() {
+        // The "last" point is actually the 2nd last item in _points
+        // This means the path will end at the cursor position when redrawn
+        const { length } = this._points;
+
+        if (length > 2) {
+            this._points.splice(length - 2, 1);
+        }
+    }
+
+    /**
+     * Sets the style that should be used for path generation and rendering
+     *
+     * If an invalid valid for MEASURE_TOOL_STYLE is passed, it will default to
+     * `MEASURE_TOOL_STYLE.STRAIGHT`
+     *
+     * @for MeasurePath
+     * @method setStyle
+     * @param style {MEASURE_TOOL_STYLE}
+     */
+    setStyle(style) {
+        this._style = style;
+    }
+
+    /**
+     * Updates the last point in the path
+     *
+     * The value can be an object with a `#relativePosition` property,
+     * or a array of numbers that represent a `relativePosition`
+     *
+     * @for MeasurePath
+     * @method updateEndPoint
+     * @param value {AircraftModel|FixModel|array<number>}
+     */
+    updateLastPoint(value) {
+        this._throwIfPointInvalid(value);
+
+        if (!this.hasStarted) {
+            return;
+        }
+
+        if (!this.hasLegs) {
+            this.addPoint(value);
+
+            return;
+        }
+
+        this._points[this._points.length - 1] = value;
+    }
+
+    // ------------------------------ PRIVATE ------------------------------
+
+    /**
+     * Builds the initial turn parameters that are needed to fly to the first fix
+     *
+     * @for MeasurePath
+     * @method _buildInitialTurnParameters
+     * @returns {object}
+     * @private
+     */
+    _buildInitialTurnParameters() {
+        if (!this.hasStyleInitialTurn) {
+            return null;
+        }
+
+        const { aircraft } = this;
+
+        if (aircraft === null) {
+            return null;
+        }
+
+        const { groundSpeed, groundTrack } = aircraft;
+        const turnRate = 3; // Turn rate seems fixed at 3°/sec // groundSpeed > 250 ? 1.5 : 3;
+        const turnRadius = km(groundSpeed / (turnRate * 20 * Math.PI));
+        const start = aircraft.relativePosition;
+        const fix = this._getRelativePositionAtIndex(1);
+
+        // Get the turn direction by using the basic bearing to the next point
+        const bearingToFix = bearingToPoint(start, fix);
+        const isRHT = radians_normalize(bearingToFix - groundTrack) < Math.PI;
+        const direction = isRHT ? 1 : -1;
+
+        // The centre of the turn circle is offset to the left or right by 90°
+        const bearingToCenter = groundTrack + (direction * Math.PI / 2);
+        const center = [
+            start[0] + (turnRadius * Math.sin(bearingToCenter)),
+            start[1] + (turnRadius * Math.cos(bearingToCenter))
+        ];
+
+        // Turn exit (tangent from turn circle to the fix)
+        const centerToFixBearing = bearingToPoint(center, fix);
+        const centerToFixDistance = distance2d(center, fix);
+        const outboundCourse = centerToFixBearing + (direction * Math.asin(turnRadius / centerToFixDistance));
+
+        // Entry and exit angles
+        const entryAngle = bearingToCenter + Math.PI;
+        const exitAngle = outboundCourse - (direction * Math.PI / 2);
+
+        // The exit point is the point on the turn circle at the exit angle
+        const exitPoint = [
+            center[0] + (turnRadius * Math.sin(exitAngle)),
+            center[1] + (turnRadius * Math.cos(exitAngle))
+        ];
+
+        // Length around the arc
+        let turnAngle;
+        if (isRHT) {
+            turnAngle = exitAngle - entryAngle;
+        } else {
+            turnAngle = entryAngle - exitAngle;
+        }
+        const arcLength = turnRadius * radians_normalize(turnAngle);
+
+        return {
+            isRHT,
+            turnRadius,
+            arcLength,
+            entryAngle,
+            exitAngle,
+            center,
+            exitPoint
+        };
+    }
+
+    /**
+     * Builds the text label that displays the distance and
+     * optional duration and bearings
+     *
+     * @for MeasurePath
+     * @method _buildLabel
+     * @param distance {number} The distance (in NM) that the leg covers
+     * @param duration {number} The length of time (in minutes) that flying the leg will take
+     * @param bearing {number|null} The bearing (degrees magnetic) along the leg
+     * @private
+     */
+    _buildLabel(distance, duration, bearing = null) {
+        let label = `${distance.toPrecision(3)} NM`;
+
+        if (duration !== 0) {
+            label += `, ${duration.toFixed(1)} min`;
+        }
+
+        if (bearing !== null) {
+            label += `, ${bearing}° M`;
+        }
+
+        return label;
+    }
+
+    /**
+     * Gets the relative position for the point at the specified index.
+     *
+     * @for MeasurePath
+     * @method _getRelativePositionAtIndex
+     * @param index {number}
+     * @returns {array<number>}
+     */
+    _getRelativePositionAtIndex(index) {
+        const point = this._points[index];
+
+        return this._getRelativePosition(point);
+    }
+
+    /**
+     * Gets the relative position for the point at the specified index.
+     *
+     * @for MeasurePath
+     * @method _getRelativePosition
+     * @param point {AircraftModel|FixModel|array<number>}
+     * @returns {array<number>}
+     */
+    _getRelativePosition(point) {
+        return point.relativePosition || point;
+    }
+
+    /**
+     * Facade for throwing a TypeError if a point value is not a valid type
+     *
+     * @for MeasurePath
+     * @method _throwIfPointInvalid
+     * @param value {AircraftModel|FixModel|array<number>}
+    */
+    _throwIfPointInvalid(value) {
+        if (!(value instanceof Array || value instanceof AircraftModel || value instanceof FixModel)) {
+            throw new TypeError(`value cannot be ${typeof value}. An Array, AircraftModel or FixModel is expected.`);
+        }
+    }
+}

--- a/src/assets/scripts/client/measurement/MeasurePath.js
+++ b/src/assets/scripts/client/measurement/MeasurePath.js
@@ -245,11 +245,22 @@ export default class MeasurePath {
 
     /**
      * Removes the last point from the path
+     * Note: This "last" point is the one that follows the cursor position
      *
      * @for MeasurePath
      * @method removeLastPoint
      */
     removeLastPoint() {
+        this._points.pop();
+    }
+
+    /**
+     * Removes the second-to-last point from the path
+     *
+     * @for MeasurePath
+     * @method removePreviousPoint
+     */
+    removePreviousPoint() {
         // The "last" point is actually the 2nd last item in _points
         // This means the path will end at the cursor position when redrawn
         const { length } = this._points;

--- a/src/assets/scripts/client/measurement/MeasurePath.js
+++ b/src/assets/scripts/client/measurement/MeasurePath.js
@@ -180,15 +180,10 @@ export default class MeasurePath {
 
         // If there is an initialTurn (eg. a turn onto the first leg), then the exit point is used
         // as the first point in the path
-        // We also calculate the distance and time take to fly the turn
         if (initialTurn !== null) {
-            const { exitPoint, arcLength } = initialTurn;
-            const distance = nm(arcLength);
-            const duration = _round((distance / groundSpeed) * TIME.ONE_HOUR_IN_MINUTES, 1);
+            const { exitPoint } = initialTurn;
 
             initialValues.lastPoint = exitPoint;
-            initialValues.totalDistance = distance;
-            initialValues.totalDuration = duration;
 
             pointsList[0] = exitPoint;
         }
@@ -198,7 +193,7 @@ export default class MeasurePath {
         const firstLeg = new MeasureLegModel(firstPoint);
         initialValues.previousLeg = firstLeg;
 
-        pointsList.reduce((lastValues, point) => {
+        pointsList.reduce((lastValues, point, index) => {
             const { previousLeg } = lastValues;
             let { totalDistance, totalDuration } = lastValues;
             const leg = new MeasureLegModel(
@@ -206,9 +201,14 @@ export default class MeasurePath {
                 radius,
                 previousLeg
             );
-            const distance = nm(leg.distance);
             const bearing = heading_to_string(leg.bearing);
+            let distance = nm(leg.distance);
             let duration = 0;
+
+            // If there's an initial turn, include the length of that in the first leg
+            if (index === 0 && initialTurn !== null) {
+                distance += nm(initialTurn.arcLength);
+            }
 
             if (groundSpeed !== null) {
                 duration = _round((distance / groundSpeed) * TIME.ONE_HOUR_IN_MINUTES, 1);

--- a/src/assets/scripts/client/measurement/MeasurePath.js
+++ b/src/assets/scripts/client/measurement/MeasurePath.js
@@ -188,10 +188,10 @@ export default class MeasurePath {
             pointsList[0] = exitPoint;
         }
 
-        // The first leg is just an end point
+        // The initial leg is just an end point
         const firstPoint = this._getRelativePosition(pointsList.shift());
-        const firstLeg = new MeasureLegModel(firstPoint);
-        initialValues.previousLeg = firstLeg;
+        const initialLeg = new MeasureLegModel(firstPoint);
+        initialValues.previousLeg = initialLeg;
 
         pointsList.reduce((lastValues, point, index) => {
             const { previousLeg } = lastValues;
@@ -239,7 +239,7 @@ export default class MeasurePath {
 
         return {
             initialTurn,
-            firstLeg
+            firstLeg: initialLeg.next
         };
     }
 

--- a/src/assets/scripts/client/measurement/MeasureTool.js
+++ b/src/assets/scripts/client/measurement/MeasureTool.js
@@ -1,27 +1,15 @@
-import _round from 'lodash/round';
 import EventBus from '../lib/EventBus';
-import { radians_normalize } from '../math/circle';
-import { bearingToPoint } from '../math/flightMath';
-import { distance2d } from '../math/distance';
-import {
-    heading_to_string,
-    km,
-    nm
-} from '../utilities/unitConverters';
-import MeasureLegModel from './MeasureLegModel';
-import AircraftModel from '../aircraft/AircraftModel';
+import MeasurePath from './MeasurePath';
 import GameController from '../game/GameController';
-import FixModel from '../navigationLibrary/FixModel';
 import { EVENT } from '../constants/eventNames';
 import { MEASURE_TOOL_STYLE } from '../constants/inputConstants';
 import { GAME_OPTION_NAMES } from '../constants/gameOptionConstants';
-import { TIME } from '../constants/globalConstants';
 
 /**
  * Defines a `MeasureTool`
  *
  * The `MeasureTool` is used by the `InputController` to
- * accept user input and build a list of `MeasureLegModels`
+ * accept user input and build a list of `MeasurePath`s
  * which calculate distances, durations and bearings
  */
 class MeasureTool {
@@ -31,6 +19,17 @@ class MeasureTool {
      */
     constructor() {
         /**
+         * The current path being measured
+         *
+         * @for MeasureTool
+         * @property _currentPath
+         * @type {MeasurePath}
+         * @default null
+         * @private
+         */
+        this._currentPath = null;
+
+        /**
          * @for MeasureTool
          * @property _eventBus
          * @type {EventBus}
@@ -39,27 +38,16 @@ class MeasureTool {
         this._eventBus = EventBus;
 
         /**
-         * Indicates whether the tool should be receiving input
+         * The list of `MeasurePath` objects that the tools is
+         * measuring
          *
          * @for MeasureTool
-         * @property isMeasuring
-         * @type {boolean}
-         * @default false
-         */
-        this.isMeasuring = false;
-
-        /**
-         * The list of points that make up the path being measured
-         * This can be an object with a `#relativePosition` property,
-         * or a array of numbers that represent a `relativePosition`
-         *
-         * @for MeasureTool
-         * @property _points
-         * @type {AircraftModel|FixModel|array<number>}
+         * @property _paths
+         * @type {array<MeasurePath>}
          * @default []
          * @private
          */
-        this._points = [];
+        this._paths = [];
 
         /**
          * The style of how the path is rendered
@@ -77,71 +65,44 @@ class MeasureTool {
             .enable();
     }
 
-    /** Gets the aircraft at the beginning of the path
-     *
-     * @for MeasureTool
-     * @property aircraft
-     * @type {AircraftModel|null}
-     */
-    get aircraft() {
-        if (!this.hasStarted || !(this._points[0] instanceof AircraftModel)) {
-            return null;
-        }
-
-        return this._points[0];
-    }
-
     /**
-     * Indicates whether there are any valid legs
+     * Indicates whether the `MeasureTool` has any paths
      *
      * @for MeasureTool
-     * @property hasLegs
+     * @property hasPaths
      * @type {boolean}
      */
-    get hasLegs() {
-        return this._points.length > 1;
+    get hasPaths() {
+        return this._paths.length !== 0;
     }
 
     /**
-     * Indicates the `MeasureTool` has started measuring
+     * Indicates the `MeasureTool`s current path has started measuring
+     * eg. the path has at least one point
      *
      * @for MeasureTool
      * @property hasLegs
      * @type {boolean}
      */
     get hasStarted() {
-        return this._points.length !== 0;
+        return this.isMeasuring && this._currentPath.hasStarted;
     }
 
     /**
-     * Gets a flag indicating whether the '#style' indicates that
-     * the initial turn should be used when building the path
+     * Indicates whether the tool should be receiving input
      *
      * @for MeasureTool
-     * @property hasStyleInitialTurn
-     * @returns {boolean}
+     * @property isMeasuring
+     * @type {boolean}
      */
-    get hasStyleInitialTurn() {
-        return this._style === MEASURE_TOOL_STYLE.ARC_TO_NEXT ||
-            this._style === MEASURE_TOOL_STYLE.ALL_ARCED;
-    }
-
-    /**
-     * Gets a flag indicating whether the '#style' indicates that
-     * the arcs should be used when building the path
-     *
-     * @for MeasureTool
-     * @property hasStyleArced
-     * @returns {boolean}
-     */
-    get hasStyleArced() {
-        return this._style === MEASURE_TOOL_STYLE.ALL_ARCED;
+    get isMeasuring() {
+        return this._currentPath !== null;
     }
 
     // ------------------------------ LIFECYCLE ------------------------------
 
     /**
-     * @for MeasureTools
+     * @for MeasureTool
      * @method _init
      * @chainable
      * @private
@@ -159,7 +120,7 @@ class MeasureTool {
      * @private
      */
     _setupHandlers() {
-        this._onMeasureToolStyleChangeHandler = this._onMeasureToolStyleChange.bind(this);
+        this._onMeasureTooltyleChangeHandler = this._onMeasureTooltyleChange.bind(this);
 
         return this;
     }
@@ -170,7 +131,7 @@ class MeasureTool {
      * @chainable
      */
     disable() {
-        this._eventBus.off(EVENT.MEASURE_TOOL_STYLE_CHANGE, this._onMeasureToolStyleChangeHandler);
+        this._eventBus.off(EVENT.MEASURE_TOOL_STYLE_CHANGE, this._onMeasureTooltyleChangeHandler);
 
         return this;
     }
@@ -181,7 +142,7 @@ class MeasureTool {
      * @chainable
      */
     enable() {
-        this._eventBus.on(EVENT.MEASURE_TOOL_STYLE_CHANGE, this._onMeasureToolStyleChangeHandler);
+        this._eventBus.on(EVENT.MEASURE_TOOL_STYLE_CHANGE, this._onMeasureTooltyleChangeHandler);
 
         return this;
     }
@@ -191,14 +152,14 @@ class MeasureTool {
      * @method reset
      */
     reset() {
-        this._points = [];
-        this.isMeasuring = false;
+        this._paths = [];
+        this._currentPath = null;
     }
 
     // ------------------------------ PUBLIC ------------------------------
 
     /**
-     * Adds a point to the path being measured
+     * Adds a point to the current path being measured
      *
      * The value can be an object with a `#relativePosition` property,
      * or a array of numbers that represent a `relativePosition`
@@ -209,105 +170,46 @@ class MeasureTool {
      */
     addPoint(value) {
         this._throwIfNotMeasuring();
-        this._throwIfPointInvalid(value);
 
-        this._points.push(value);
+        this._currentPath.addPoint(value);
     }
 
     /**
-     * Gets the information for the path that should be drawn on the `CanvasController`
+     * Gets the information for the paths that should be drawn on the `CanvasController`
      *
      * @for MeasureTool
      * @method buildPathInfo
-     * @returns {object}
+     * @returns {array<object>}
      */
     buildPathInfo() {
-        if (!this.hasLegs) {
-            return null;
-        }
-
-        // Ground speed is only known if the first point is an AircraftModel
-        const { aircraft } = this;
-        const groundSpeed = aircraft === null ? null : aircraft.groundSpeed;
-        const initialTurn = this._buildInitialTurnParameters();
-        const pointsList = [...this._points]; // Shallow copy as the first point may be replaced
-        let radius = 0;
-
-        if (initialTurn !== null && this.hasStyleArced) {
-            radius = initialTurn.turnRadius;
-        }
-
-        // These are the values used when reducing the points array
-        const initialValues = {
-            previousLeg: null,
-            totalDistance: 0,
-            totalDuration: 0
-        };
-
-        // If there is an initialTurn (eg. a turn onto the first leg), then the exit point is used
-        // as the first point in the path
-        // We also calculate the distance and time take to fly the turn
-        if (initialTurn !== null) {
-            const { exitPoint, arcLength } = initialTurn;
-            const distance = nm(arcLength);
-            const duration = _round((distance / groundSpeed) * TIME.ONE_HOUR_IN_MINUTES, 1);
-
-            initialValues.lastPoint = exitPoint;
-            initialValues.totalDistance = distance;
-            initialValues.totalDuration = duration;
-
-            pointsList[0] = exitPoint;
-        }
-
-        // The first leg is just an end point
-        const firstPoint = this._getRelativePosition(pointsList.shift());
-        const firstLeg = new MeasureLegModel(firstPoint);
-        initialValues.previousLeg = firstLeg;
-
-        pointsList.reduce((lastValues, point) => {
-            const { previousLeg } = lastValues;
-            let { totalDistance, totalDuration } = lastValues;
-            const leg = new MeasureLegModel(
-                this._getRelativePosition(point),
-                radius,
-                previousLeg
-            );
-            const distance = nm(leg.distance);
-            const bearing = heading_to_string(leg.bearing);
-            let duration = 0;
-
-            if (groundSpeed !== null) {
-                duration = _round((distance / groundSpeed) * TIME.ONE_HOUR_IN_MINUTES, 1);
+        return this._paths.reduce((list, path) => {
+            if (path.hasLegs) {
+                list.push(path.buildPathInfo());
             }
 
-            const labels = [
-                this._buildLabel(distance, duration, bearing)
-            ];
-
-            totalDistance += distance;
-            totalDuration = _round(totalDuration + duration, 1);
-
-            if (totalDistance !== distance) {
-                labels.push(this._buildLabel(totalDistance, totalDuration));
-            }
-
-            leg.labels = labels;
-
-            return {
-                previousLeg: leg,
-                totalDistance,
-                totalDuration
-            };
-        }, initialValues);
-
-        return {
-            initialTurn,
-            firstLeg
-        };
+            return list;
+        }, []);
     }
 
     /**
-     * Removes the last point from the path
+     * Signals that the editing the current path has finished
+     *
+     * @for MeasureTool
+     * @method endPath
+     */
+    endPath() {
+        this._throwIfNotMeasuring();
+
+        // If the path isn't valid, then don't keep it
+        if (!this._currentPath.hasLegs) {
+            this._paths.pop();
+        }
+
+        this._currentPath = null;
+    }
+
+    /**
+     * Removes the last point from the current path
      *
      * @for MeasureTool
      * @method removeLastPoint
@@ -315,13 +217,24 @@ class MeasureTool {
     removeLastPoint() {
         this._throwIfNotMeasuring();
 
-        // The "last" point is actually the 2nd last item in _points
-        // This means the path will end at the cursor position when redrawn
-        const { length } = this._points;
+        this._currentPath.removeLastPoint();
+    }
 
-        if (length > 2) {
-            this._points.splice(length - 2, 1);
+    /**
+     * Signals that a new path should be created for measurement
+     *
+     * @for MeasureTool
+     * @method startNewPath
+     */
+    startNewPath() {
+        const path = new MeasurePath(this._style);
+
+        if (this._currentPath !== null) {
+            this.endPath();
         }
+
+        this._paths.push(path);
+        this._currentPath = path;
     }
 
     /**
@@ -330,7 +243,7 @@ class MeasureTool {
      * If an invalid valid for MEASURE_TOOL_STYLE is passed, it will default to
      * `MEASURE_TOOL_STYLE.STRAIGHT`
      *
-     * @for MeasureTools
+     * @for MeasureTool
      * @method setStyle
      * @param style {MEASURE_TOOL_STYLE}
      */
@@ -338,14 +251,17 @@ class MeasureTool {
         switch (style) {
             case MEASURE_TOOL_STYLE.ARC_TO_NEXT:
             case MEASURE_TOOL_STYLE.ALL_ARCED:
-                this._style = style;
-
+            case MEASURE_TOOL_STYLE.STRAIGHT:
                 break;
             default:
-                this._style = MEASURE_TOOL_STYLE.STRAIGHT;
+                style = MEASURE_TOOL_STYLE.STRAIGHT;
 
                 break;
         }
+
+        this._style = style;
+
+        this._paths.forEach((path) => path.setStyle(style));
     }
 
     /**
@@ -360,167 +276,24 @@ class MeasureTool {
      */
     updateLastPoint(value) {
         this._throwIfNotMeasuring();
-        this._throwIfPointInvalid(value);
 
-        if (!this.hasLegs) {
-            this.addPoint(value);
-
-            return;
-        }
-
-        this._points[this._points.length - 1] = value;
+        this._currentPath.updateLastPoint(value);
     }
 
     // ------------------------------ PRIVATE ------------------------------
-
-    /**
-     * Builds the initial turn parameters that are needed to fly to the first fix
-     *
-     * @for MeasureTools
-     * @method _buildInitialTurnParameters
-     * @returns {object}
-     * @private
-     */
-    _buildInitialTurnParameters() {
-        if (!this.hasStyleInitialTurn) {
-            return null;
-        }
-
-        const { aircraft } = this;
-
-        if (aircraft === null) {
-            return null;
-        }
-
-        const { groundSpeed, groundTrack } = aircraft;
-        const turnRate = 3; // Turn rate seems fixed at 3°/sec // groundSpeed > 250 ? 1.5 : 3;
-        const turnRadius = km(groundSpeed / (turnRate * 20 * Math.PI));
-        const start = aircraft.relativePosition;
-        const fix = this._getRelativePositionAtIndex(1);
-
-        // Get the turn direction by using the basic bearing to the next point
-        const bearingToFix = bearingToPoint(start, fix);
-        const isRHT = radians_normalize(bearingToFix - groundTrack) < Math.PI;
-        const direction = isRHT ? 1 : -1;
-
-        // The centre of the turn circle is offset to the left or right by 90°
-        const bearingToCenter = groundTrack + (direction * Math.PI / 2);
-        const center = [
-            start[0] + (turnRadius * Math.sin(bearingToCenter)),
-            start[1] + (turnRadius * Math.cos(bearingToCenter))
-        ];
-
-        // Turn exit (tangent from turn circle to the fix)
-        const centerToFixBearing = bearingToPoint(center, fix);
-        const centerToFixDistance = distance2d(center, fix);
-        const outboundCourse = centerToFixBearing + (direction * Math.asin(turnRadius / centerToFixDistance));
-
-        // Entry and exit angles
-        const entryAngle = bearingToCenter + Math.PI;
-        const exitAngle = outboundCourse - (direction * Math.PI / 2);
-
-        // The exit point is the point on the turn circle at the exit angle
-        const exitPoint = [
-            center[0] + (turnRadius * Math.sin(exitAngle)),
-            center[1] + (turnRadius * Math.cos(exitAngle))
-        ];
-
-        // Length around the arc
-        let turnAngle;
-        if (isRHT) {
-            turnAngle = exitAngle - entryAngle;
-        } else {
-            turnAngle = entryAngle - exitAngle;
-        }
-        const arcLength = turnRadius * radians_normalize(turnAngle);
-
-        return {
-            isRHT,
-            turnRadius,
-            arcLength,
-            entryAngle,
-            exitAngle,
-            center,
-            exitPoint
-        };
-    }
-
-    /**
-     * Builds the text label that displays the distance and
-     * optional duration and bearings
-     *
-     * @for MeasureTools
-     * @method _buildLabel
-     * @param distance {number} The distance (in NM) that the leg covers
-     * @param duration {number} The length of time (in minutes) that flying the leg will take
-     * @param bearing {number|null} The bearing (degrees magnetic) along the leg
-     * @private
-     */
-    _buildLabel(distance, duration, bearing = null) {
-        let label = `${distance.toPrecision(3)} NM`;
-
-        if (duration !== 0) {
-            label += `, ${duration.toFixed(1)} min`;
-        }
-
-        if (bearing !== null) {
-            label += `, ${bearing}° M`;
-        }
-
-        return label;
-    }
-
-    /**
-     * Gets the relative position for the point at the specified index.
-     *
-     * @for MeasureTools
-     * @method _getRelativePositionAtIndex
-     * @param index {number}
-     * @returns {array<number>}
-     */
-    _getRelativePositionAtIndex(index) {
-        const point = this._points[index];
-
-        return this._getRelativePosition(point);
-    }
-
-    /**
-     * Gets the relative position for the point at the specified index.
-     *
-     * @for MeasureTools
-     * @method _getRelativePosition
-     * @param point {AircraftModel|FixModel|array<number>}
-     * @returns {array<number>}
-     */
-    _getRelativePosition(point) {
-        return point.relativePosition || point;
-    }
 
     /**
      * Update the `#_style` property
      *
      * This method should only be called via the `EventBus`
      *
-     * @for MeasureTools
-     * @method _onMeasureToolStyleChange
+     * @for MeasureTool
+     * @method _onMeasureTooltyleChange
      * @param style {MEASURE_TOOL_STYLE}
      * @private
      */
-    _onMeasureToolStyleChange(style) {
+    _onMeasureTooltyleChange(style) {
         this.setStyle(style);
-    }
-
-    /**
-     * Facade for throwing a TypeError if a point value is not a valid type
-     *
-     * @for MeasureTool
-     * @method _throwIfPointInvalid
-     * @param value {AircraftModel|FixModel|array<number>}
-    */
-    _throwIfPointInvalid(value) {
-        if (!(value instanceof Array || value instanceof AircraftModel || value instanceof FixModel)) {
-            throw new TypeError(`value cannot be ${typeof value}. An Array, AircraftModel or FixModel is expected.`);
-        }
     }
 
     /**

--- a/src/assets/scripts/client/measurement/MeasureTool.js
+++ b/src/assets/scripts/client/measurement/MeasureTool.js
@@ -1,0 +1,363 @@
+import { radians_normalize } from '../math/circle';
+import { bearingToPoint } from '../math/flightMath';
+import { distance2d } from '../math/distance';
+import {
+    heading_to_string,
+    km,
+    nm
+} from '../utilities/unitConverters';
+import MeasureLegModel from './MeasureLegModel';
+import AircraftModel from '../aircraft/AircraftModel';
+import { TIME } from '../constants/globalConstants';
+
+/**
+ * Defines a `MeasureTool`
+ *
+ * The `MeasureTool` is used by the `InputController` to
+ * accept user input and build a list of `MeasureLegModels`
+ * which calculate distances, durations and bearings
+ */
+export default class MeasureTool {
+    /**
+     * @for MeasureLeg
+     * @constructor
+     */
+    constructor() {
+        /**
+         * Indicates whether the tool should be receiving input
+         *
+         * @for `MeasureTool`
+         * @property isMeasuring
+         * @type {boolean}
+         * @default false
+         */
+        this.isMeasuring = false;
+
+        /**
+         * The list of points that make up the path being measured
+         * This can be an object with a `#relativePosition` property,
+         * or a array of numbers that represent a `relativePosition`
+         *
+         * @for `MeasureTool`
+         * @property _points
+         * @type {AircraftModel|FixModel|array<number>}
+         * @default []
+         * @private
+         */
+        this._points = [];
+    }
+
+    /** Gets the aircraft at the beginning of the path
+     *
+     * @for MeasureTool
+     * @property aircraft
+     * @type {AircraftModel|null}
+     */
+    get aircraft() {
+        if (this.hasStarted && this._points[0] instanceof AircraftModel) {
+            return this._points[0];
+        }
+
+        return null;
+    }
+
+    /**
+     * Indicates whether there are any valid legs
+     *
+     * @for MeasureTool
+     * @property hasLegs
+     * @type {boolean}
+     */
+    get hasLegs() {
+        return this._points.length > 1;
+    }
+
+    /**
+     * Indicates the `MeasureTool` has started measuring
+     *
+     * @for MeasureTool
+     * @property hasLegs
+     * @type {boolean}
+     */
+    get hasStarted() {
+        return this._points.length !== 0;
+    }
+
+    // ------------------------------ LIFECYCLE ------------------------------
+
+    /**
+     * @for MeasureTool
+     * @method reset
+     */
+    reset() {
+        this._points = [];
+        this.isMeasuring = false;
+    }
+
+    // ------------------------------ PUBLIC ------------------------------
+
+    /**
+     * Adds a point to the path being measured
+     *
+     * The value can be an object with a `#relativePosition` property,
+     * or a array of numbers that represent a `relativePosition`
+     *
+     * @for MeasureTool
+     * @method addPoint
+     * @param value {AircraftModel|FixModel|array<number>}
+     */
+    addPoint(value) {
+        this._points.push(value);
+    }
+
+    /**
+     * Gets the information for the path that should be drawn on the `CanvasController`
+     *
+     * @for MeasureTool
+     * @method getPathInfo
+     * @returns {object}
+     */
+    getPathInfo() {
+        if (!this.hasLegs) {
+            return [];
+        }
+
+        // Ground speed is only known if the first point is an AircraftModel
+        const { aircraft } = this;
+        const groundSpeed = aircraft === null ? null : aircraft.groundSpeed;
+        const initialTurn = this._getInitialTurnParameters();
+        const turnRadius = initialTurn !== null ? initialTurn.turnRadius : 0;
+        const pointsList = [...this._points]; // Shallow copy as the first point may be replaced
+
+        // These are the values used when reducing the points array
+        const initialValues = {
+            previousLeg: null,
+            totalDistance: 0,
+            totalDuration: 0
+        };
+
+        // If there is an initialTurn (eg. a turn onto the first leg), then the exit point is used
+        // as the first point in the path
+        // We also calculate the distance and time take to fly the turn
+        if (initialTurn !== null) {
+            const { exitPoint, arcLength } = initialTurn;
+            const distance = nm(arcLength);
+            const duration = Math.round((distance / groundSpeed) * TIME.ONE_HOUR_IN_SECONDS);
+
+            initialValues.lastPoint = exitPoint;
+            initialValues.totalDistance = distance;
+            initialValues.totalDuration = duration;
+
+            pointsList[0] = exitPoint;
+        }
+
+        // The first leg is just an end point
+        const firstPoint = this._getRelativePosition(pointsList.shift());
+        const firstLeg = new MeasureLegModel(firstPoint);
+        initialValues.previousLeg = firstLeg;
+
+        pointsList.reduce((lastValues, point) => {
+            const { previousLeg } = lastValues;
+            let { totalDistance, totalDuration } = lastValues;
+            const leg = new MeasureLegModel(
+                this._getRelativePosition(point),
+                turnRadius,
+                previousLeg
+            );
+            const distance = nm(leg.distance);
+            const bearing = heading_to_string(leg.bearing);
+            let duration = 0;
+
+            if (groundSpeed !== null) {
+                duration = Math.round((distance / groundSpeed) * TIME.ONE_HOUR_IN_SECONDS);
+            }
+
+            const labels = [
+                this._getLabel(distance, duration, bearing)
+            ];
+
+            totalDistance += distance;
+            totalDuration += duration;
+
+            if (totalDistance !== distance) {
+                labels.push(this._getLabel(totalDistance, totalDuration));
+            }
+
+            leg.labels = labels;
+
+            return {
+                previousLeg: leg,
+                totalDistance,
+                totalDuration
+            };
+        }, initialValues);
+
+        return {
+            initialTurn,
+            firstLeg
+        };
+    }
+
+    /**
+     * Removes the last point from the path
+     *
+     * @for MeasureTool
+     * @method removeLastPoint
+     */
+    removeLastPoint() {
+        // The "last" point is actually the 2nd last item in _points
+        // This means the path will end at the cursor position when redrawn
+        const { length } = this._points;
+        if (length > 2) {
+            this._points.splice(length - 2, 1);
+        }
+    }
+
+    /**
+     * Starts the measure tools for the specifeid aircraft
+     * and adds an initial leg
+     *
+     * The startValue can be an object with a `#relativePosition` property,
+     * or a array of numbers that represent a `relativePosition`
+     *
+     * @for MeasureTool
+     * @method startMeasuring
+     * @param startValue {AircraftModel|FixModel|array<number>}
+     */
+    startMeasuring(startValue) {
+        this._points = [startValue];
+    }
+
+    /**
+     * Updates the last point in the path
+     *
+     * The value can be an object with a `#relativePosition` property,
+     * or a array of numbers that represent a `relativePosition`
+     *
+     * @for MeasureTool
+     * @method updateEndPoint
+     * @param value {array<number>}
+     */
+    updateLastPoint(value) {
+        if (this.hasLegs) {
+            this._points[this._points.length - 1] = value;
+        } else {
+            this.addPoint(value);
+        }
+    }
+
+    // ------------------------------ PRIVATE ------------------------------
+
+    /**
+     * Gets the initial turn parameters that are needed to fly to the first fix
+     *
+     * @for MeasureTools
+     * @method _getInitialTurnParameters
+     * @returns {object}
+     * @private
+     */
+    _getInitialTurnParameters() {
+        const { aircraft } = this;
+
+        if (aircraft === null) {
+            return null;
+        }
+
+        const { groundSpeed, groundTrack } = aircraft;
+        const turnRate = 3; // Turn rate seems fixed at 3°/sec // groundSpeed > 250 ? 1.5 : 3;
+        const turnRadius = km(groundSpeed / (turnRate * 20 * Math.PI));
+        const start = aircraft.relativePosition;
+        const fix = this._getRelativePositionAtIndex(1);
+
+        // Get the turn direction by using the basic bearing to the next point
+        const bearingToFix = bearingToPoint(start, fix);
+        const isRHT = radians_normalize(bearingToFix - groundTrack) < Math.PI;
+        const direction = isRHT ? 1 : -1;
+
+        // The centre of the turn circle is offset to the left or right by 90°
+        const bearingToCenter = groundTrack + (direction * Math.PI / 2);
+        const center = [
+            start[0] + (turnRadius * Math.sin(bearingToCenter)),
+            start[1] + (turnRadius * Math.cos(bearingToCenter))
+        ];
+
+        // Turn exit (tangent from turn circle to the fix)
+        const centerToFixBearing = bearingToPoint(center, fix);
+        const centerToFixDistance = distance2d(center, fix);
+        const outboundCourse = centerToFixBearing + (direction * Math.asin(turnRadius / centerToFixDistance));
+
+        // Entry and exit angles
+        const entryAngle = bearingToCenter + Math.PI;
+        const exitAngle = outboundCourse - (direction * Math.PI / 2);
+
+        // The exit point is the point on the turn circle at the exit angle
+        const exitPoint = [
+            center[0] + (turnRadius * Math.sin(exitAngle)),
+            center[1] + (turnRadius * Math.cos(exitAngle))
+        ];
+
+        // Length around the arc
+        let turnAngle;
+        if (isRHT) {
+            turnAngle = exitAngle - entryAngle;
+        } else {
+            turnAngle = entryAngle - exitAngle;
+        }
+        const arcLength = turnRadius * radians_normalize(turnAngle);
+
+        return {
+            isRHT,
+            turnRadius,
+            arcLength,
+            entryAngle,
+            exitAngle,
+            center,
+            exitPoint
+        };
+    }
+
+    /**
+     * Get the text label that displays the distance and
+     * optional duration and bearings
+     *
+     * @param distance {number}
+     * @param duration {number}
+     * @param bearing {number|null}
+     * @private
+     */
+    _getLabel(distance, duration, bearing = null) {
+        let label = `${distance.toFixed(1)} NM`;
+
+        if (duration !== 0) {
+            label += `, ${duration.toLocaleString()} s`;
+        }
+
+        if (bearing !== null) {
+            label += `, ${bearing}° M`;
+        }
+
+        return label;
+    }
+
+    /**
+     * Gets the relative position for the point at the specified index.
+     *
+     * @param index {number}
+     * @returns {array<number>}
+     */
+    _getRelativePositionAtIndex(index) {
+        const point = this._points[index];
+
+        return this._getRelativePosition(point);
+    }
+
+    /**
+     * Gets the relative position for the point at the specified index.
+     *
+     * @param point {AircraftModel|FixModel|array<number>}
+     * @returns {array<number>}
+     */
+    _getRelativePosition(point) {
+        return point.relativePosition || point;
+    }
+}

--- a/src/assets/scripts/client/measurement/MeasureTool.js
+++ b/src/assets/scripts/client/measurement/MeasureTool.js
@@ -72,12 +72,12 @@ class MeasureTool {
          * The style of how the path is rendered
          *
          * @for MeasureTool
-         * @property _style
+         * @property style
          * @type {number}
          * @default MEASURE_TOOL_STYLE.STRAIGHT
          * @private
          */
-        this._style = MEASURE_TOOL_STYLE.STRAIGHT;
+        this.style = MEASURE_TOOL_STYLE.STRAIGHT;
 
         this._init()
             ._setupHandlers()
@@ -129,7 +129,7 @@ class MeasureTool {
      * @private
      */
     _init() {
-        this._style = GameController.getGameOption(GAME_OPTION_NAMES.MEASURE_TOOL_PATH);
+        this.style = GameController.getGameOption(GAME_OPTION_NAMES.MEASURE_TOOL_PATH);
 
         return this;
     }
@@ -464,7 +464,7 @@ class MeasureTool {
      */
     _hasStyle(flag) {
         /* eslint-disable no-bitwise */
-        return (this._style & flag) !== 0;
+        return (this.style & flag) !== 0;
     }
 
     /**
@@ -478,7 +478,7 @@ class MeasureTool {
      * @private
      */
     _onMeasureToolStyleChange(style) {
-        this._style = style;
+        this.style = style;
     }
 
     /**

--- a/src/assets/scripts/client/measurement/MeasureTool.js
+++ b/src/assets/scripts/client/measurement/MeasureTool.js
@@ -126,7 +126,6 @@ export default class MeasureTool {
         const { aircraft } = this;
         const groundSpeed = aircraft === null ? null : aircraft.groundSpeed;
         const initialTurn = this._getInitialTurnParameters();
-        const turnRadius = initialTurn !== null ? initialTurn.turnRadius : 0;
         const pointsList = [...this._points]; // Shallow copy as the first point may be replaced
 
         // These are the values used when reducing the points array
@@ -161,7 +160,7 @@ export default class MeasureTool {
             let { totalDistance, totalDuration } = lastValues;
             const leg = new MeasureLegModel(
                 this._getRelativePosition(point),
-                turnRadius,
+                0, // don't radius the vertices
                 previousLeg
             );
             const distance = nm(leg.distance);

--- a/src/assets/scripts/client/measurement/MeasureTool.js
+++ b/src/assets/scripts/client/measurement/MeasureTool.js
@@ -232,7 +232,7 @@ class MeasureTool {
      */
     startNewPath() {
         if (this.isMeasuring) {
-            return;
+            throw new Error('Cannot start a new path. The current path hasn\'t been ended.');
         }
 
         const path = new MeasurePath(this._style);

--- a/src/assets/scripts/client/measurement/MeasureTool.js
+++ b/src/assets/scripts/client/measurement/MeasureTool.js
@@ -10,6 +10,7 @@ import {
 } from '../utilities/unitConverters';
 import MeasureLegModel from './MeasureLegModel';
 import AircraftModel from '../aircraft/AircraftModel';
+import FixModel from '../navigationLibrary/FixModel';
 import { EVENT } from '../constants/eventNames';
 import { GAME_OPTION_NAMES } from '../constants/gameOptionConstants';
 import { TIME } from '../constants/globalConstants';
@@ -189,6 +190,9 @@ class MeasureTool {
      * @param value {AircraftModel|FixModel|array<number>}
      */
     addPoint(value) {
+        this._throwIfNotMeasuring();
+        this._throwIfPointInvalid(value);
+
         this._points.push(value);
     }
 
@@ -291,6 +295,8 @@ class MeasureTool {
      * @method removeLastPoint
      */
     removeLastPoint() {
+        this._throwIfNotMeasuring();
+
         // The "last" point is actually the 2nd last item in _points
         // This means the path will end at the cursor position when redrawn
         const { length } = this._points;
@@ -301,21 +307,6 @@ class MeasureTool {
     }
 
     /**
-     * Starts the measure tools for the specifeid aircraft
-     * and adds an initial leg
-     *
-     * The startValue can be an object with a `#relativePosition` property,
-     * or a array of numbers that represent a `relativePosition`
-     *
-     * @for MeasureTool
-     * @method startMeasuring
-     * @param startValue {AircraftModel|FixModel|array<number>}
-     */
-    startMeasuring(startValue) {
-        this._points.push(startValue);
-    }
-
-    /**
      * Updates the last point in the path
      *
      * The value can be an object with a `#relativePosition` property,
@@ -323,9 +314,12 @@ class MeasureTool {
      *
      * @for MeasureTool
      * @method updateEndPoint
-     * @param value {array<number>}
+     * @param value {AircraftModel|FixModel|array<number>}
      */
     updateLastPoint(value) {
+        this._throwIfNotMeasuring();
+        this._throwIfPointInvalid(value);
+
         if (!this.hasLegs) {
             this.addPoint(value);
 
@@ -485,6 +479,31 @@ class MeasureTool {
      */
     _onMeasureToolStyleChange(style) {
         this._style = style;
+    }
+
+    /**
+     * Facade for throwing a TypeError if a point value is not a valid type
+     *
+     * @for MeasureTool
+     * @method _throwIfPointInvalid
+     * @param value {AircraftModel|FixModel|array<number>}
+    */
+    _throwIfPointInvalid(value) {
+        if (!(value instanceof Array || value instanceof AircraftModel || value instanceof FixModel)) {
+            throw new TypeError(`value cannot be ${typeof value}. An Array, AircraftModel or FixModel is expected.`);
+        }
+    }
+
+    /**
+     * Facade for throwing an Error if the `#isMeasuring` flag is not set
+     *
+     * @for MeasureTool
+     * @method _throwIfNotMeasuring
+     */
+    _throwIfNotMeasuring() {
+        if (!this.isMeasuring) {
+            throw Error(`Cannot add point when MeasureTool.isMeasuring is ${this.isMeasuring}`);
+        }
     }
 }
 

--- a/src/assets/scripts/client/measurement/MeasureTool.js
+++ b/src/assets/scripts/client/measurement/MeasureTool.js
@@ -200,6 +200,10 @@ class MeasureTool {
     endPath() {
         this._throwIfNotMeasuring();
 
+        // Discard the point which is attached to the cursor, and keep
+        // only those points which have been clicked into place
+        this._currentPath.removeLastPoint();
+
         // If the path isn't valid, then don't keep it
         if (!this._currentPath.hasLegs) {
             this._paths.pop();
@@ -209,15 +213,15 @@ class MeasureTool {
     }
 
     /**
-     * Removes the last point from the current path
+     * Removes the second-to-last point from the current path
      *
      * @for MeasureTool
-     * @method removeLastPoint
+     * @method removePreviousPoint
      */
-    removeLastPoint() {
+    removePreviousPoint() {
         this._throwIfNotMeasuring();
 
-        this._currentPath.removeLastPoint();
+        this._currentPath.removePreviousPoint();
     }
 
     /**

--- a/src/assets/scripts/client/measurement/MeasureTool.js
+++ b/src/assets/scripts/client/measurement/MeasureTool.js
@@ -205,7 +205,7 @@ class MeasureTool {
      */
     buildPathInfo() {
         if (!this.hasLegs) {
-            return [];
+            return null;
         }
 
         // Ground speed is only known if the first point is an AircraftModel

--- a/src/assets/scripts/client/measurement/MeasureTool.js
+++ b/src/assets/scripts/client/measurement/MeasureTool.js
@@ -227,11 +227,11 @@ class MeasureTool {
      * @method startNewPath
      */
     startNewPath() {
-        const path = new MeasurePath(this._style);
-
-        if (this._currentPath !== null) {
-            this.endPath();
+        if (this.isMeasuring) {
+            return;
         }
+
+        const path = new MeasurePath(this._style);
 
         this._paths.push(path);
         this._currentPath = path;

--- a/src/assets/scripts/client/measurement/MeasureTool.js
+++ b/src/assets/scripts/client/measurement/MeasureTool.js
@@ -17,7 +17,7 @@ import { TIME } from '../constants/globalConstants';
  * accept user input and build a list of `MeasureLegModels`
  * which calculate distances, durations and bearings
  */
-export default class MeasureTool {
+class MeasureTool {
     /**
      * @for MeasureLeg
      * @constructor
@@ -360,3 +360,8 @@ export default class MeasureTool {
         return point.relativePosition || point;
     }
 }
+
+/**
+ * The static instance of the `MeasureTool` class
+ */
+export default new MeasureTool();

--- a/src/assets/scripts/client/measurement/MeasureTool.js
+++ b/src/assets/scripts/client/measurement/MeasureTool.js
@@ -248,18 +248,11 @@ class MeasureTool {
      * @param style {MEASURE_TOOL_STYLE}
      */
     setStyle(style) {
-        switch (style) {
-            case MEASURE_TOOL_STYLE.ARC_TO_NEXT:
-            case MEASURE_TOOL_STYLE.ALL_ARCED:
-            case MEASURE_TOOL_STYLE.STRAIGHT:
-                break;
-            default:
-                style = MEASURE_TOOL_STYLE.STRAIGHT;
+        const isValid = Object.keys(MEASURE_TOOL_STYLE).some((k) => {
+            return MEASURE_TOOL_STYLE[k] === style;
+        });
 
-                break;
-        }
-
-        this._style = style;
+        this._style = isValid ? style : MEASURE_TOOL_STYLE.STRAIGHT;
 
         this._paths.forEach((path) => path.setStyle(style));
     }

--- a/src/assets/scripts/client/navigationLibrary/FixCollection.js
+++ b/src/assets/scripts/client/navigationLibrary/FixCollection.js
@@ -105,15 +105,15 @@ class FixCollection extends BaseCollection {
      *
      * @for FixCollection
      * @method getNearestFix
-     * @param position {StaticPositionModel}
-     * @param allowRnavFixes {boolean} A flag indicating whether RNAV fixes should be used
+     * @param position {array<number>} These are x, y canvas units (km)
+     * @param hiddenFixes {boolean} A flag indicating whether hidden fixes should be used
      */
-    getNearestFix(position, allowRnavFixes = false) {
+    getNearestFix(position, hiddenFixes = false) {
         return this._items.reduce((lastResult, fix) => {
             let [nearest, distance] = lastResult;
             const d = distance2d(fix.relativePosition, position);
 
-            if ((fix.isRealFix || allowRnavFixes) && d < distance) {
+            if ((fix.isRealFix || hiddenFixes) && d < distance) {
                 nearest = fix;
                 distance = d;
             }

--- a/src/assets/scripts/client/navigationLibrary/FixCollection.js
+++ b/src/assets/scripts/client/navigationLibrary/FixCollection.js
@@ -1,10 +1,9 @@
-import _compact from 'lodash/compact';
 import _find from 'lodash/find';
 import _forEach from 'lodash/forEach';
-import _map from 'lodash/map';
 // TODO: Start using the model source factory again!
 // import modelSourceFactory from '../base/ModelSource/ModelSourceFactory';
 import BaseCollection from '../base/BaseCollection';
+import { distance2d } from '../math/distance';
 import FixModel from './FixModel';
 
 /**
@@ -102,6 +101,28 @@ class FixCollection extends BaseCollection {
     }
 
     /**
+     * Returns the nearest fix to the specified position
+     *
+     * @for FixCollection
+     * @method getNearestFix
+     * @param position {StaticPositionModel}
+     * @param allowRnavFixes {boolean} A flag indicating whether RNAV fixes should be used
+     */
+    getNearestFix(position, allowRnavFixes = false) {
+        return this._items.reduce((lastResult, fix) => {
+            let [nearest, distance] = lastResult;
+            const d = distance2d(fix.relativePosition, position);
+
+            if ((fix.isRealFix || allowRnavFixes) && d < distance) {
+                nearest = fix;
+                distance = d;
+            }
+
+            return [nearest, distance];
+        }, [null, Infinity]);
+    }
+
+    /**
      * Return the position model for the specified fix, if that fix exists
      *
      * @for FixCollection
@@ -127,13 +148,7 @@ class FixCollection extends BaseCollection {
      * @return {array<FixModel>}
      */
     findRealFixes() {
-        const realFixList = _map(this._items, (item) => {
-            if (item.name.indexOf('_') !== 0) {
-                return item;
-            }
-        });
-
-        return _compact(realFixList);
+        return this._items.filter((fix) => fix.isRealFix);
     }
 
     /**

--- a/src/assets/scripts/client/navigationLibrary/FixModel.js
+++ b/src/assets/scripts/client/navigationLibrary/FixModel.js
@@ -1,6 +1,7 @@
 import _cloneDeep from 'lodash/cloneDeep';
 import BaseModel from '../base/BaseModel';
 import StaticPositionModel from '../base/StaticPositionModel';
+import { RNAV_WAYPOINT_PREFIX } from '../constants/waypointConstants';
 
 /**
  * Defines a navigational `FixModel`
@@ -40,6 +41,17 @@ export default class FixModel extends BaseModel {
         this._positionModel = null;
 
         this.init(fixName, fixCoordinate, referencePosition);
+    }
+
+    /**
+     * Indicates whether the fix is a real fix, not an RNAV fix
+     * (prefixed with an underscore)
+     *
+     * @property isRealFix
+     * @return {boolean}
+     */
+    get isRealFix() {
+        return this.name[0] !== RNAV_WAYPOINT_PREFIX;
     }
 
     /**

--- a/test/game/GameOptions.spec.js
+++ b/test/game/GameOptions.spec.js
@@ -18,7 +18,8 @@ ava('sets #_options on instantiation', (t) => {
         'drawProjectedPaths',
         'softCeiling',
         'mouseClickDrag',
-        'rangeRings'
+        'rangeRings',
+        'measureToolPath'
     ];
 
     const model = new GameOptions();

--- a/test/measurement/MeasureTool.spec.js
+++ b/test/measurement/MeasureTool.spec.js
@@ -1,0 +1,131 @@
+import ava from 'ava';
+
+import {
+    createAirportControllerFixture
+} from '../fixtures/airportFixtures';
+import {
+    createNavigationLibraryFixture
+} from '../fixtures/navigationLibraryFixtures';
+import AircraftModel from '../../src/assets/scripts/client/aircraft/AircraftModel';
+import MeasureTool, { MEASURE_TOOL_STYLE } from '../../src/assets/scripts/client/measurement/MeasureTool';
+import FixCollection from '../../src/assets/scripts/client/navigationLibrary/FixCollection';
+import MeasureLegModel from '../../src/assets/scripts/client/measurement/MeasureLegModel';
+import { ARRIVAL_AIRCRAFT_INIT_PROPS_MOCK } from '../aircraft/_mocks/aircraftMocks';
+
+const CURSOR_POSITION = [500, 20];
+
+function createAircaft() {
+    return new AircraftModel(ARRIVAL_AIRCRAFT_INIT_PROPS_MOCK);
+}
+
+ava.before(() => {
+    createNavigationLibraryFixture();
+    createAirportControllerFixture();
+});
+
+ava.beforeEach(() => {
+    MeasureTool.reset();
+});
+
+ava.serial('.addPoint() throws when #isMeasuring is not set', (t) => {
+    t.throws(() => MeasureTool.addPoint(CURSOR_POSITION));
+});
+
+ava.serial('.removeLastPoint() throws when #isMeasuring is not set', (t) => {
+    t.throws(() => MeasureTool.removeLastPoint());
+});
+
+ava.serial('.updateLastPoint() throws when #isMeasuring is not set', (t) => {
+    t.throws(() => MeasureTool.updateLastPoint(CURSOR_POSITION));
+});
+
+ava.serial('.addPoint() throws when point value is invalid', (t) => {
+    MeasureTool.isMeasuring = true;
+
+    t.throws(() => MeasureTool.addPoint({}));
+    t.throws(() => MeasureTool.addPoint(null));
+    t.notThrows(() => MeasureTool.addPoint(FixCollection.findFixByName('BAKRR')));
+    t.notThrows(() => MeasureTool.updateLastPoint(createAircaft()));
+    t.notThrows(() => MeasureTool.addPoint(CURSOR_POSITION));
+});
+
+ava.serial('.updateLastPoint() throws when point value is invalid', (t) => {
+    MeasureTool.isMeasuring = true;
+
+    t.throws(() => MeasureTool.updateLastPoint({}));
+    t.throws(() => MeasureTool.updateLastPoint(null));
+    t.notThrows(() => MeasureTool.updateLastPoint(FixCollection.findFixByName('BAKRR')));
+    t.notThrows(() => MeasureTool.updateLastPoint(createAircaft()));
+    t.notThrows(() => MeasureTool.updateLastPoint(CURSOR_POSITION));
+});
+
+ava.serial('.addPoint() sets the correct flags', (t) => {
+    MeasureTool.isMeasuring = true;
+    MeasureTool.addPoint(FixCollection.findFixByName('DBIGE'));
+
+    t.is(MeasureTool.hasStarted, true);
+    t.is(MeasureTool.hasLegs, false);
+    t.is(MeasureTool.isMeasuring, true);
+});
+
+ava.serial('.reset() clears the flags to their initial state', (t) => {
+    MeasureTool.isMeasuring = true;
+    MeasureTool.addPoint(FixCollection.findFixByName('BAKRR'));
+    MeasureTool.addPoint(FixCollection.findFixByName('DBIGE'));
+    MeasureTool.reset();
+
+    t.is(MeasureTool.hasStarted, false);
+    t.is(MeasureTool.hasLegs, false);
+    t.is(MeasureTool.isMeasuring, false);
+});
+
+ava.serial('.buildPathInfo builds a correct MeasureLegModel from FixModel points', (t) => {
+    const bakrr = FixCollection.findFixByName('BAKRR');
+    const dbige = FixCollection.findFixByName('DBIGE');
+
+    MeasureTool.isMeasuring = true;
+    MeasureTool.addPoint(bakrr);
+    MeasureTool.addPoint(dbige);
+
+    const { initialTurn, firstLeg } = MeasureTool.buildPathInfo();
+    const leg1 = firstLeg.next;
+
+    t.is(initialTurn, null);
+    t.true(firstLeg instanceof MeasureLegModel);
+    t.is(firstLeg.previous, null);
+    t.is(leg1.next, null);
+
+    t.deepEqual(leg1.startPoint, bakrr.relativePosition);
+    t.deepEqual(leg1.endPoint, dbige.relativePosition);
+    t.not(leg1.midPoint, null);
+    t.not(leg1.bearing, 0);
+    t.not(leg1.distance, 0);
+    t.is(leg1.labels.length, 1);
+    t.is(leg1.radius, 0);
+});
+
+ava.serial('.buildPathInfo builds a correct MeasureLegModel from mixed points', (t) => {
+    const bakrr = FixCollection.findFixByName('BAKRR');
+    const aircraft = createAircaft();
+    aircraft.groundSpeed = 180;
+
+    MeasureTool.isMeasuring = true;
+    /* eslint-disable no-bitwise */
+    MeasureTool.style = MEASURE_TOOL_STYLE.INITIAL_TURN | MEASURE_TOOL_STYLE.ARCED;
+    MeasureTool.addPoint(aircraft);
+    MeasureTool.addPoint(bakrr);
+    MeasureTool.addPoint(CURSOR_POSITION);
+
+    const { initialTurn, firstLeg } = MeasureTool.buildPathInfo();
+    const leg1 = firstLeg.next;
+    const leg2 = leg1.next;
+
+    t.not(initialTurn, null);
+    t.true(firstLeg instanceof MeasureLegModel);
+    t.is(firstLeg.previous, null);
+    t.is(leg2.next, null);
+
+    t.not(initialTurn.turnRadius, 0);
+    t.not(leg1.radius, 0);
+    t.is(leg2.radius, 0);
+});

--- a/test/measurement/MeasureTool.spec.js
+++ b/test/measurement/MeasureTool.spec.js
@@ -79,6 +79,16 @@ ava.serial('.reset() clears the flags to their initial state', (t) => {
     t.is(MeasureTool.isMeasuring, false);
 });
 
+ava.serial('buildPathInfo returns null when there are no valid legs', (t) => {
+    const bakrr = FixCollection.findFixByName('BAKRR');
+
+    MeasureTool.isMeasuring = true;
+    MeasureTool.addPoint(bakrr);
+    const pathInfo = MeasureTool.buildPathInfo();
+
+    t.is(pathInfo, null);
+});
+
 ava.serial('.buildPathInfo builds a correct MeasureLegModel from FixModel points', (t) => {
     const bakrr = FixCollection.findFixByName('BAKRR');
     const dbige = FixCollection.findFixByName('DBIGE');
@@ -93,6 +103,7 @@ ava.serial('.buildPathInfo builds a correct MeasureLegModel from FixModel points
     t.is(initialTurn, null);
     t.true(firstLeg instanceof MeasureLegModel);
     t.is(firstLeg.previous, null);
+    t.is(firstLeg.startPoint, null);
     t.is(leg1.next, null);
 
     t.deepEqual(leg1.startPoint, bakrr.relativePosition);
@@ -128,4 +139,19 @@ ava.serial('.buildPathInfo builds a correct MeasureLegModel from mixed points', 
     t.not(initialTurn.turnRadius, 0);
     t.not(leg1.radius, 0);
     t.is(leg2.radius, 0);
+});
+
+ava.serial('.removeLastPoint() removes a point as expected', (t) => {
+    MeasureTool.isMeasuring = true;
+    MeasureTool.addPoint(FixCollection.findFixByName('BAKRR'));
+    MeasureTool.addPoint(FixCollection.findFixByName('DBIGE'));
+    MeasureTool.addPoint(CURSOR_POSITION);
+
+    t.is(MeasureTool._points.length, 3);
+
+    MeasureTool.removeLastPoint();
+    t.is(MeasureTool._points.length, 2);
+
+    MeasureTool.removeLastPoint();
+    t.is(MeasureTool._points.length, 2);
 });

--- a/test/measurement/MeasureTool.spec.js
+++ b/test/measurement/MeasureTool.spec.js
@@ -50,6 +50,11 @@ ava.serial('.addPoint() throws when point value is invalid', (t) => {
     t.notThrows(() => MeasureTool.addPoint(CURSOR_POSITION));
 });
 
+ava.serial('.startNewPath() throws when the current path hasn\'t been ended.', (t) => {
+    t.notThrows(() => MeasureTool.startNewPath());
+    t.throws(() => MeasureTool.startNewPath());
+});
+
 ava.serial('.updateLastPoint() throws when point value is invalid', (t) => {
     MeasureTool.startNewPath();
 

--- a/test/measurement/MeasureTool.spec.js
+++ b/test/measurement/MeasureTool.spec.js
@@ -7,9 +7,10 @@ import {
     createNavigationLibraryFixture
 } from '../fixtures/navigationLibraryFixtures';
 import AircraftModel from '../../src/assets/scripts/client/aircraft/AircraftModel';
-import MeasureTool, { MEASURE_TOOL_STYLE } from '../../src/assets/scripts/client/measurement/MeasureTool';
+import MeasureTool from '../../src/assets/scripts/client/measurement/MeasureTool';
 import FixCollection from '../../src/assets/scripts/client/navigationLibrary/FixCollection';
 import MeasureLegModel from '../../src/assets/scripts/client/measurement/MeasureLegModel';
+import { MEASURE_TOOL_STYLE } from '../../src/assets/scripts/client/constants/inputConstants';
 import { ARRIVAL_AIRCRAFT_INIT_PROPS_MOCK } from '../aircraft/_mocks/aircraftMocks';
 
 const CURSOR_POSITION = [500, 20];
@@ -122,7 +123,7 @@ ava.serial('.buildPathInfo builds a correct MeasureLegModel from mixed points', 
 
     MeasureTool.isMeasuring = true;
     /* eslint-disable no-bitwise */
-    MeasureTool.style = MEASURE_TOOL_STYLE.INITIAL_TURN | MEASURE_TOOL_STYLE.ARCED;
+    MeasureTool.setStyle(MEASURE_TOOL_STYLE.ALL_ARCED);
     MeasureTool.addPoint(aircraft);
     MeasureTool.addPoint(bakrr);
     MeasureTool.addPoint(CURSOR_POSITION);

--- a/test/measurement/MeasureTool.spec.js
+++ b/test/measurement/MeasureTool.spec.js
@@ -88,7 +88,7 @@ ava.serial('.reset() clears the flags to their initial state', (t) => {
     t.is(MeasureTool.isMeasuring, false);
 });
 
-ava.serial('buildPathInfo returns an empty array when there are no valid legs', (t) => {
+ava.serial('.buildPathInfo() returns an empty array when there are no valid legs', (t) => {
     const bakrr = FixCollection.findFixByName('BAKRR');
 
     MeasureTool.startNewPath();
@@ -100,7 +100,7 @@ ava.serial('buildPathInfo returns an empty array when there are no valid legs', 
     t.deepEqual(pathInfo, []);
 });
 
-ava.serial('.buildPathInfo builds a correct MeasureLegModel from FixModel points', (t) => {
+ava.serial('.buildPathInfo() builds a correct MeasureLegModel from FixModel points', (t) => {
     const bakrr = FixCollection.findFixByName('BAKRR');
     const dbige = FixCollection.findFixByName('DBIGE');
 
@@ -128,7 +128,7 @@ ava.serial('.buildPathInfo builds a correct MeasureLegModel from FixModel points
     t.is(leg1.radius, 0);
 });
 
-ava.serial('.buildPathInfo builds a correct MeasureLegModel from mixed points', (t) => {
+ava.serial('.buildPathInfo() builds a correct MeasureLegModel from mixed points', (t) => {
     const bakrr = FixCollection.findFixByName('BAKRR');
     const aircraft = createAircaft();
     aircraft.groundSpeed = 180;
@@ -168,4 +168,18 @@ ava.serial('.removeLastPoint() removes a point as expected', (t) => {
 
     MeasureTool.removeLastPoint();
     t.is(MeasureTool._currentPath._points.length, 2);
+});
+
+ava.serial('.setStyle() correctly sets the _style property', (t) => {
+    MeasureTool.setStyle(MEASURE_TOOL_STYLE.STRAIGHT);
+    t.is(MeasureTool._style, MEASURE_TOOL_STYLE.STRAIGHT);
+
+    MeasureTool.setStyle(MEASURE_TOOL_STYLE.ARC_TO_NEXT);
+    t.is(MeasureTool._style, MEASURE_TOOL_STYLE.ARC_TO_NEXT);
+
+    MeasureTool.setStyle(MEASURE_TOOL_STYLE.ALL_ARCED);
+    t.is(MeasureTool._style, MEASURE_TOOL_STYLE.ALL_ARCED);
+
+    MeasureTool.setStyle('a random value');
+    t.is(MeasureTool._style, MEASURE_TOOL_STYLE.STRAIGHT);
 });

--- a/test/measurement/MeasureTool.spec.js
+++ b/test/measurement/MeasureTool.spec.js
@@ -65,6 +65,14 @@ ava.serial('.updateLastPoint() throws when point value is invalid', (t) => {
     t.notThrows(() => MeasureTool.updateLastPoint(CURSOR_POSITION));
 });
 
+ava.serial('hasPaths returns correct value', (t) => {
+    t.false(MeasureTool.hasPaths);
+
+    MeasureTool.startNewPath();
+
+    t.true(MeasureTool.hasPaths);
+});
+
 ava.serial('.addPoint() sets the correct flags', (t) => {
     MeasureTool.startNewPath();
 
@@ -80,17 +88,6 @@ ava.serial('.addPoint() sets the correct flags', (t) => {
 
     t.false(MeasureTool.isMeasuring);
     t.false(MeasureTool.hasStarted);
-});
-
-ava.serial('.reset() clears the flags to their initial state', (t) => {
-    MeasureTool.startNewPath();
-    MeasureTool.addPoint(FixCollection.findFixByName('BAKRR'));
-    MeasureTool.addPoint(FixCollection.findFixByName('DBIGE'));
-    MeasureTool.endPath();
-    MeasureTool.reset();
-
-    t.is(MeasureTool.hasStarted, false);
-    t.is(MeasureTool.isMeasuring, false);
 });
 
 ava.serial('.buildPathInfo() returns an empty array when there are no saved points', (t) => {
@@ -189,6 +186,17 @@ ava.serial('.removePreviousPoint() removes the second-to-last point in the curre
     t.deepEqual(MeasureTool._currentPath._points, [bakrr, CURSOR_POSITION]);
 });
 
+ava.serial('.reset() clears the flags to their initial state', (t) => {
+    MeasureTool.startNewPath();
+    MeasureTool.addPoint(FixCollection.findFixByName('BAKRR'));
+    MeasureTool.addPoint(FixCollection.findFixByName('DBIGE'));
+    MeasureTool.endPath();
+    MeasureTool.reset();
+
+    t.is(MeasureTool.hasStarted, false);
+    t.is(MeasureTool.isMeasuring, false);
+});
+
 ava.serial('.setStyle() correctly sets the _style property', (t) => {
     MeasureTool.setStyle(MEASURE_TOOL_STYLE.STRAIGHT);
     t.is(MeasureTool._style, MEASURE_TOOL_STYLE.STRAIGHT);
@@ -201,4 +209,21 @@ ava.serial('.setStyle() correctly sets the _style property', (t) => {
 
     MeasureTool.setStyle('a random value');
     t.is(MeasureTool._style, MEASURE_TOOL_STYLE.STRAIGHT);
+});
+
+ava.serial('.updateLastPoint() adds a new point if there is no point to update', (t) => {
+    MeasureTool.startNewPath();
+    MeasureTool.addPoint(FixCollection.findFixByName('BAKRR'));
+    MeasureTool.updateLastPoint(CURSOR_POSITION);
+
+    t.is(MeasureTool._currentPath._points.length, 2);
+});
+
+ava.serial('.updateLastPoint() updates the last point', (t) => {
+    MeasureTool.startNewPath();
+    MeasureTool.addPoint(FixCollection.findFixByName('BAKRR'));
+    MeasureTool.addPoint(FixCollection.findFixByName('DBIGE'));
+    MeasureTool.updateLastPoint(CURSOR_POSITION);
+
+    t.is(MeasureTool._currentPath._points.length, 2);
 });

--- a/test/measurement/MeasureTool.spec.js
+++ b/test/measurement/MeasureTool.spec.js
@@ -125,21 +125,20 @@ ava.serial('.buildPathInfo() builds a correct MeasureLegModel from FixModel poin
 
     const [pathInfo] = MeasureTool.buildPathInfo();
     const { initialTurn, firstLeg } = pathInfo;
-    const leg1 = firstLeg.next;
 
     t.is(initialTurn, null);
     t.true(firstLeg instanceof MeasureLegModel);
-    t.is(firstLeg.previous, null);
-    t.is(firstLeg.startPoint, null);
-    t.is(leg1.next, null);
+    t.not(firstLeg.previous, null);
+    t.not(firstLeg.startPoint, null);
+    t.is(firstLeg.next, null);
 
-    t.deepEqual(leg1.startPoint, bakrr.relativePosition);
-    t.deepEqual(leg1.endPoint, dbige.relativePosition);
-    t.not(leg1.midPoint, null);
-    t.not(leg1.bearing, 0);
-    t.not(leg1.distance, 0);
-    t.is(leg1.labels.length, 1);
-    t.is(leg1.radius, 0);
+    t.deepEqual(firstLeg.startPoint, bakrr.relativePosition);
+    t.deepEqual(firstLeg.endPoint, dbige.relativePosition);
+    t.not(firstLeg.midPoint, null);
+    t.not(firstLeg.bearing, 0);
+    t.not(firstLeg.distance, 0);
+    t.is(firstLeg.labels.length, 1);
+    t.is(firstLeg.radius, 0);
 });
 
 ava.serial('.buildPathInfo() builds a correct MeasureLegModel from mixed points', (t) => {
@@ -158,16 +157,14 @@ ava.serial('.buildPathInfo() builds a correct MeasureLegModel from mixed points'
     const [pathInfo] = MeasureTool.buildPathInfo();
     const { initialTurn, firstLeg } = pathInfo;
     const leg1 = firstLeg.next;
-    const leg2 = leg1.next;
 
     t.not(initialTurn, null);
     t.true(firstLeg instanceof MeasureLegModel);
-    t.is(firstLeg.previous, null);
-    t.is(leg2.next, null);
+    t.is(leg1.next, null);
 
     t.not(initialTurn.turnRadius, 0);
-    t.not(leg1.radius, 0);
-    t.is(leg2.radius, 0);
+    t.not(firstLeg.radius, 0);
+    t.is(leg1.radius, 0);
 });
 
 ava.serial('.removePreviousPoint() removes the second-to-last point in the current path', (t) => {

--- a/test/navigationLibrary/Fix/FixCollection.spec.js
+++ b/test/navigationLibrary/Fix/FixCollection.spec.js
@@ -8,7 +8,7 @@ import { airportPositionFixtureKSFO } from '../../fixtures/airportFixtures';
 import {
     FIX_LIST_MOCK,
     SMALL_FIX_LIST_MOCK
-} from '../Fix/_mocks/fixMocks';
+} from './_mocks/fixMocks';
 
 ava.before(() => {
     FixCollection.removeItems();
@@ -82,6 +82,15 @@ ava.serial('.getFixRelativePosition() returns null if a FixModel does not exist 
     const result = FixCollection.getFixRelativePosition('');
 
     t.true(!result);
+});
+
+ava.serial('.getNearestFix() returns a fix and distance', t => {
+    // In reality, this isnt the nearest fix to KSFO, but is the nearest in the mocks
+    const expectedFix = FixCollection.findFixByName('OAL');
+    const [fix, distance] = FixCollection.getNearestFix(airportPositionFixtureKSFO.relativePosition);
+
+    t.is(fix, expectedFix);
+    t.not(distance, Infinity);
 });
 
 ava.serial('.findRealFixes() returns a list of fixes that dont have `_` prepending thier name', t => {

--- a/test/navigationLibrary/Fix/FixModel.spec.js
+++ b/test/navigationLibrary/Fix/FixModel.spec.js
@@ -3,7 +3,8 @@ import FixModel from '../../../src/assets/scripts/client/navigationLibrary/FixMo
 import DynamicPositionModel from '../../../src/assets/scripts/client/base/DynamicPositionModel';
 import {
     FIXNAME_MOCK,
-    FIX_COORDINATE_MOCK
+    FIX_COORDINATE_MOCK,
+    REAL_FIXNAME_MOCK
 } from './_mocks/fixMocks';
 import { airportPositionFixtureKSFO } from '../../fixtures/airportFixtures';
 import {
@@ -64,6 +65,14 @@ ava('.init() sets name in upperCase', t => {
 
     model = new FixModel('u443rcas3', FIX_COORDINATE_MOCK, airportPositionFixtureKSFO);
     t.true(model.name === 'U443RCAS3');
+});
+
+ava('.isRealFix returns correct value', (t) => {
+    let model = new FixModel(FIXNAME_MOCK, FIX_COORDINATE_MOCK, airportPositionFixtureKSFO);
+    t.false(model.isRealFix);
+
+    model = new FixModel(REAL_FIXNAME_MOCK, FIX_COORDINATE_MOCK, airportPositionFixtureKSFO);
+    t.true(model.isRealFix);
 });
 
 ava('.clonePosition() returns a DynamicPositionModel with the position information of the FixModel', t => {


### PR DESCRIPTION
Resolves #45

The purpose of this pull request is to implement a *T (or equivalent) tool to measure distances, bearings on the scope.

Currently, it's initialted by holding down the Shift, although a scope command or button could be used to do the same.
* The tool will snap to the nearest aircraft or fix, or if none is found nearby it defaults to the cursor position
* Multiple ponts are supported, and can be an Aircraft, Fix, or Arbitrary point, and any combination of the above
* The path is updated as the mouse is moved to provide immediate vector information
* If the first point is an aircraft, the current ground speed will be used to estimate timings and turn radii

Isssues:
* There is currently no option to disable snapping. A 2nd keyboard modifier could be used.
* When drawing _"hairpin"_ paths, the tool will struggle to draw accurate arcs as the fillet (turn) radius may be too large.
* Tests are needed, as usual...

I've explain as much as possible in the comments, but I'm sure there'll be plenty of WFTs!