### PR TITLE
bugfix/1456 - Only allow headings between 001 and 360 degrees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - <a href="https://github.com/openscope/openscope/issues/1105" target="_blank">#1105</a> - Add in-sim Airport Guide accessible via footer button
 
 ### Bugfixes
+- <a href="https://github.com/openscope/openscope/issues/1456" target="_blank">#1456</a> - Only allow headings between 001 and 360
 
 ### Enhancements & Refactors
 - <a href="https://github.com/openscope/openscope/issues/1451" target="_blank">#1451</a> - Add ability to specify the radial with the `hold` command

--- a/src/assets/scripts/client/parsers/aircraftCommandParser/aircraftCommandParserMessages.js
+++ b/src/assets/scripts/client/parsers/aircraftCommandParser/aircraftCommandParserMessages.js
@@ -35,6 +35,8 @@ export const ERROR_MESSAGE = {
     ALTITUDE_MUST_BE_NUMBER: `${INVALID_ARG}. Altitude must be a number`,
     ALTITUDE_EXPEDITE_ARG: `${INVALID_ARG}. Altitude accepts only "expedite" or "x" as a second argument`,
     HEADING_MUST_BE_NUMBER: `${INVALID_ARG}. Heading must be a number`,
+    HEADING_MUST_BE_VALID_COURSE: `${INVALID_ARG}. Heading must be between 001 and 360`,
+    INCREMENTAL_HEADING_MUST_BE_POSITIVE: `${INVALID_ARG}. Incremental heading must be positive`,
     MUST_BE_STRING: `${INVALID_ARG}. Must be a string`,
     INVALID_DIRECTION_STRING: `${INVALID_ARG}. Expected one of 'left / l / right / r' as the first argument when passed three arguments`,
     HEADING_ACCEPTS_BOOLEAN_AS_THIRD_ARG: `${INVALID_ARG}. Heading accepts a boolean for the third argument when passed three arguments`,

--- a/src/assets/scripts/client/parsers/aircraftCommandParser/argumentValidators.js
+++ b/src/assets/scripts/client/parsers/aircraftCommandParser/argumentValidators.js
@@ -228,10 +228,8 @@ export const headingValidator = (args = []) => {
 
     switch (length) {
         case 1:
-            numberFromString = convertStringToNumber(args[0]);
-
-            if (_isNaN(numberFromString)) {
-                return ERROR_MESSAGE.HEADING_MUST_BE_NUMBER;
+            if (!isValidCourseString(args[0])) {
+                return ERROR_MESSAGE.HEADING_MUST_BE_VALID_COURSE;
             }
 
             break;
@@ -242,8 +240,16 @@ export const headingValidator = (args = []) => {
                 return ERROR_MESSAGE.INVALID_DIRECTION_STRING;
             }
 
+            if (args[1].length === 3 && !isValidCourseString(args[1])) {
+                return ERROR_MESSAGE.HEADING_MUST_BE_VALID_COURSE;
+            }
+
             if (_isNaN(numberFromString)) {
                 return ERROR_MESSAGE.HEADING_MUST_BE_NUMBER;
+            }
+
+            if (numberFromString < 1) {
+                return ERROR_MESSAGE.INCREMENTAL_HEADING_MUST_BE_POSITIVE;
             }
 
             break;

--- a/test/parsers/aircraftCommandParser/argumentValidator.spec.js
+++ b/test/parsers/aircraftCommandParser/argumentValidator.spec.js
@@ -179,37 +179,44 @@ ava('.fixValidator() returns a string when passed anything other than a string',
 
 ava('.headingValidator() returns a string when passed the wrong number of arguments', t => {
     let result = headingValidator(['042']);
-    t.true(typeof result === 'undefined');
+    t.is(result, undefined);
 
     result = headingValidator(['l', '42']);
-    t.true(typeof result === 'undefined');
+    t.is(result, undefined);
 
     result = headingValidator();
-    t.true(result === 'Invalid argument length. Expected one or two arguments');
+    t.is(result, 'Invalid argument length. Expected one or two arguments');
 
     result = headingValidator([]);
-    t.true(result === 'Invalid argument length. Expected one or two arguments');
+    t.is(result, 'Invalid argument length. Expected one or two arguments');
 
     result = headingValidator(['l', '42', 'threeve']);
-    t.true(result === 'Invalid argument length. Expected one or two arguments');
+    t.is(result, 'Invalid argument length. Expected one or two arguments');
 });
 
 ava('.headingValidator() returns a string when passed the wrong type of arguments', t => {
-    t.true(headingValidator(['threeve']) === 'Invalid argument. Heading must be a number');
-    t.true(headingValidator(['42', '42']) === 'Invalid argument. Expected one of \'left / l / right / r\' as the first argument when passed three arguments');
-    t.true(headingValidator(['l', 'threeve']) === 'Invalid argument. Heading must be a number');
-    t.true(headingValidator(['42', '42']) === 'Invalid argument. Expected one of \'left / l / right / r\' as the first argument when passed three arguments');
-    t.true(headingValidator(['l', 'threeve']) === 'Invalid argument. Heading must be a number');
+    t.is(headingValidator(['threeve']), 'Invalid argument. Heading must be between 001 and 360');
+    t.is(headingValidator(['42', '42']), 'Invalid argument. Expected one of \'left / l / right / r\' as the first argument when passed three arguments');
+    t.is(headingValidator(['l', 'threeve']), 'Invalid argument. Heading must be a number');
+    t.is(headingValidator(['42', '42']), 'Invalid argument. Expected one of \'left / l / right / r\' as the first argument when passed three arguments');
+    t.is(headingValidator(['l', 'threeve']), 'Invalid argument. Heading must be a number');
+    t.is(headingValidator(['000']), 'Invalid argument. Heading must be between 001 and 360');
+    t.is(headingValidator(['361']), 'Invalid argument. Heading must be between 001 and 360');
+    t.is(headingValidator(['l', '000']), 'Invalid argument. Heading must be between 001 and 360');
+    t.is(headingValidator(['l', '361']), 'Invalid argument. Heading must be between 001 and 360');
+    t.is(headingValidator(['l', '0']), 'Invalid argument. Incremental heading must be positive');
+    t.is(headingValidator(['l', '-9']), 'Invalid argument. Incremental heading must be positive');
 });
 
 ava('.headingValidator() returns undefined when passed a number as a single argument', t => {
     const result = headingValidator(['042']);
-    t.true(typeof result === 'undefined');
+    t.is(result, undefined);
 });
 
 ava('.headingValidator() returns undefined when passed a string and a number as arguments', t => {
-    const result = headingValidator(['l', '042']);
-    t.true(typeof result === 'undefined');
+    t.is(headingValidator(['l', '2']), undefined);
+    t.is(headingValidator(['l', '42']), undefined);
+    t.is(headingValidator(['l', '042']), undefined);
 });
 
 ava('.holdValidator() returns a string when passed the wrong number of arguments', t => {


### PR DESCRIPTION
Resolves #1456

The purpose of this pull request is to:

* Only allow absolute headings between 001 and 360
* Reject non-positive incremental headings
* Update tests accordingly