### PR TITLE
hotifx/1480 - Ensure settings menu appears above flight strip bay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 6.16.0 (January 1, 2020)
+### New Features
+
+### Bugfixes
+
+### Enhancements & Refactors
+
 # 6.15.0 (December 1, 2019)
 ### New Features
 - <a href="https://github.com/openscope/openscope/issues/1105" target="_blank">#1105</a> - Add in-sim Airport Guide accessible via footer button

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,7 @@
-# 6.16.0 (January 1, 2020)
-### New Features
+# 6.15.1 (December 2, 2020)
+### Hotfixes
+- <a href="https://github.com/openscope/openscope/issues/1480" target="_blank">#1480</a> - Ensure settings menu appears above flight strip bay
 
-### Bugfixes
-
-### Enhancements & Refactors
 
 # 6.15.0 (December 1, 2019)
 ### New Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "openscope",
-  "version": "6.15.0",
+  "version": "6.16.0-BETA",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "openscope",
-  "version": "6.16.0-BETA",
+  "version": "6.15.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openscope",
-  "version": "6.15.0",
+  "version": "6.16.0-BETA",
   "description": "An ATC simulator in HTML5",
   "engines": {
     "node": "11.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openscope",
-  "version": "6.16.0-BETA",
+  "version": "6.15.1",
   "description": "An ATC simulator in HTML5",
   "engines": {
     "node": "11.3.0",

--- a/src/assets/style/module/controls/_controls.less
+++ b/src/assets/style/module/controls/_controls.less
@@ -3,7 +3,7 @@
     margin: 0;
     padding: 0;
     overflow: hidden;
-    z-index: 2;
+    z-index: 125;
 }
 
 .control-item {


### PR DESCRIPTION
Resolves #1480

The purpose of this pull request is to ensure that the command popup menu is displayed above the expanded stripview

It would be ideal if we can get this merged for v.15.0