### PR TITLE
Fixes broken link in aircraft-commands.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Enhancements & Refactors
 - <a href="https://github.com/openscope/openscope/issues/1486" target="_blank">#1486</a> - Update AFL airline
+- <a href="https://github.com/openscope/openscope/issues/1507" target="_blank">#1507</a> - Fix broken link in aircraft commands documentation
 
 
 # 6.15.1 (December 2, 2020)

--- a/documentation/aircraft-commands.md
+++ b/documentation/aircraft-commands.md
@@ -13,7 +13,7 @@
 
 - [Expect Runway](#expect-runway)
 - [Descend via STAR](#descend-via-star)
-- [Land](#land)
+- [ILS](#ils)
 
 [Routing Commands](#routing-commands)
 


### PR DESCRIPTION
Resolves #1496.
Replaces external PR #1496.

All work by @ach1980.

Fixes broken link in aircraft commands page.