### PR TITLE
bugfix/1389 - Prevent unfair penalty at KDCA on IRONS7 by deactivating R6601B/C

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### New Features
 
 ### Bugfixes
+- <a href="https://github.com/openscope/openscope/issues/1389" target="_blank">#1389</a> - Prevent unfair penalty at KDCA on IRONS7 arrivals by deactivating R6601B/C
 
 ### Enhancements & Refactors
 - <a href="https://github.com/openscope/openscope/issues/1486" target="_blank">#1486</a> - Update AFL airline

--- a/assets/airports/kdca.json
+++ b/assets/airports/kdca.json
@@ -909,8 +909,8 @@
             ]
         },
         {
-            "name": "R-6601",
-            "height": "9000ft",
+            "name": "R-6601A",
+            "height": "4500ft",
             "coordinates": [
                 ["N38d04m37", "W077d18m44"],
                 ["N38d09m45", "W077d11m59"],


### PR DESCRIPTION
Resolves #1389.

Prevent unfair penalty at KDCA on IRONS7 by deactivating R6601B/C.
