### PR TITLE
bugfix/1316 Mark deep render when aircraft is (de)selected

### DIFF
--- a/src/assets/scripts/client/InputController.js
+++ b/src/assets/scripts/client/InputController.js
@@ -209,7 +209,7 @@ export default class InputController {
         this.$commandInput.val('');
 
         this._eventBus.trigger(EVENT.DESELECT_ACTIVE_STRIP_VIEW, {});
-        this._eventBus.trigger(EVENT.SELECT_AIRCRAFT);
+        this._eventBus.trigger(EVENT.TOGGLE_COMPASS);
     }
 
     /**
@@ -431,7 +431,7 @@ export default class InputController {
         }
 
         this._eventBus.trigger(EVENT.SELECT_STRIP_VIEW_FROM_DATA_BLOCK, aircraftModel);
-        this._eventBus.trigger(EVENT.SELECT_AIRCRAFT);
+        this._eventBus.trigger(EVENT.TOGGLE_COMPASS);
     };
 
     /**

--- a/src/assets/scripts/client/InputController.js
+++ b/src/assets/scripts/client/InputController.js
@@ -209,6 +209,7 @@ export default class InputController {
         this.$commandInput.val('');
 
         this._eventBus.trigger(EVENT.DESELECT_ACTIVE_STRIP_VIEW, {});
+        this._eventBus.trigger(EVENT.SELECT_AIRCRAFT);
     }
 
     /**
@@ -430,6 +431,7 @@ export default class InputController {
         }
 
         this._eventBus.trigger(EVENT.SELECT_STRIP_VIEW_FROM_DATA_BLOCK, aircraftModel);
+        this._eventBus.trigger(EVENT.SELECT_AIRCRAFT);
     };
 
     /**

--- a/src/assets/scripts/client/canvas/CanvasController.js
+++ b/src/assets/scripts/client/canvas/CanvasController.js
@@ -244,7 +244,7 @@ export default class CanvasController {
         this._onToggleVideoMapHandler = this._onToggleVideoMap.bind(this);
         this._onRangeRingsChangeHandler = this._onRangeRingsChange.bind(this);
         this._onResizeHandler = this.canvas_resize.bind(this);
-        this._onSelectAircraft = this._onSelectAircraft.bind(this);
+        this._onToggleAircraft = this._onToggleAircraft.bind(this);
 
         this._setThemeHandler = this._setTheme.bind(this);
 
@@ -270,7 +270,7 @@ export default class CanvasController {
         this._eventBus.on(EVENT.RANGE_RINGS_CHANGE, this._onRangeRingsChangeHandler);
         this._eventBus.on(EVENT.AIRPORT_CHANGE, this._onAirportChangeHandler);
         this._eventBus.on(EVENT.SET_THEME, this._setThemeHandler);
-        this._eventBus.on(EVENT.SELECT_AIRCRAFT, this._onSelectAircraft);
+        this._eventBus.on(EVENT.TOGGLE_COMPASS, this._onToggleAircraft);
         window.addEventListener('resize', this._onResizeHandler);
 
         this.$element.addClass(this.theme.CLASSNAME);
@@ -296,7 +296,7 @@ export default class CanvasController {
         this._eventBus.off(EVENT.RANGE_RINGS_CHANGE, this._onRangeRingsChangeHandler);
         this._eventBus.off(EVENT.AIRPORT_CHANGE, this._onAirportChangeHandler);
         this._eventBus.off(EVENT.SET_THEME, this._setTheme);
-        this._eventBus.off(EVENT.SELECT_AIRCRAFT, this._onSelectAircraft);
+        this._eventBus.off(EVENT.TOGGLE_COMPASS, this._onToggleAircraft);
         window.removeEventListener('resize', this._onResizeHandler);
 
         return this.destroy();
@@ -2381,10 +2381,10 @@ export default class CanvasController {
      * class via the `EventBus`
      *
      * @for CanvasController
-     * @method _onSelectAircraft
+     * @method _onToggleAircraft
      * @private
      */
-    _onSelectAircraft(){
+    _onToggleAircraft(){
         this._markDeepRender();
     }
 

--- a/src/assets/scripts/client/canvas/CanvasController.js
+++ b/src/assets/scripts/client/canvas/CanvasController.js
@@ -244,6 +244,7 @@ export default class CanvasController {
         this._onToggleVideoMapHandler = this._onToggleVideoMap.bind(this);
         this._onRangeRingsChangeHandler = this._onRangeRingsChange.bind(this);
         this._onResizeHandler = this.canvas_resize.bind(this);
+        this._onSelectAircraft = this._onSelectAircraft.bind(this);
 
         this._setThemeHandler = this._setTheme.bind(this);
 
@@ -269,6 +270,7 @@ export default class CanvasController {
         this._eventBus.on(EVENT.RANGE_RINGS_CHANGE, this._onRangeRingsChangeHandler);
         this._eventBus.on(EVENT.AIRPORT_CHANGE, this._onAirportChangeHandler);
         this._eventBus.on(EVENT.SET_THEME, this._setThemeHandler);
+        this._eventBus.on(EVENT.SELECT_AIRCRAFT, this._onSelectAircraft);
         window.addEventListener('resize', this._onResizeHandler);
 
         this.$element.addClass(this.theme.CLASSNAME);
@@ -294,6 +296,7 @@ export default class CanvasController {
         this._eventBus.off(EVENT.RANGE_RINGS_CHANGE, this._onRangeRingsChangeHandler);
         this._eventBus.off(EVENT.AIRPORT_CHANGE, this._onAirportChangeHandler);
         this._eventBus.off(EVENT.SET_THEME, this._setTheme);
+        this._eventBus.off(EVENT.SELECT_AIRCRAFT, this._onSelectAircraft);
         window.removeEventListener('resize', this._onResizeHandler);
 
         return this.destroy();
@@ -2368,6 +2371,20 @@ export default class CanvasController {
      * @private
      */
     _onRangeRingsChange() {
+        this._markDeepRender();
+    }
+
+    /**
+     * Notify that an aircraft has been selected or deselected
+     *
+     * This method will only be `trigger`ed by some other
+     * class via the `EventBus`
+     *
+     * @for CanvasController
+     * @method _onSelectAircraft
+     * @private
+     */
+    _onSelectAircraft(){
         this._markDeepRender();
     }
 

--- a/src/assets/scripts/client/canvas/CanvasController.js
+++ b/src/assets/scripts/client/canvas/CanvasController.js
@@ -2384,7 +2384,7 @@ export default class CanvasController {
      * @method _onToggleAircraft
      * @private
      */
-    _onToggleAircraft(){
+    _onToggleAircraft() {
         this._markDeepRender();
     }
 


### PR DESCRIPTION
Resolves #1316

The compass now (dis)appears once the aircraft is (de)selected instead of having the player scroll the mouse wheel for it to initially appear.
