### PR TITLE
enhancement/1343 Regenerate inbound traffic when arrival rate changes

### DIFF
--- a/src/assets/scripts/client/aircraft/AircraftController.js
+++ b/src/assets/scripts/client/aircraft/AircraftController.js
@@ -22,6 +22,7 @@ import { isEmptyOrNotArray } from '../utilities/validatorUtilities';
 import { FLIGHT_CATEGORY } from '../constants/aircraftConstants';
 import { EVENT, AIRCRAFT_EVENT } from '../constants/eventNames';
 import { INVALID_INDEX } from '../constants/globalConstants';
+import { THEME } from '../constants/themes';
 
 // Temporary const declaration here to attach to the window AND use as internal property
 const aircraft = {};
@@ -144,6 +145,7 @@ export default class AircraftController {
      */
     _setupHandlers() {
         this._onRemoveAircraftHandler = this.aircraft_remove.bind(this);
+        this._onRemoveOutsideAircraft = this.aircraft_remove_all_outside.bind(this);
 
         return this;
     }
@@ -159,6 +161,7 @@ export default class AircraftController {
         this._eventBus.on(EVENT.SELECT_STRIP_VIEW_FROM_DATA_BLOCK, this.onSelectAircraftStrip);
         this._eventBus.on(EVENT.DESELECT_ACTIVE_STRIP_VIEW, this._onDeselectActiveStripView);
         this._eventBus.on(EVENT.REMOVE_AIRCRAFT, this._onRemoveAircraftHandler);
+        this._eventBus.on(EVENT.REMOVE_OUTSIDE_AIRCRAFT, this._onRemoveOutsideAircraft);
         this._eventBus.on(EVENT.REMOVE_AIRCRAFT_CONFLICT, this.removeConflict);
 
         return this;
@@ -175,6 +178,7 @@ export default class AircraftController {
         this._eventBus.off(EVENT.SELECT_STRIP_VIEW_FROM_DATA_BLOCK, this._onSelectAircraftStrip);
         this._eventBus.off(EVENT.DESELECT_ACTIVE_STRIP_VIEW, this._onDeselectActiveStripView);
         this._eventBus.off(EVENT.REMOVE_AIRCRAFT, this._onRemoveAircraftHandler);
+        this._eventBus.off(EVENT.REMOVE_OUTSIDE_AIRCRAFT, this.aircraft_remove_all);
         this._eventBus.off(EVENT.REMOVE_AIRCRAFT_CONFLICT, this.removeConflict);
 
         return this;
@@ -289,6 +293,19 @@ export default class AircraftController {
         // iterating forward would cause skipping as the array shifts
         for (let i = this.aircraft.list.length - 1; i >= 0; i--) {
             this.aircraft_remove(this.aircraft.list[i]);
+        }
+    }
+
+    /**
+     * This method is very similar to aircraft_remove_all() but only removes outside aircraft
+     *
+     * @for AircraftController
+     * @method aircraft_remove_all_outside
+     */
+    aircraft_remove_all_outside(){
+        for (let i = this.aircraft.list.length - 1; i >= 0; i--) {
+            if(!aircraft.list[i].isControllable)
+                this.aircraft_remove(this.aircraft.list[i]);
         }
     }
 

--- a/src/assets/scripts/client/aircraft/AircraftController.js
+++ b/src/assets/scripts/client/aircraft/AircraftController.js
@@ -301,10 +301,11 @@ export default class AircraftController {
      * @for AircraftController
      * @method aircraft_remove_all_outside
      */
-    aircraft_remove_all_outside(){
+    aircraft_remove_all_outside() {
         for (let i = this.aircraft.list.length - 1; i >= 0; i--) {
-            if(!aircraft.list[i].isControllable)
+            if (!aircraft.list[i].isControllable) {
                 this.aircraft_remove(this.aircraft.list[i]);
+            }
         }
     }
 

--- a/src/assets/scripts/client/aircraft/AircraftController.js
+++ b/src/assets/scripts/client/aircraft/AircraftController.js
@@ -22,7 +22,6 @@ import { isEmptyOrNotArray } from '../utilities/validatorUtilities';
 import { FLIGHT_CATEGORY } from '../constants/aircraftConstants';
 import { EVENT, AIRCRAFT_EVENT } from '../constants/eventNames';
 import { INVALID_INDEX } from '../constants/globalConstants';
-import { THEME } from '../constants/themes';
 
 // Temporary const declaration here to attach to the window AND use as internal property
 const aircraft = {};

--- a/src/assets/scripts/client/constants/gameOptionConstants.js
+++ b/src/assets/scripts/client/constants/gameOptionConstants.js
@@ -18,6 +18,7 @@ export const GAME_OPTION_NAMES = {
     PROJECTED_TRACK_LINE_LENGTHS: 'ptlLengths',
     RANGE_RINGS: 'rangeRings',
     SOFT_CEILING: 'softCeiling',
+    RESET_ARRIVALS: 'resetArrivals',
     THEME: 'theme'
 };
 
@@ -149,19 +150,19 @@ export const GAME_OPTION_VALUES = [
     },
     {
         name: GAME_OPTION_NAMES.RESET_ARRIVALS,
-        defaultValue: true,
+        defaultValue: 'yes',
         description: 'Allow reset of arrivals upon change',
         help: 'If set to yes, arrivals outside of the airspace will be reset when the arrival rate is changed. If set to no, arrivals will slowly begin arriving at the desired rate',
         type: 'select',
-        onChangeEventHandler: EVENT.RESET_ARRIVALS_OPTION,
+        onChangeEventHandler: null,
         optionList: [
             {
                 displayLabel: 'Yes',
-                value: true
+                value: 'yes'
             },
             {
                 displayLabel: 'No',
-                value: false
+                value: 'no'
             }
         ]
     },

--- a/src/assets/scripts/client/constants/gameOptionConstants.js
+++ b/src/assets/scripts/client/constants/gameOptionConstants.js
@@ -148,6 +148,24 @@ export const GAME_OPTION_VALUES = [
         ]
     },
     {
+        name: GAME_OPTION_NAMES.RESET_ARRIVALS,
+        defaultValue: true,
+        description: 'Allow reset of arrivals upon change',
+        help: 'If set to yes, arrivals outside of the airspace will be reset when the arrival rate is changed. If set to no, arrivals will slowly begin arriving at the desired rate',
+        type: 'select',
+        onChangeEventHandler: EVENT.RESET_ARRIVALS_OPTION,
+        optionList: [
+            {
+                displayLabel: 'Yes',
+                value: true
+            },
+            {
+                displayLabel: 'No',
+                value: false
+            }
+        ]
+    },
+    {
         name: GAME_OPTION_NAMES.MOUSE_CLICK_DRAG,
         defaultValue: 'right',
         description: 'Panning Button',

--- a/src/assets/scripts/client/trafficGenerator/buildPreSpawnAircraft.js
+++ b/src/assets/scripts/client/trafficGenerator/buildPreSpawnAircraft.js
@@ -324,6 +324,25 @@ const _calculateDistancesAlongRoute = (waypointModelList, airport) => {
 };
 
 /**
+ * Calculate the offset rate for the preSpawn Aircraft. "rate" will use the arrival rate of the TrafficController
+ *
+ * @function _calculateRateOffset
+ * @param rate
+ * @returns {float}
+ */
+const _calculateRateOffset = (rate) => {
+    if (rate <= 1) {
+        return 1;
+    }
+
+    const initialVal = 0.90;
+    const currentRate = rate - 1;
+    const offsetAmount = 0.03;
+    const offsetRate = initialVal - (offsetAmount * currentRate);
+    return offsetRate;
+};
+
+/**
  * Calculate heading, nextFix and position data to be used when creating an
  * `AircraftModel` along a route.
  *
@@ -337,7 +356,7 @@ const _preSpawn = (spawnPatternJson, airport) => {
     const airspaceCeiling = airport.maxAssignableAltitude;
     const spawnSpeed = spawnPatternJson.speed;
     const spawnAltitude = spawnPatternJson.altitude;
-    const entrailDistance = spawnSpeed / spawnPatternJson.rate;
+    const entrailDistance = (spawnSpeed / spawnPatternJson.rate) * _calculateRateOffset(1);
     const routeModel = new RouteModel(spawnPatternJson.route);
     const waypointModelList = routeModel.waypoints;
     const totalDistance = _calculateDistancesAlongRoute(waypointModelList, airport);

--- a/src/assets/scripts/client/ui/TrafficRateController.js
+++ b/src/assets/scripts/client/ui/TrafficRateController.js
@@ -2,9 +2,7 @@ import $ from 'jquery';
 import _forEach from 'lodash/forEach';
 import EventBus from '../lib/EventBus';
 import EventTracker from '../EventTracker';
-import GameController from '../game/GameController';
 import SpawnPatternCollection from '../trafficGenerator/SpawnPatternCollection';
-import SpawnPatternModel from '../trafficGenerator/SpawnPatternModel';
 import SpawnScheduler from '../trafficGenerator/SpawnScheduler';
 import { SELECTORS, CLASSNAMES } from '../constants/selectors';
 import { FLIGHT_CATEGORY } from '../constants/aircraftConstants';
@@ -183,7 +181,7 @@ export default class TrafficRateController {
      * @param {boolean} value
      * @method onArrivalSettingsChange
      */
-    onArrivalSettingsChange(value){
+    onArrivalSettingsChange(value) {
         this.canResetArrivals = value;
     }
 
@@ -301,8 +299,10 @@ export default class TrafficRateController {
             this._updateRate(spawnPattern, $childOutput);
         }
 
-        //Apply the reset to arrivals only if the arrivals category is changed
-        if(category == "arrival" && this.canResetArrivals == true){
+        /**
+         * Apply the reset to arrivals only if the arrivals category is changed
+         */
+        if (category === 'arrival' && this.canResetArrivals === true) {
             this._eventBus.trigger(EVENT.REMOVE_OUTSIDE_AIRCRAFT);
         }
     }


### PR DESCRIPTION
Resolves #1343 

[WIP] Trying to work on resetting the arrival aircraft once the arrival rate is reset.

What Works:
   - Deleting all the aircraft outside the airspace once the rate is changed.
   - The Settings panel has the option to turn off/on feature [does not completely work]

One issue that I would love help with is how to set `this.canResetArrivals` to false when the option "No" is chosen. For some reason, the event `EVENT.RESET_ARRIVALS_OPTION` does not seem to call the `onArrivalSettingsChange()` even though I set it to do exactly that.

[Also I'm pretty new so if you any criticism about what needs to be fixed then I'll gladly listen.]
