### PR TITLE
enhancement/1581 - Add Ability to Reset Scratchpad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Enhancements & Refactors
 - <a href="https://github.com/openscope/openscope/issues/1590" target="_blank">#1590</a> - Update KLAX airport guide description
 - <a href="https://github.com/openscope/openscope/issues/1589" target="_blank">#1589</a> - Update KDCA airport guide links
+- <a href="https://github.com/openscope/openscope/issues/1581" target="_blank">#1581</a> - Add ability to reset scratchpad with "."
 
 # 6.17.1 (May 21, 2020)
 ### Hotfixes

--- a/documentation/scope-commands.md
+++ b/documentation/scope-commands.md
@@ -53,13 +53,13 @@ _More Info -_ On real ATC systems, moving the data block is sometimes used by co
 
 ~~_More Info -_ **THIS COMMAND IS NOT YET AVAILABLE**~~
 
-### Set Scratch Pad~~
+### Set Scratchpad
 
 _Syntax -_ `[scratchpad text] [CID]`
 
-_Description -_ This will amend the value stored in the target's data block's scratch pad. This value can be a maximum of three alphanumeric characters.~~
+_Description -_ This will amend the value stored in the target's data block's scratchpad. This value can be either two or three alphanumeric characters.
 
-More Info -
+More Info - To reset the scratchpad, set it to a period symbol `. [CID]`
 
 ### Toggle Halo
 

--- a/src/assets/scripts/client/parsers/scopeCommandParser/ScopeCommandModel.js
+++ b/src/assets/scripts/client/parsers/scopeCommandParser/ScopeCommandModel.js
@@ -107,6 +107,10 @@ export default class ScopeCommandModel {
             return COMMAND_FUNCTIONS.INITIATE_HANDOFF;
         }
 
+        if (firstElement === '.') {
+            return COMMAND_FUNCTIONS.SCRATCHPAD;
+        }
+
         if (firstElement.indexOf(DATA_BLOCK_DIRECTION_LENGTH_SEPARATOR) !== -1 || firstElement.length < 2) {
             return COMMAND_FUNCTIONS.MOVE_DATA_BLOCK;
         }

--- a/src/assets/scripts/client/scope/RadarTargetModel.js
+++ b/src/assets/scripts/client/scope/RadarTargetModel.js
@@ -539,8 +539,7 @@ export default class RadarTargetModel {
      *
      * @for RadarTargetModel
      * @method setDefaultScratchpad
-     * @private
-     * @chainable
+     * @return {array} [success of operation, system's response]
      */
     setDefaultScratchpad() {
         if (this.aircraftModel.isDeparture()) {

--- a/src/assets/scripts/client/scope/RadarTargetModel.js
+++ b/src/assets/scripts/client/scope/RadarTargetModel.js
@@ -172,8 +172,7 @@ export default class RadarTargetModel {
         this._theme = theme;
 
         this._init(aircraftModel)
-            .enable()
-            .setDefaultScratchpad(aircraftModel);
+            .enable();
     }
 
     /**
@@ -268,6 +267,8 @@ export default class RadarTargetModel {
         this._dataBlockLeaderLength = this._theme.DATA_BLOCK.LEADER_LENGTH;
         this._routeString = aircraftModel.fms.getRouteString();
 
+        this.setDefaultScratchpad();
+
         return this;
     }
 
@@ -276,6 +277,7 @@ export default class RadarTargetModel {
     *
     * @for RadarTargetModel
     * @method enable
+    * @chainable
     */
     enable() {
         this._eventBus.on(EVENT.SET_THEME, this._setTheme);
@@ -288,9 +290,12 @@ export default class RadarTargetModel {
     *
     * @for RadarTargetModel
     * @method disable
+    * @chainable
     */
     disable() {
         this._eventBus.off(EVENT.SET_THEME, this._setTheme);
+
+        return this;
     }
 
     /**
@@ -298,6 +303,7 @@ export default class RadarTargetModel {
     *
     * @for RadarTargetModel
     * @method reset
+    * @chainable
     */
     reset() {
         this.aircraftModel = null;
@@ -310,6 +316,8 @@ export default class RadarTargetModel {
         this._interimAltitude = INVALID_NUMBER;
         this._isUnderOurControl = true;
         this._routeString = '';
+
+        return this;
     }
 
     /**
@@ -534,14 +542,14 @@ export default class RadarTargetModel {
      * @private
      * @chainable
      */
-    setDefaultScratchpad(aircraftModel) {
-        if (aircraftModel.isDeparture()) {
-            this.scratchPadText = aircraftModel.fms.getFlightPlanEntry();
+    setDefaultScratchpad() {
+        if (this.aircraftModel.isDeparture()) {
+            this.scratchPadText = this.aircraftModel.fms.getFlightPlanEntry();
 
             return [true, 'RESET SCRATCHPAD'];
         }
 
-        this.scratchPadText = aircraftModel.destination.substr(1, 3);
+        this.scratchPadText = this.aircraftModel.destination.substr(1, 3);
 
         return [true, 'RESET SCRATCHPAD'];
     }

--- a/src/assets/scripts/client/scope/RadarTargetModel.js
+++ b/src/assets/scripts/client/scope/RadarTargetModel.js
@@ -172,7 +172,7 @@ export default class RadarTargetModel {
         this._theme = theme;
 
         this._init(aircraftModel)
-            ._initializeScratchPad()
+            .setDefaultScratchpad()
             .enable();
     }
 
@@ -267,26 +267,6 @@ export default class RadarTargetModel {
         this._dataBlockLeaderDirection = this._theme.DATA_BLOCK.LEADER_DIRECTION;
         this._dataBlockLeaderLength = this._theme.DATA_BLOCK.LEADER_LENGTH;
         this._routeString = aircraftModel.fms.getRouteString();
-
-        return this;
-    }
-
-    /**
-     * Initialize the value of the scratchpad
-     *
-     * @for RadarTargetModel
-     * @method _initializeScratchPad
-     * @private
-     * @chainable
-     */
-    _initializeScratchPad() {
-        if (this.aircraftModel.isDeparture()) {
-            this.scratchPadText = this.aircraftModel.fms.getFlightPlanEntry();
-
-            return this;
-        }
-
-        this.scratchPadText = this.aircraftModel.destination.substr(1, 3);
 
         return this;
     }
@@ -542,6 +522,26 @@ export default class RadarTargetModel {
         this._haloRadius = radius;
 
         return [true, 'ADJUST HALO'];
+    }
+
+    /**
+     * Initialize the value of the scratchpad
+     *
+     * @for RadarTargetModel
+     * @method setDefaultScratchpad
+     * @private
+     * @chainable
+     */
+    setDefaultScratchpad() {
+        if (this.aircraftModel.isDeparture()) {
+            this.scratchPadText = this.aircraftModel.fms.getFlightPlanEntry();
+
+            return this;
+        }
+
+        this.scratchPadText = this.aircraftModel.destination.substr(1, 3);
+
+        return this;
     }
 
     /**

--- a/src/assets/scripts/client/scope/RadarTargetModel.js
+++ b/src/assets/scripts/client/scope/RadarTargetModel.js
@@ -527,7 +527,7 @@ export default class RadarTargetModel {
     }
 
     /**
-     * Initialize the value of the scratchpad
+     * Set default value of the scratchpad
      *
      * @for RadarTargetModel
      * @method setDefaultScratchpad

--- a/src/assets/scripts/client/scope/RadarTargetModel.js
+++ b/src/assets/scripts/client/scope/RadarTargetModel.js
@@ -172,8 +172,8 @@ export default class RadarTargetModel {
         this._theme = theme;
 
         this._init(aircraftModel)
-            .setDefaultScratchpad()
-            .enable();
+            .enable()
+            .setDefaultScratchpad(aircraftModel);
     }
 
     /**
@@ -279,6 +279,8 @@ export default class RadarTargetModel {
     */
     enable() {
         this._eventBus.on(EVENT.SET_THEME, this._setTheme);
+
+        return this;
     }
 
     /**
@@ -532,16 +534,16 @@ export default class RadarTargetModel {
      * @private
      * @chainable
      */
-    setDefaultScratchpad() {
-        if (this.aircraftModel.isDeparture()) {
-            this.scratchPadText = this.aircraftModel.fms.getFlightPlanEntry();
+    setDefaultScratchpad(aircraftModel) {
+        if (aircraftModel.isDeparture()) {
+            this.scratchPadText = aircraftModel.fms.getFlightPlanEntry();
 
-            return this;
+            return [true, 'RESET SCRATCHPAD'];
         }
 
-        this.scratchPadText = this.aircraftModel.destination.substr(1, 3);
+        this.scratchPadText = aircraftModel.destination.substr(1, 3);
 
-        return this;
+        return [true, 'RESET SCRATCHPAD'];
     }
 
     /**

--- a/src/assets/scripts/client/scope/ScopeModel.js
+++ b/src/assets/scripts/client/scope/ScopeModel.js
@@ -303,7 +303,7 @@ export default class ScopeModel {
         }
 
         if (scratchPadText === '.') {
-            return radarTargetModel.setDefaultScratchpad(radarTargetModel.aircraftModel);
+            return radarTargetModel.setDefaultScratchpad();
         }
 
         return radarTargetModel.setScratchpad(scratchPadText.toUpperCase());

--- a/src/assets/scripts/client/scope/ScopeModel.js
+++ b/src/assets/scripts/client/scope/ScopeModel.js
@@ -302,6 +302,10 @@ export default class ScopeModel {
             return [false, 'ERR: SCRATCHPAD MAX 3 CHAR'];
         }
 
+        if (scratchPadText === '.') {
+            return radarTargetModel.setDefaultScratchpad();
+        }
+
         return radarTargetModel.setScratchpad(scratchPadText.toUpperCase());
     }
 

--- a/src/assets/scripts/client/scope/ScopeModel.js
+++ b/src/assets/scripts/client/scope/ScopeModel.js
@@ -303,7 +303,7 @@ export default class ScopeModel {
         }
 
         if (scratchPadText === '.') {
-            return radarTargetModel.setDefaultScratchpad();
+            return radarTargetModel.setDefaultScratchpad(radarTargetModel.aircraftModel);
         }
 
         return radarTargetModel.setScratchpad(scratchPadText.toUpperCase());

--- a/test/scope/RadarTargetModel.spec.js
+++ b/test/scope/RadarTargetModel.spec.js
@@ -199,29 +199,29 @@ ava('.setHalo() calls .removeHalo() when a halo is requested of the same radius 
     t.true(removeHaloStub.calledWithExactly());
 });
 
-ava('._initializeScratchPad() sets #_scratchPadText to show aircraft\'s destination', (t) => {
+ava('.setDefaultScratchpad() sets #_scratchPadText to show aircraft\'s destination', (t) => {
     const model = new RadarTargetModel(THEME.DEFAULT, ARRIVAL_AIRCRAFT_MODEL_MOCK);
     const expectedValue = model.aircraftModel.destination.substr(1);
 
-    model._initializeScratchPad();
+    model.setDefaultScratchpad();
 
     t.true(model._scratchPadText === expectedValue);
 });
 
-ava('._initializeScratchPad() sets #_scratchPadText to departure exit fix when aircraft is on departure route', (t) => {
+ava('.setDefaultScratchpad() sets #_scratchPadText to departure exit fix when aircraft is on departure route', (t) => {
     const model = new RadarTargetModel(THEME.DEFAULT, DEPARTURE_AIRCRAFT_MODEL_MOCK);
     const expectedValue = 'GUP';
 
-    model._initializeScratchPad();
+    model.setDefaultScratchpad();
 
     t.true(model._scratchPadText === expectedValue);
 });
 
-ava('._initializeScratchPad() sets #_scratchPadText to arrival airport when aircraft is on arrival route', (t) => {
+ava('.setDefaultScratchpad() sets #_scratchPadText to arrival airport when aircraft is on arrival route', (t) => {
     const model = new RadarTargetModel(THEME.DEFAULT, ARRIVAL_AIRCRAFT_MODEL_MOCK);
     const expectedValue = 'LAS';
 
-    model._initializeScratchPad();
+    model.setDefaultScratchpad();
 
     t.true(model._scratchPadText === expectedValue);
 });

--- a/test/scope/ScopeModel.spec.js
+++ b/test/scope/ScopeModel.spec.js
@@ -265,6 +265,21 @@ ava('.setScratchpad() returns scratchpad length error when too many characters p
     t.true(radarTargetModelSetScratchPadSpy.notCalled);
 });
 
+ava('.setScratchpad() calls and returns RadarTargetModel.setDefaultScratchpad() with no parameters', (t) => {
+    const model = new ScopeModel();
+    const radarTargetModel = createRadarTargetArrivalMock();
+    const radarTargetModelSetScratchpadSpy = sinon.spy(radarTargetModel, 'setScratchpad');
+    const radarTargetModelSetDefaultScratchpadSpy = sinon.spy(radarTargetModel, 'setDefaultScratchpad');
+    const resetScratchPadTrigger = '.';
+    const expectedResponse = [true, 'RESET SCRATCHPAD'];
+    const response = model.setScratchpad(radarTargetModel, resetScratchPadTrigger);
+
+    t.deepEqual(response, expectedResponse);
+    t.true(radarTargetModelSetScratchpadSpy.notCalled);
+    t.true(radarTargetModelSetDefaultScratchpadSpy.called);
+    t.true(radarTargetModelSetDefaultScratchpadSpy.calledWithExactly());
+});
+
 ava('.setScratchpad() sets RadarTargetModel._scratchPadText to the specified string', (t) => {
     const model = new ScopeModel();
     const radarTargetModel = createRadarTargetArrivalMock();


### PR DESCRIPTION
Resolves #1581.
Replaces #1592.

Add the ability to clear/reset an aircraft's scratchpad. Typing `. [CID]` (scope command) will reset the aircraft's scratchpad to its destination or first fix as automated on spawn.