### PR TITLE
refactor/1606 - Rename options panel title to settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - <a href="https://github.com/openscope/openscope/issues/1590" target="_blank">#1590</a> - Update KLAX airport guide description
 - <a href="https://github.com/openscope/openscope/issues/1589" target="_blank">#1589</a> - Update KDCA airport guide links
 - <a href="https://github.com/openscope/openscope/issues/1581" target="_blank">#1581</a> - Add ability to reset scratchpad with "."
+- <a href="https://github.com/openscope/openscope/issues/1606" target="_blank">#1606</a> - Retitle options menu to "Settings"
 
 # 6.17.1 (May 21, 2020)
 ### Hotfixes

--- a/src/assets/scripts/client/ui/SettingsController.js
+++ b/src/assets/scripts/client/ui/SettingsController.js
@@ -11,7 +11,7 @@ import { SELECTORS } from '../constants/selectors';
  */
 const UI_SETTINGS_MODAL_TEMPLATE = `
     <div class="option-dialog dialog">
-        <p class="dialog-title">Options</p>
+        <p class="dialog-title">Settings</p>
         <div class="dialog-body nice-scrollbar"></div>
     </div>`;
 


### PR DESCRIPTION
Resolves #1606 

The purpose of this pull request is to rename the `Options` panel title to `Settings`.