### PR TITLE
refactor/1645 - Change expedite command from "x" to "ex"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 6.20.0 (September 1, 2020)
+# 6.20.0 (October 1, 2020)
 ### New Features
 
 ### Bugfixes
@@ -6,6 +6,7 @@
 ### Enhancements & Refactors
 - <a href="https://github.com/openscope/openscope/issues/1615" target="_blank">#1615</a> - Fix broken link in KSTL airport guide
 - <a href="https://github.com/openscope/openscope/issues/1583" target="_blank">#1583</a> - Update EDDF to AIRAC 2009
+- <a href="https://github.com/openscope/openscope/issues/1645" target="_blank">#1645</a> - Change expedite command from "x" to "ex" (since "x" is now used for "cross")
 
 # 6.19.0 (August 10, 2020)
 ### New Features

--- a/documentation/aircraft-commands.md
+++ b/documentation/aircraft-commands.md
@@ -303,9 +303,9 @@ writing altitudes you would drop the last two zeros. For example, 3,000ft =
 "30", 8,300ft = "83", 10,000ft = "100", and FL180 (18,000ft) = "180".
 Airplanes will not descend below 1000 feet (unless locked on ILS).
 
-Altitude also accepts an `expedite` or `x` argument which can be used as the last item in the command.
+Altitude also accepts an `expedite` or `ex` argument which can be used as the last item in the command.
 
-_Syntax -_ `AAL123 c [alt]` or `AAL123 c [alt] x`
+_Syntax -_ `AAL123 c [alt]` or `AAL123 c [alt] ex`
 
 ### Fly Present Heading
 

--- a/src/assets/scripts/client/parsers/aircraftCommandParser/aircraftCommandMap.js
+++ b/src/assets/scripts/client/parsers/aircraftCommandParser/aircraftCommandMap.js
@@ -231,7 +231,7 @@ export const AIRCRAFT_COMMAND_MAP = {
  * @type {array}
  * @final
  */
-export const EXPEDITE = ['expedite', 'x'];
+export const EXPEDITE = ['expedite', 'ex'];
 
 /**
  * Get the name of a command when given any of that command's aliases

--- a/src/assets/scripts/client/parsers/aircraftCommandParser/aircraftCommandParserMessages.js
+++ b/src/assets/scripts/client/parsers/aircraftCommandParser/aircraftCommandParserMessages.js
@@ -33,7 +33,7 @@ export const ERROR_MESSAGE = {
     ONE_TO_THREE_ARG_LENGTH: `${INVALID_ARG_LENGTH}. Expected one, two, or three arguments`,
     ONE_OR_THREE_ARG_LENGTH: `${INVALID_ARG_LENGTH}. Expected one or three arguments`,
     TWO_OR_THREE_ARG_LENGTH: `${INVALID_ARG_LENGTH}. Expected two or three arguments`,
-    ALTITUDE_EXPEDITE_ARG: `${INVALID_ARG}. Altitude accepts only "expedite" or "x" as a second argument`,
+    ALTITUDE_EXPEDITE_ARG: `${INVALID_ARG}. Altitude accepts only "expedite" or "ex" as a second argument`,
     ALTITUDE_MUST_BE_NUMBER: `${INVALID_ARG}. Altitude must be a number`,
     SPEED_MUST_BE_NUMBER: `${INVALID_ARG}. Speed must be a number`,
     HEADING_MUST_BE_NUMBER: `${INVALID_ARG}. Heading must be a number`,

--- a/src/assets/scripts/client/parsers/aircraftCommandParser/argumentValidators.js
+++ b/src/assets/scripts/client/parsers/aircraftCommandParser/argumentValidators.js
@@ -107,7 +107,7 @@ export const twoOrThreeArgumentsValidator = (args = []) => {
  * Allowed argument shapes:
  * - ['030']
  * - ['030', 'expedite']
- * - ['030', 'x']
+ * - ['030', 'ex']
  * ```
  *
  * @function altitudeValidator

--- a/test/parsers/aircraftCommandParser/argumentParser.spec.js
+++ b/test/parsers/aircraftCommandParser/argumentParser.spec.js
@@ -19,7 +19,7 @@ ava('.altitudeParser() converts a string flight level altitude to a number altit
 });
 
 ava('.altitudeParser() returns true if the second argument is not undefined', t => {
-    const result = altitudeParser(['080', 'x']);
+    const result = altitudeParser(['080', 'ex']);
 
     t.true(result[1]);
 });

--- a/test/parsers/aircraftCommandParser/argumentValidator.spec.js
+++ b/test/parsers/aircraftCommandParser/argumentValidator.spec.js
@@ -126,15 +126,15 @@ ava('.altitudeValidator() returns a string when passed the wrong number of argum
     t.true(result === 'Invalid argument length. Expected one or two arguments');
 });
 
-ava('.altitudeValidator() returns a string when passed anything other than expedite or x as the second argument', t => {
+ava('.altitudeValidator() returns a string when passed anything other than expedite or ex as the second argument', t => {
     let result = altitudeValidator(['100', 'expedite']);
     t.true(typeof result === 'undefined');
 
-    result = altitudeValidator(['100', 'x']);
+    result = altitudeValidator(['100', 'ex']);
     t.true(typeof result === 'undefined');
 
     result = altitudeValidator(['100', '']);
-    t.true(result === 'Invalid argument. Altitude accepts only "expedite" or "x" as a second argument');
+    t.true(result === 'Invalid argument. Altitude accepts only "expedite" or "ex" as a second argument');
 });
 
 ava('.optionalAltitudeValidator() returns undefined when no value is passed', t => {


### PR DESCRIPTION
Resolves #1645.

Change expedite command from "x" to "ex" (since "x" is now used for "cross").

@lucianoasmus @j-651 @Hawaiicoder @af6754 @wmstapp