### PR TITLE
bugfix/1190 - re-add .notSelectable css class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ### Bugfixes
 - <a href="https://github.com/openscope/openscope/issues/1565" target="_blank">#1565</a> - Prevent aircraft from taxiing to a runway they're already holding short of
-- <a href="https://github.com/openscope/openscope/issues/1190" target="_blank">#1190</a> - Fix .notSelectable CSS class functionality
+- <a href="https://github.com/openscope/openscope/issues/1190" target="_blank">#1190</a> - Prevent selection of text in most dialogs
 
 ### Enhancements & Refactors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ### Bugfixes
 - <a href="https://github.com/openscope/openscope/issues/1565" target="_blank">#1565</a> - Prevent aircraft from taxiing to a runway they're already holding short of
+- <a href="https://github.com/openscope/openscope/issues/1190" target="_blank">#1190</a> - Fix .notSelectable CSS class functionality
 
 ### Enhancements & Refactors
 

--- a/src/assets/scripts/client/ui/SettingsController.js
+++ b/src/assets/scripts/client/ui/SettingsController.js
@@ -10,7 +10,7 @@ import { SELECTORS } from '../constants/selectors';
  * @final
  */
 const UI_SETTINGS_MODAL_TEMPLATE = `
-    <div class="option-dialog dialog">
+    <div class="option-dialog dialog notSelectable">
         <p class="dialog-title">Settings</p>
         <div class="dialog-body nice-scrollbar"></div>
     </div>`;

--- a/src/assets/scripts/client/ui/TrafficRateController.js
+++ b/src/assets/scripts/client/ui/TrafficRateController.js
@@ -16,7 +16,7 @@ import { TRACKABLE_EVENT } from '../constants/trackableEvents';
  * @final
  */
 const UI_TRAFFIC_MODAL_TEMPLATE = `
-    <div class="traffic-dialog dialog">
+    <div class="traffic-dialog dialog notSelectable">
         <p class="dialog-title">Traffic rate</p>
         <div class="dialog-body nice-scrollbar"></div>
     </div>`;

--- a/src/assets/scripts/client/ui/TutorialView.js
+++ b/src/assets/scripts/client/ui/TutorialView.js
@@ -15,7 +15,7 @@ import { TRACKABLE_EVENT } from '../constants/trackableEvents';
 const tutorial = {};
 
 const TUTORIAL_TEMPLATE = '' +
-    '<div id="tutorial">' +
+    '<div id="tutorial" class="notSelectable">' +
     '   <h1></h1>' +
     '   <main></main>' +
     '   <div class="prev"><img src="assets/images/prev.png" title="Previous step" /></div>' +

--- a/src/assets/style/helpers/_util.less
+++ b/src/assets/style/helpers/_util.less
@@ -2,6 +2,15 @@
     display: none !important;
 }
 
+.notSelectable {
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+}
+
 .u-float-right {
     float: right;
 }

--- a/src/templates/_airportGuide.hbs
+++ b/src/templates/_airportGuide.hbs
@@ -1,3 +1,3 @@
-<div id="airportGuide-container" class="nice-scrollbar">
+<div id="airportGuide-container" class="nice-scrollbar notSelectable">
     <div id="airportGuide-bd" class="js-airportGuide-view"></div>
 </div>

--- a/src/templates/_airportSwitch.hbs
+++ b/src/templates/_airportSwitch.hbs
@@ -1,4 +1,4 @@
-<div id="airport-switch" class="dialog">
+<div id="airport-switch" class="dialog notSelectable">
     <p class="dialog-title">Select Airport</p>
     <div class="dialog-body nice-scrollbar"></div>
 </div>

--- a/src/templates/_changelog.hbs
+++ b/src/templates/_changelog.hbs
@@ -1,4 +1,4 @@
-<div class="changelog-container js-changelogContainer nice-scrollbar">
+<div class="changelog-container js-changelogContainer nice-scrollbar notSelectable">
     <h1 class="changelog-hd">Changelog</h1>
     <h2 class="changelog-version">v{{version}}</h2>
     <p class="js-changelog blackBox"></p>

--- a/src/templates/_footer.hbs
+++ b/src/templates/_footer.hbs
@@ -111,5 +111,5 @@
             </div>
         </li>
     </ul>
-    <div id="score" title="Score">-</div>
+    <div id="score" class="notSelectable" title="Score">-</div>
 </div>


### PR DESCRIPTION
Resolves #1190

The purpose of this pull request is to re-add functionality to the `.notSelectable` class

@erikquinn thanks for your help on my last PR - I couldn't see any test cases for this, so I presume there's no need to add those for CSS, haha. If I'm missing anything please just let me know
