### PR TITLE
bugfix/1280 - remove redundant timeout-based taxi->wait mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### New Features
 
 ### Bugfixes
+- <a href="https://github.com/openscope/openscope/issues/1280" target="_blank">#1280</a> - Remove redundant timeout-based TAXI->WAITING mechanism 
 
 ### Enhancements & Refactors
 

--- a/src/assets/scripts/client/aircraft/AircraftModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftModel.js
@@ -1333,26 +1333,11 @@ export default class AircraftModel {
 
         this.taxi_start = TimeKeeper.accumulatedDeltaTime;
 
-        GameController.game_timeout(
-            this._changeFromTaxiToWaiting,
-            this.taxi_time,
-            this,
-            null
-        );
-
         const readback = {};
         readback.log = `taxi to and hold short of Runway ${runwayModel.name}`;
         readback.say = `taxi to and hold short of Runway ${radio_runway(runwayModel.name)}`;
 
         return [true, readback];
-    }
-
-    /**
-     * @for AircraftModel
-     * @method _changeFromTaxiToWaiting
-     */
-    _changeFromTaxiToWaiting() {
-        this.setFlightPhase(FLIGHT_PHASE.WAITING);
     }
 
     /**


### PR DESCRIPTION
Resolves #1280

The purpose of this pull request is to remove the redundant timeout-based taxi->wait mechanism most likely responsible for #1280. See [this comment](https://github.com/openscope/openscope/issues/1280#issuecomment-755171939) to (artificially) reproduce the bug.

Have tested these changes with traffic set for departures only up to >500 score with no issues.
