### PR TITLE
bugfix/1707 - fix various minor keyboard input bugs / UX issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Bugfixes
 - <a href="https://github.com/openscope/openscope/issues/1280" target="_blank">#1280</a> - Remove redundant timeout-based TAXI->WAITING mechanism 
 - <a href="https://github.com/openscope/openscope/issues/1705" target="_blank">#1705</a> - Re-fix range ring drawing position
+- <a href="https://github.com/openscope/openscope/issues/1707" target="_blank">#1707</a> - Fix minor keyboard input inconsistencies and correct command documentation
 
 ### Enhancements & Refactors
 - <a href="https://github.com/openscope/openscope/issues/1703" target="_blank">#1703</a> - Add more PTL ranges, some including 30sec PTLs

--- a/documentation/aircraft-commands.md
+++ b/documentation/aircraft-commands.md
@@ -103,7 +103,7 @@ _Syntax -_ `AAL123 cto`
 
 ### Taxi
 
-_Aliases -_ `taxi` / `wait` / `w`
+_Aliases -_ `taxi`, `wait`, `w`
 
 _Information -_ This command tells the specified plane to taxi to and hold short
 of the specified runway.
@@ -141,7 +141,7 @@ _Syntax -_ `AAL123 dvs` or `AAL123 dvs [alt]`
 
 ### ILS
 
-_Aliases -_ `ils` / `i` / `*`
+_Aliases -_ `ils`, `i`, `*`
 
 _Hotkey -_  `numpad *`
 
@@ -160,7 +160,7 @@ These commands allow you to manipulate the route in the aircraft's FMS.
 
 ### ~~Fix~~
 
-~~_Aliases -_ `f` / `fix` / `track`~~
+~~_Aliases -_ `f`, `fix`, `track`~~
 
 ~~_Syntax -_ `AAL123 f [fixname]`~~
 
@@ -216,7 +216,7 @@ _Syntax -_ `AAL123 continue` or `AAL123 xh BOTON`
 
 ### Proceed Direct
 
-_Aliases -_ `direct` / `pd` / `dct`
+_Aliases -_ `direct`, `pd`, `dct`
 
 _Information -_ This command instructs the aircraft to go direct to a
 navigational fix, taking a shortcut. For example, if an aircraft is flying
@@ -307,9 +307,9 @@ These commands control the three most basic ways we can control aircraft, collec
 
 ### Altitude
 
-_Aliases -_ `climb` / `c` / `descend` / `d` / `altitude` / `a`
+_Aliases -_ `climb`, `c`, `descend`, `d`, `altitude`, `a`
 
-_Hotkeys -_ `up arrow` / `down arrow` (if "Control Method" setting = "Arrow Keys")
+_Hotkeys -_ `up arrow`, `down arrow` (if "Control Method" setting = "Arrow Keys")
 
 _Information -_ This command tells the specified plane the altitude, in
 hundreds of feet (flight levels), it should travel to. This means that when
@@ -332,9 +332,9 @@ _Syntax -_ `AAL123 fph`
 
 ### Heading
 
-_Aliases -_ `heading` / `h` / `turn` / `t` / `fh`
+_Aliases -_ `heading`, `h`, `turn`, `t`, `fh`
 
-_Hotkeys -_ `left arrow` / `right arrow` (if "Control Method" setting = "Arrow Keys")
+_Hotkeys -_ `left arrow`, `right arrow` (if "Control Method" setting = "Arrow Keys")
 
 _Information -_ This command tells the aircraft the target heading to fly
 towards: up (north) is 360, right (east) is 090, down (south) is 180, and left
@@ -353,9 +353,9 @@ _Syntax -_ `AAL123 fh [hdg]` or `AAL123 (rightarrow) [hdg]` or `AAL123 t r 270` 
 
 ### Speed
 
-_Aliases -_ `speed` / `slow` / `sp` / `+` / `-`
+_Aliases -_ `speed`, `slow`, `sp`, `+`, `-`
 
-_Hotkeys -_ `numpad +` / `numpad -`
+_Hotkeys -_ `numpad +`, `numpad -`
 
 _Information -_ This command sets the target speed; aircraft will stay within
 their safe speeds if you tell them to fly faster or slower than they are able

--- a/documentation/aircraft-commands.md
+++ b/documentation/aircraft-commands.md
@@ -90,7 +90,7 @@ _Syntax -_ `AAL123 cvs` or `AAL123 cvs [alt]`
 
 ### Takeoff
 
-_Aliases -_ `takeoff`, `to`, `cto`
+_Aliases -_ `takeoff`, `to`, `cto`, `/`
 
 _Hotkey -_ `numpad /`
 

--- a/src/assets/scripts/client/InputController.js
+++ b/src/assets/scripts/client/InputController.js
@@ -537,7 +537,7 @@ export default class InputController {
                     event.preventDefault();
                     this.onCommandInputChangeHandler();
                 } else {
-                    this.selectPreviousAircraft();
+                    this.selectNextAircraft();
                     event.preventDefault();
                 }
 

--- a/src/assets/scripts/client/InputController.js
+++ b/src/assets/scripts/client/InputController.js
@@ -501,7 +501,7 @@ export default class InputController {
             // turning
             case KEY_CODES.LEFT_ARROW:
             case LEGACY_KEY_CODES.LEFT_ARROW:
-                if (this._isArrowControlMethod()) {
+                if (this._isArrowControlMethod() && this.commandBarContext === COMMAND_CONTEXT.AIRCRAFT) {
                     this.$commandInput.val(`${currentCommandInputValue} t l `);
                     event.preventDefault();
                     this.onCommandInputChangeHandler();
@@ -510,7 +510,7 @@ export default class InputController {
                 break;
             case KEY_CODES.RIGHT_ARROW:
             case LEGACY_KEY_CODES.RIGHT_ARROW:
-                if (this._isArrowControlMethod()) {
+                if (this._isArrowControlMethod() && this.commandBarContext === COMMAND_CONTEXT.AIRCRAFT) {
                     this.$commandInput.val(`${currentCommandInputValue} t r `);
                     event.preventDefault();
                     this.onCommandInputChangeHandler();
@@ -520,7 +520,7 @@ export default class InputController {
             // climb / descend
             case KEY_CODES.UP_ARROW:
             case LEGACY_KEY_CODES.UP_ARROW:
-                if (this._isArrowControlMethod()) {
+                if (this._isArrowControlMethod() && this.commandBarContext === COMMAND_CONTEXT.AIRCRAFT) {
                     this.$commandInput.val(`${currentCommandInputValue} c `);
                     event.preventDefault();
                     this.onCommandInputChangeHandler();
@@ -532,7 +532,7 @@ export default class InputController {
                 break;
             case KEY_CODES.DOWN_ARROW:
             case LEGACY_KEY_CODES.DOWN_ARROW:
-                if (this._isArrowControlMethod()) {
+                if (this._isArrowControlMethod() && this.commandBarContext === COMMAND_CONTEXT.AIRCRAFT) {
                     this.$commandInput.val(`${currentCommandInputValue} d `);
                     event.preventDefault();
                     this.onCommandInputChangeHandler();
@@ -545,31 +545,39 @@ export default class InputController {
             // takeoff / landing
             case KEY_CODES.NUM_DIVIDE:
             case LEGACY_KEY_CODES.NUM_DIVIDE:
-                this.$commandInput.val(`${currentCommandInputValue} takeoff `);
-                event.preventDefault();
-                this.onCommandInputChangeHandler();
+                if (this.commandBarContext === COMMAND_CONTEXT.AIRCRAFT) {
+                    this.$commandInput.val(`${currentCommandInputValue} takeoff `);
+                    event.preventDefault();
+                    this.onCommandInputChangeHandler();
+                }
 
                 break;
             case KEY_CODES.NUM_MULTIPLY:
             case LEGACY_KEY_CODES.NUM_MULTIPLY:
-                this.$commandInput.val(`${currentCommandInputValue} * `);
-                event.preventDefault();
-                this.onCommandInputChangeHandler();
+                if (this.commandBarContext === COMMAND_CONTEXT.AIRCRAFT) {
+                    this.$commandInput.val(`${currentCommandInputValue} * `);
+                    event.preventDefault();
+                    this.onCommandInputChangeHandler();
+                }
 
                 break;
             // speed up / slow down
             case KEY_CODES.NUM_ADD:
             case LEGACY_KEY_CODES.NUM_ADD:
-                this.$commandInput.val(`${currentCommandInputValue} + `);
-                event.preventDefault();
-                this.onCommandInputChangeHandler();
+                if (this.commandBarContext === COMMAND_CONTEXT.AIRCRAFT) {
+                    this.$commandInput.val(`${currentCommandInputValue} + `);
+                    event.preventDefault();
+                    this.onCommandInputChangeHandler();
+                }
 
                 break;
             case KEY_CODES.NUM_SUBTRACT:
             case LEGACY_KEY_CODES.NUM_SUBTRACT:
-                this.$commandInput.val(`${currentCommandInputValue} - `);
-                event.preventDefault();
-                this.onCommandInputChangeHandler();
+                if (this.commandBarContext === COMMAND_CONTEXT.AIRCRAFT) {
+                    this.$commandInput.val(`${currentCommandInputValue} - `);
+                    event.preventDefault();
+                    this.onCommandInputChangeHandler();
+                }
 
                 break;
             case KEY_CODES.F1:

--- a/src/assets/scripts/client/InputController.js
+++ b/src/assets/scripts/client/InputController.js
@@ -546,7 +546,7 @@ export default class InputController {
             case KEY_CODES.NUM_DIVIDE:
             case LEGACY_KEY_CODES.NUM_DIVIDE:
                 if (this.commandBarContext === COMMAND_CONTEXT.AIRCRAFT) {
-                    this.$commandInput.val(`${currentCommandInputValue} takeoff `);
+                    this.$commandInput.val(`${currentCommandInputValue} / `);
                     event.preventDefault();
                     this.onCommandInputChangeHandler();
                 }

--- a/src/assets/scripts/client/commands/aircraftCommand/aircraftCommandMap.js
+++ b/src/assets/scripts/client/commands/aircraftCommand/aircraftCommandMap.js
@@ -200,7 +200,7 @@ export const AIRCRAFT_COMMAND_MAP = {
         isSystemCommand: false
     },
     takeoff: {
-        aliases: ['cto', 'to', 'takeoff'],
+        aliases: ['/', 'cto', 'to', 'takeoff'],
         functionName: 'runTakeoff',
         isSystemCommand: false
     },


### PR DESCRIPTION
Resolves #1707

The purpose of this pull request is to fix these minor issues:
- down arrow for input command history navigation
- restrict aircraft command hotkeys behavior to aircraft mode, no longer affect scope mode
- make `/` an alias for `takeoff`, for user convenience and consistency
  - command documentation updated accordingly

Follow-up on #1699
While updating the aircraft command documentation I also just noticed that there was inconsistent use of both slash and comma to delimit different aliases or hotkeys for the same command. Changed to commas across the board for consistency.

