### PR TITLE
enhancement/1715 - Sync fast-forward menu button with timewarp system commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - <a href="https://github.com/openscope/openscope/issues/1280" target="_blank">#1280</a> - Remove redundant timeout-based TAXI->WAITING mechanism 
 - <a href="https://github.com/openscope/openscope/issues/1705" target="_blank">#1705</a> - Re-fix range ring drawing position
 - <a href="https://github.com/openscope/openscope/issues/1707" target="_blank">#1707</a> - Fix minor keyboard input inconsistencies and correct command documentation
+- <a href="https://github.com/openscope/openscope/issues/1716" target="_blank">#1716</a> - Prevent timewarping by negative values
 
 ### Enhancements & Refactors
 - <a href="https://github.com/openscope/openscope/issues/1703" target="_blank">#1703</a> - Add more PTL ranges, some including 30sec PTLs
@@ -13,6 +14,7 @@
 - <a href="https://github.com/openscope/openscope/issues/1692" target="_blank">#1692</a> - Remove obsolete caveats for GOATZ1 and DIRBY1 arrivals from KLAX airport guide
 - <a href="https://github.com/openscope/openscope/issues/1677" target="_blank">#1677</a> - Update Munich airport (EDDM) to AIRAC 2015
 - <a href="https://github.com/openscope/openscope/issues/1712" target="_blank">#1712</a> - Centralize z-index declarations for ease of layer management
+- <a href="https://github.com/openscope/openscope/issues/1715" target="_blank">#1715</a> - Sync fast-forward command bar button with timewarp commands
 
 
 # 6.22.0 (January 3, 2021)

--- a/documentation/aircraft-commands.md
+++ b/documentation/aircraft-commands.md
@@ -475,7 +475,9 @@ _Syntax -_ `pause`
 
 ### Timewarp
 
-_Information -_ Sets the rate at which time passes, normal is `1`. While the time warp button can only set the rate to `1`, `2`, or `5`, the command accepts any number.
+~~_Aliases -_ `tw`~~
+
+_Information -_ Sets the rate at which time passes, normal is `1`. While the time warp button can only set the rate to `1`, `2`, or `5`, the timewarp command accepts any value greater than or equal to 1.
 
 _Parameters -_ A number to multiply the rate at which time passes. `1` resets to normal time.
 

--- a/src/assets/scripts/client/commands/aircraftCommand/aircraftCommandMap.js
+++ b/src/assets/scripts/client/commands/aircraftCommand/aircraftCommandMap.js
@@ -210,7 +210,7 @@ export const AIRCRAFT_COMMAND_MAP = {
         isSystemCommand: false
     },
     timewarp: {
-        aliases: ['timewarp'],
+        aliases: ['timewarp', 'tw'],
         functionName: '',
         isSystemCommand: true
     },

--- a/src/assets/scripts/client/game/GameController.js
+++ b/src/assets/scripts/client/game/GameController.js
@@ -261,7 +261,8 @@ class GameController {
     updateTimescale(nextValue) {
         if (nextValue === 0) {
             this.game_timewarp_toggle();
-
+            return;
+        } else if (nextValue < 0) {
             return;
         }
 

--- a/src/assets/scripts/client/game/GameController.js
+++ b/src/assets/scripts/client/game/GameController.js
@@ -267,6 +267,22 @@ class GameController {
         }
 
         TimeKeeper.updateSimulationRate(nextValue);
+        EventTracker.recordEvent(TRACKABLE_EVENT.OPTIONS, 'timewarp', nextValue);
+
+        const $fastForwards = $(SELECTORS.DOM_SELECTORS.FAST_FORWARDS);
+        if (nextValue === 1) {
+            $fastForwards.removeClass(SELECTORS.CLASSNAMES.SPEED_2);
+            $fastForwards.removeClass(SELECTORS.CLASSNAMES.SPEED_5);
+            $fastForwards.prop('title', 'Set time warp to 2');
+        } else if (nextValue < 5) {
+            $fastForwards.removeClass(SELECTORS.CLASSNAMES.SPEED_5);
+            $fastForwards.addClass(SELECTORS.CLASSNAMES.SPEED_2);
+            $fastForwards.prop('title', 'Set time warp to 5');
+        } else {
+            $fastForwards.removeClass(SELECTORS.CLASSNAMES.SPEED_2);
+            $fastForwards.addClass(SELECTORS.CLASSNAMES.SPEED_5);
+            $fastForwards.prop('title', 'Reset time warp');
+        }
     }
 
     /**
@@ -279,27 +295,12 @@ class GameController {
      * @method game_timewarp_toggle
      */
     game_timewarp_toggle() {
-        const $fastForwards = $(SELECTORS.DOM_SELECTORS.FAST_FORWARDS);
-
         if (TimeKeeper.simulationRate >= 5) {
-            TimeKeeper.updateSimulationRate(1);
-            EventTracker.recordEvent(TRACKABLE_EVENT.OPTIONS, 'timewarp', '1');
-
-            $fastForwards.removeClass(SELECTORS.CLASSNAMES.SPEED_5);
-            $fastForwards.prop('title', 'Set time warp to 2');
+            this.updateTimescale(1);
         } else if (TimeKeeper.simulationRate === 1) {
-            TimeKeeper.updateSimulationRate(2);
-            EventTracker.recordEvent(TRACKABLE_EVENT.OPTIONS, 'timewarp', '2');
-
-            $fastForwards.addClass(SELECTORS.CLASSNAMES.SPEED_2);
-            $fastForwards.prop('title', 'Set time warp to 5');
+            this.updateTimescale(2);
         } else {
-            TimeKeeper.updateSimulationRate(5);
-            EventTracker.recordEvent(TRACKABLE_EVENT.OPTIONS, 'timewarp', '5');
-
-            $fastForwards.removeClass(SELECTORS.CLASSNAMES.SPEED_2);
-            $fastForwards.addClass(SELECTORS.CLASSNAMES.SPEED_5);
-            $fastForwards.prop('title', 'Reset time warp');
+            this.updateTimescale(5);
         }
     }
 

--- a/src/assets/scripts/client/game/GameController.js
+++ b/src/assets/scripts/client/game/GameController.js
@@ -270,6 +270,7 @@ class GameController {
         EventTracker.recordEvent(TRACKABLE_EVENT.OPTIONS, 'timewarp', nextValue);
 
         const $fastForwards = $(SELECTORS.DOM_SELECTORS.FAST_FORWARDS);
+
         if (nextValue === 1) {
             $fastForwards.removeClass(SELECTORS.CLASSNAMES.SPEED_2);
             $fastForwards.removeClass(SELECTORS.CLASSNAMES.SPEED_5);


### PR DESCRIPTION
Resolves #1715
Resolves #1716

The purpose of this pull request is to:

- make the fast-forward menu button synchronize with any manually issued `timewarp` system commands
- prevent attempts to travel backward in time :stuck_out_tongue_closed_eyes: 