### PR TITLE
[#1719] test parse and validate properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@
 - <a href="https://github.com/openscope/openscope/issues/1718" target="_blank">#1718</a> - Sync aircraft command map with command definitions
 - <a href="https://github.com/openscope/openscope/issues/1725" target="_blank">#1725</a> - Convert airport load list to JSON
 - <a href="https://github.com/openscope/openscope/issues/217" target="_blank">#217</a> - Differentiate projected path color for selected vs non-selected aircraft
-- <a href="https://github.com/openscope/openscope/issues/495" target="_blank">#495</a> - Scrolls strip into view when aircraft radar return double clicked
+- <a href="https://github.com/openscope/openscope/issues/495" target="_blank">#495</a> - Scroll strip into view when aircraft radar return double clicked
+- <a href="https://github.com/openscope/openscope/issues/495" target="_blank">#495</a> - Expand on command parser testing
 
 
 # 6.22.0 (January 3, 2021)

--- a/src/assets/scripts/client/commands/aircraftCommand/aircraftCommandDefinitions.js
+++ b/src/assets/scripts/client/commands/aircraftCommand/aircraftCommandDefinitions.js
@@ -28,7 +28,8 @@ import {
     holdParser,
     timewarpParser,
     optionalAltitudeParser,
-    crossingParser, ilsParser
+    crossingParser,
+    ilsParser
 } from '../parsers/argumentParsers';
 
 /**

--- a/src/assets/scripts/client/commands/aircraftCommand/aircraftCommandDefinitions.js
+++ b/src/assets/scripts/client/commands/aircraftCommand/aircraftCommandDefinitions.js
@@ -48,7 +48,6 @@ export const noop = (args) => args;
 /**
  * Call `convertStringToNumber` and store the result in an array
  *
-
  * @function strToNumArray
  * @param args {*}
  */

--- a/src/assets/scripts/client/commands/aircraftCommand/aircraftCommandDefinitions.js
+++ b/src/assets/scripts/client/commands/aircraftCommand/aircraftCommandDefinitions.js
@@ -28,7 +28,7 @@ import {
     holdParser,
     timewarpParser,
     optionalAltitudeParser,
-    crossingParser
+    crossingParser, ilsParser
 } from '../parsers/argumentParsers';
 
 /**
@@ -42,7 +42,17 @@ import {
  * @param args {*}
  * @return {*}
  */
-const noop = (args) => args;
+export const noop = (args) => args;
+
+
+/**
+ * Call `convertStringToNumber` and store the result in an array
+ *
+
+ * @function strToNumArray
+ * @param args {*}
+ */
+export const strToNumArray = (args) => [convertStringToNumber(args)];
 
 /**
  * System and Aircraft command definitions that accept zero arguments
@@ -149,8 +159,7 @@ const SINGLE_ARG_AIRCRAFT_COMMANDS = {
     },
     ils: {
         validate: singleArgumentValidator,
-        // TODO: split this out to custom parser once the null value is defined
-        parse: (args) => [null, args[0]]
+        parse: ilsParser
     },
     land: {
         validate: zeroOrOneArgumentValidator,
@@ -164,7 +173,7 @@ const SINGLE_ARG_AIRCRAFT_COMMANDS = {
         validate: singleArgumentValidator,
         // calling method is expecting an array with values that will get spread later, thus we purposly
         // return an array here
-        parse: (args) => [convertStringToNumber(args)]
+        parse: strToNumArray
     },
     reroute: {
         validate: singleArgumentValidator,
@@ -182,7 +191,7 @@ const SINGLE_ARG_AIRCRAFT_COMMANDS = {
         validate: singleArgumentValidator,
         // calling method is expecting an array with values that will get spread later, thus we purposly
         // return an array here
-        parse: (arg) => [convertStringToNumber(arg)]
+        parse: strToNumArray
     },
     star: {
         validate: singleArgumentValidator,

--- a/src/assets/scripts/client/commands/parsers/argumentParsers.js
+++ b/src/assets/scripts/client/commands/parsers/argumentParsers.js
@@ -24,6 +24,15 @@ const HOLD_COMMAND_ARG_NAMES = {
 };
 
 /**
+ * Parses the the runway of an ils command.
+ *
+ * @function ilsParser
+ * @param args {array}
+ */
+// TODO: define the second value
+export const ilsParser = (args) => [null, args[0]];
+
+/**
  * Converts a flight level altitude to a number in thousands and converts second arg to a boolean
  *
  * @function altitudeParser
@@ -237,9 +246,11 @@ export const crossingParser = (args = []) => {
     // Set i to 1 to skip fixName
     for (let i = 1; i < args.length; i++) {
         if (args[i][0].toLowerCase() === 'a') {
-            altitude = convertToThousands(args[i].toString().substr(1));
+            altitude = convertToThousands(args[i].toString()
+                .substr(1));
         } else if (args[i][0].toLowerCase() === 's') {
-            speed = convertStringToNumber(args[i].toString().substr(1));
+            speed = convertStringToNumber(args[i].toString()
+                .substr(1));
         }
     }
 

--- a/test/commands/definitions/aircraftCommandMap.spec.js
+++ b/test/commands/definitions/aircraftCommandMap.spec.js
@@ -1,0 +1,221 @@
+import ava from 'ava';
+import AircraftCommandModel
+    from '../../../src/assets/scripts/client/commands/aircraftCommand/AircraftCommandModel';
+
+import {
+    altitudeValidator,
+    crossingValidator,
+    fixValidator,
+    headingValidator,
+    holdValidator,
+    squawkValidator,
+    optionalAltitudeValidator
+} from '../../../src/assets/scripts/client/commands/parsers/argumentValidators';
+import {
+    altitudeParser,
+    ilsParser,
+    crossingParser,
+    headingParser,
+    holdParser,
+    optionalAltitudeParser
+} from '../../../src/assets/scripts/client/commands/parsers/argumentParsers';
+import { AIRCRAFT_COMMAND_MAP } from '../../../src/assets/scripts/client/commands/aircraftCommand/aircraftCommandMap';
+
+import { noopParse, zeroArgVal, singleArgVal, strToNumArrayParse, zeroOrOneArgumentVal } from './testUtils';
+
+const extractParseAndValidate = (t, cmd) => {
+    const model = new AircraftCommandModel(cmd);
+    const parse = model._commandDefinition.parse.toString();
+    const validate = model._commandDefinition.validate.toString();
+    t.false(AIRCRAFT_COMMAND_MAP[cmd].isSystemCommand);
+    return [parse, validate];
+};
+
+ava('noop parser and zeroArgumentsValidator used by abort', t => {
+    const [parse, validate] = extractParseAndValidate(t, 'abort');
+    t.true(parse === noopParse() && validate === zeroArgVal());
+});
+
+ava('noop parser and zeroArgumentsValidator used by clearedAsFiled', t => {
+    const [parse, validate] = extractParseAndValidate(t, 'clearedAsFiled');
+    t.true(parse === noopParse() && validate === zeroArgVal());
+});
+
+
+ava('noop parser and zeroArgumentsValidator used by debug', t => {
+    const [parse, validate] = extractParseAndValidate(t, 'debug');
+    t.true(parse === noopParse() && validate === zeroArgVal());
+});
+
+ava('noop parser and zeroArgumentsValidator used by delete', t => {
+    const [parse, validate] = extractParseAndValidate(t, 'delete');
+    t.true(parse === noopParse() && validate === zeroArgVal());
+});
+
+ava('noop parser and zeroArgumentsValidator used by flyPresentHeading', t => {
+    const [parse, validate] = extractParseAndValidate(t, 'flyPresentHeading');
+    t.true(parse === noopParse() && validate === zeroArgVal());
+});
+
+ava('noop parser and zeroArgumentsValidator used by takeoff', t => {
+    const [parse, validate] = extractParseAndValidate(t, 'takeoff');
+    t.true(parse === noopParse() && validate === zeroArgVal());
+});
+
+ava('noop parser and zeroArgumentsValidator used by sayAltitude', t => {
+    const [parse, validate] = extractParseAndValidate(t, 'sayAltitude');
+    t.true(parse === noopParse() && validate === zeroArgVal());
+});
+
+ava('noop parser and zeroArgumentsValidator used by sayAssignedAltitude', t => {
+    const [parse, validate] = extractParseAndValidate(t, 'sayAssignedAltitude');
+    t.true(parse === noopParse() && validate === zeroArgVal());
+});
+
+ava('noop parser and zeroArgumentsValidator used by sayHeading', t => {
+    const [parse, validate] = extractParseAndValidate(t, 'sayHeading');
+    t.true(parse === noopParse() && validate === zeroArgVal());
+});
+
+ava('noop parser and zeroArgumentsValidator used by sayAssignedHeading', t => {
+    const [parse, validate] = extractParseAndValidate(t, 'sayAssignedHeading');
+    t.true(parse === noopParse() && validate === zeroArgVal());
+});
+
+ava('noop parser and zeroArgumentsValidator used by sayIndicatedAirspeed', t => {
+    const [parse, validate] = extractParseAndValidate(t, 'sayIndicatedAirspeed');
+    t.true(parse === noopParse() && validate === zeroArgVal());
+});
+
+ava('noop parser and zeroArgumentsValidator used by sayAssignedSpeed', t => {
+    const [parse, validate] = extractParseAndValidate(t, 'sayAssignedSpeed');
+    t.true(parse === noopParse() && validate === zeroArgVal());
+});
+
+ava('noop parser and zeroArgumentsValidator used by sayRoute', t => {
+    const [parse, validate] = extractParseAndValidate(t, 'sayRoute');
+    t.true(parse === noopParse() && validate === zeroArgVal());
+});
+
+ava('strToNumArray parser and singleArgumentValidator used by `', t => {
+    const [parse, validate] = extractParseAndValidate(t, '`');
+    t.true(parse === strToNumArrayParse() && validate === singleArgVal());
+});
+
+
+ava('noop parser and singleArgumentValidator used by direct', t => {
+    const [parse, validate] = extractParseAndValidate(t, 'direct');
+    t.true(parse === noopParse() && validate === singleArgVal());
+});
+
+ava('noop parser and singleArgumentValidator used by expectArrivalRunway', t => {
+    const [parse, validate] = extractParseAndValidate(t, 'expectArrivalRunway');
+    t.true(parse === noopParse() && validate === singleArgVal());
+});
+
+ava('ilsParser and singleArgumentValidator used by ils', t => {
+    const [parse, validate] = extractParseAndValidate(t, 'ils');
+    const tmp = ilsParser;
+    t.true(parse === tmp.toString() && validate === singleArgVal());
+});
+
+ava('noop parser and zeroOrOneArgumentValidator used by land', t => {
+    const [parse, validate] = extractParseAndValidate(t, 'land');
+    t.true(parse === noopParse() && validate === zeroOrOneArgumentVal());
+});
+
+ava('noop parser and singleArgumentValidator used by moveDataBlock', t => {
+    const [parse, validate] = extractParseAndValidate(t, 'moveDataBlock');
+    t.true(parse === noopParse() && validate === singleArgVal());
+});
+
+
+ava('noop parser and singleArgumentValidator used by reroute', t => {
+    const [parse, validate] = extractParseAndValidate(t, 'reroute');
+    t.true(parse === noopParse() && validate === singleArgVal());
+});
+
+ava('noop parser and singleArgumentValidator used by route', t => {
+    const [parse, validate] = extractParseAndValidate(t, 'route');
+    t.true(parse === noopParse() && validate === singleArgVal());
+});
+
+ava('noop parser and singleArgumentValidator used by sid', t => {
+    const [parse, validate] = extractParseAndValidate(t, 'sid');
+    t.true(parse === noopParse() && validate === singleArgVal());
+});
+
+ava('strToNumArray parser and singleArgumentValidator used by speed', t => {
+    const [parse, validate] = extractParseAndValidate(t, 'speed');
+    t.true(parse === strToNumArrayParse() && validate === singleArgVal());
+});
+
+ava('noop parser and singleArgumentValidator used by star', t => {
+    const [parse, validate] = extractParseAndValidate(t, 'star');
+    t.true(parse === noopParse() && validate === singleArgVal());
+});
+
+ava('noop parser and zeroOrOneArgumentValidator used by taxi', t => {
+    const [parse, validate] = extractParseAndValidate(t, 'taxi');
+    t.true(parse === noopParse() && validate === zeroOrOneArgumentVal());
+});
+
+ava('noop parser and zeroOrOneArgumentValidator used by cancelHold', t => {
+    const [parse, validate] = extractParseAndValidate(t, 'cancelHold');
+    t.true(parse === noopParse() && validate === zeroOrOneArgumentVal());
+});
+
+ava('altitude parser and altitude validator used by altitude', t => {
+    const [parse, validate] = extractParseAndValidate(t, 'altitude');
+    const p = altitudeParser;
+    const v = altitudeValidator;
+    t.true(parse === p.toString() && validate === v.toString());
+});
+
+ava('crossing parser and crossing validator used by cross', t => {
+    const [parse, validate] = extractParseAndValidate(t, 'cross');
+    const p = crossingParser;
+    const v = crossingValidator;
+    t.true(parse === p.toString() && validate === v.toString());
+});
+
+ava('noop parser and fix validator used by fix', t => {
+    const [parse, validate] = extractParseAndValidate(t, 'fix');
+    const v = fixValidator;
+    t.true(parse === noopParse() && validate === v.toString());
+});
+
+ava('heading parser and heading validator used by heading', t => {
+    const [parse, validate] = extractParseAndValidate(t, 'heading');
+    const p = headingParser;
+    const v = headingValidator;
+    t.true(parse === p.toString() && validate === v.toString());
+});
+
+ava('hold parser and hold validator used by hold', t => {
+    const [parse, validate] = extractParseAndValidate(t, 'hold');
+    const p = holdParser;
+    const v = holdValidator;
+    t.true(parse === p.toString() && validate === v.toString());
+});
+
+ava('noop parser and squawk validator used by squawk', t => {
+    const [parse, validate] = extractParseAndValidate(t, 'squawk');
+    const v = squawkValidator;
+    t.true(parse === noopParse() && validate === v.toString());
+});
+
+
+ava('optionalAltitudeParser and optionalAltitudeValidator used by descendViaStar', t => {
+    const [parse, validate] = extractParseAndValidate(t, 'descendViaStar');
+    const p = optionalAltitudeParser;
+    const v = optionalAltitudeValidator;
+    t.true(parse === p.toString() && validate === v.toString());
+});
+
+ava('optionalAltitudeParser and optionalAltitudeValidator used by climbViaSid', t => {
+    const [parse, validate] = extractParseAndValidate(t, 'climbViaSid');
+    const p = optionalAltitudeParser;
+    const v = optionalAltitudeValidator;
+    t.true(parse === p.toString() && validate === v.toString());
+});

--- a/test/commands/definitions/aircraftCommandMap.spec.js
+++ b/test/commands/definitions/aircraftCommandMap.spec.js
@@ -43,12 +43,6 @@ ava('noop parser and zeroArgumentsValidator used by clearedAsFiled', t => {
     t.true(parse === noopParse() && validate === zeroArgVal());
 });
 
-
-ava('noop parser and zeroArgumentsValidator used by debug', t => {
-    const [parse, validate] = extractParseAndValidate(t, 'debug');
-    t.true(parse === noopParse() && validate === zeroArgVal());
-});
-
 ava('noop parser and zeroArgumentsValidator used by delete', t => {
     const [parse, validate] = extractParseAndValidate(t, 'delete');
     t.true(parse === noopParse() && validate === zeroArgVal());
@@ -98,12 +92,6 @@ ava('noop parser and zeroArgumentsValidator used by sayRoute', t => {
     const [parse, validate] = extractParseAndValidate(t, 'sayRoute');
     t.true(parse === noopParse() && validate === zeroArgVal());
 });
-
-ava('strToNumArray parser and singleArgumentValidator used by `', t => {
-    const [parse, validate] = extractParseAndValidate(t, '`');
-    t.true(parse === strToNumArrayParse() && validate === singleArgVal());
-});
-
 
 ava('noop parser and singleArgumentValidator used by direct', t => {
     const [parse, validate] = extractParseAndValidate(t, 'direct');

--- a/test/commands/definitions/aircraftCommandMap.spec.js
+++ b/test/commands/definitions/aircraftCommandMap.spec.js
@@ -21,7 +21,9 @@ import {
 } from '../../../src/assets/scripts/client/commands/parsers/argumentParsers';
 import { AIRCRAFT_COMMAND_MAP } from '../../../src/assets/scripts/client/commands/aircraftCommand/aircraftCommandMap';
 
-import { noopParse, zeroArgVal, singleArgVal, strToNumArrayParse, zeroOrOneArgumentVal } from './testUtils';
+import {
+    noopParse, zeroArgVal, singleArgVal, strToNumArrayParse, zeroOrOneArgumentVal
+} from './testUtils';
 
 const extractParseAndValidate = (t, cmd) => {
     const model = new AircraftCommandModel(cmd);

--- a/test/commands/definitions/systemCommandMap.spec.js
+++ b/test/commands/definitions/systemCommandMap.spec.js
@@ -1,0 +1,65 @@
+import ava from 'ava';
+import AircraftCommandModel
+    from '../../../src/assets/scripts/client/commands/aircraftCommand/AircraftCommandModel';
+
+import { AIRCRAFT_COMMAND_MAP } from '../../../src/assets/scripts/client/commands/aircraftCommand/aircraftCommandMap';
+import { timewarpParser } from '../../../src/assets/scripts/client/commands/parsers/argumentParsers';
+
+import {
+    noopParse, zeroArgVal, singleArgVal, strToNumArrayParse, zeroOrOneArgumentVal
+} from './testUtils';
+
+const extractParseAndValidate = (t, cmd) => {
+    const model = new AircraftCommandModel(cmd);
+    const parse = model._commandDefinition.parse.toString();
+    const validate = model._commandDefinition.validate.toString();
+    t.true(AIRCRAFT_COMMAND_MAP[cmd].isSystemCommand);
+    return [parse, validate];
+};
+
+ava('noop parser and zeroArgumentsValidator used by airac', t => {
+    const [parse, validate] = extractParseAndValidate(t, 'airac');
+    t.true(parse === noopParse() && validate === zeroArgVal());
+});
+
+ava('noop parser and singleArgumentValidator used by airport', t => {
+    const [parse, validate] = extractParseAndValidate(t, 'airport');
+    t.true(parse === noopParse() && validate === singleArgVal());
+});
+
+ava('noop parser and zeroArgumentsValidator used by auto', t => {
+    const [parse, validate] = extractParseAndValidate(t, 'auto');
+    t.true(parse === noopParse() && validate === zeroArgVal());
+});
+
+ava('noop parser and zeroArgumentsValidator used by clear', t => {
+    const [parse, validate] = extractParseAndValidate(t, 'clear');
+    t.true(parse === noopParse() && validate === zeroArgVal());
+});
+
+ava('noop parser and zeroArgumentsValidator used by pause', t => {
+    const [parse, validate] = extractParseAndValidate(t, 'pause');
+    t.true(parse === noopParse() && validate === zeroArgVal());
+});
+
+ava('noop parser and zeroArgumentsValidator used by tutorial', t => {
+    const [parse, validate] = extractParseAndValidate(t, 'tutorial');
+    t.true(parse === noopParse() && validate === zeroArgVal());
+});
+
+ava('strToNumArray parser and singleArgumentValidator used by rate', t => {
+    const [parse, validate] = extractParseAndValidate(t, 'rate');
+    t.true(parse === strToNumArrayParse() && validate === singleArgVal());
+});
+
+ava('timewarp parser and zeroOrOneArgumentValidator used by timewarp', t => {
+    const [parse, validate] = extractParseAndValidate(t, 'timewarp');
+    const p = timewarpParser;
+    const v = zeroOrOneArgumentVal();
+    t.true(parse === p.toString() && validate === v.toString());
+});
+
+ava('noop parser and zeroArgumentsValidator used by transmit', t => {
+    const [parse, validate] = extractParseAndValidate(t, 'transmit');
+    t.true(parse === noopParse() && validate === zeroArgVal());
+});

--- a/test/commands/definitions/systemCommandMap.spec.js
+++ b/test/commands/definitions/systemCommandMap.spec.js
@@ -58,8 +58,3 @@ ava('timewarp parser and zeroOrOneArgumentValidator used by timewarp', t => {
     const v = zeroOrOneArgumentVal();
     t.true(parse === p.toString() && validate === v.toString());
 });
-
-ava('noop parser and zeroArgumentsValidator used by transmit', t => {
-    const [parse, validate] = extractParseAndValidate(t, 'transmit');
-    t.true(parse === noopParse() && validate === zeroArgVal());
-});

--- a/test/commands/definitions/systemCommandMap.spec.js
+++ b/test/commands/definitions/systemCommandMap.spec.js
@@ -1,12 +1,14 @@
 import ava from 'ava';
 import AircraftCommandModel
     from '../../../src/assets/scripts/client/commands/aircraftCommand/AircraftCommandModel';
-
 import { AIRCRAFT_COMMAND_MAP } from '../../../src/assets/scripts/client/commands/aircraftCommand/aircraftCommandMap';
 import { timewarpParser } from '../../../src/assets/scripts/client/commands/parsers/argumentParsers';
-
 import {
-    noopParse, zeroArgVal, singleArgVal, strToNumArrayParse, zeroOrOneArgumentVal
+    noopParse,
+    zeroArgVal,
+    singleArgVal,
+    strToNumArrayParse,
+    zeroOrOneArgumentVal
 } from './testUtils';
 
 const extractParseAndValidate = (t, cmd) => {

--- a/test/commands/definitions/testUtils.js
+++ b/test/commands/definitions/testUtils.js
@@ -1,0 +1,30 @@
+import { noop, strToNumArray } from '../../../src/assets/scripts/client/commands/aircraftCommand/aircraftCommandDefinitions';
+import {
+    singleArgumentValidator,
+    zeroArgumentsValidator, zeroOrOneArgumentValidator
+} from '../../../src/assets/scripts/client/commands/parsers/argumentValidators';
+
+export const noopParse = () => {
+    const tmp = noop;
+    return tmp.toString();
+};
+
+export const strToNumArrayParse = () => {
+    const tmp = strToNumArray;
+    return tmp.toString();
+};
+
+export const zeroArgVal = () => {
+    const tmp = zeroArgumentsValidator;
+    return tmp.toString();
+};
+
+export const singleArgVal = () => {
+    const tmp = singleArgumentValidator;
+    return tmp.toString();
+};
+
+export const zeroOrOneArgumentVal = () => {
+    const tmp = zeroOrOneArgumentValidator;
+    return tmp.toString();
+};


### PR DESCRIPTION
Closes #1719 
Introduces tests to assert the assignments of validate and parse properties to commands.

~**Currently blocked on #1718**.~

Resolved and rebased on latest development branch