### PR TITLE
Refactor/1718 Sync aircraftCommandMap and aircraftCommandDefinitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - <a href="https://github.com/openscope/openscope/issues/1677" target="_blank">#1677</a> - Update Munich airport (EDDM) to AIRAC 2015
 - <a href="https://github.com/openscope/openscope/issues/1712" target="_blank">#1712</a> - Centralize z-index declarations for ease of layer management
 - <a href="https://github.com/openscope/openscope/issues/1715" target="_blank">#1715</a> - Sync fast-forward command bar button with timewarp commands
+- <a href="https://github.com/openscope/openscope/issues/1718" target="_blank">#1718</a> - Sync aircraft command map with command definitions
 
 
 # 6.22.0 (January 3, 2021)

--- a/src/assets/scripts/client/commands/aircraftCommand/aircraftCommandDefinitions.js
+++ b/src/assets/scripts/client/commands/aircraftCommand/aircraftCommandDefinitions.js
@@ -118,6 +118,10 @@ const ZERO_ARG_AIRCRAFT_COMMANDS = {
     sayAssignedSpeed: {
         validate: zeroArgumentsValidator,
         parse: noop
+    },
+    sayRoute: {
+        validate: zeroArgumentsValidator,
+        parse: noop
     }
 };
 

--- a/src/assets/scripts/client/commands/aircraftCommand/aircraftCommandDefinitions.js
+++ b/src/assets/scripts/client/commands/aircraftCommand/aircraftCommandDefinitions.js
@@ -83,10 +83,6 @@ const ZERO_ARG_AIRCRAFT_COMMANDS = {
         validate: zeroArgumentsValidator,
         parse: noop
     },
-    debug: {
-        validate: zeroArgumentsValidator,
-        parse: noop
-    },
     delete: {
         validate: zeroArgumentsValidator,
         parse: noop

--- a/src/assets/scripts/client/commands/aircraftCommand/aircraftCommandDefinitions.js
+++ b/src/assets/scripts/client/commands/aircraftCommand/aircraftCommandDefinitions.js
@@ -131,12 +131,6 @@ const ZERO_ARG_AIRCRAFT_COMMANDS = {
  * @final
  */
 const SINGLE_ARG_AIRCRAFT_COMMANDS = {
-    '`': {
-        validate: singleArgumentValidator,
-        // calling method is expecting an array with values that will get spread later, thus we purposly
-        // return an array here
-        parse: (args) => [convertStringToNumber(args)]
-    },
     airport: {
         validate: singleArgumentValidator,
         parse: noop

--- a/src/assets/scripts/client/commands/aircraftCommand/aircraftCommandMap.js
+++ b/src/assets/scripts/client/commands/aircraftCommand/aircraftCommandMap.js
@@ -214,11 +214,6 @@ export const AIRCRAFT_COMMAND_MAP = {
         functionName: '',
         isSystemCommand: true
     },
-    transmit: {
-        aliases: ['transmit'],
-        functionName: '',
-        isSystemCommand: true
-    },
     tutorial: {
         aliases: ['tutorial'],
         functionName: '',


### PR DESCRIPTION
Resolves #1718 

The purpose of this pull request is to sync `aircraftCommandMap` and `aircraftCommandDefinitions`.

---

Edit: sayRoute (`sr`) is not fixed by this as `AircraftCommander.runSayRoute()` is not properly implemented, but I'm going to raise an separate issue.
