### PR TITLE
enhancement/495 - double click aircraft radar return scrolls strip into view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - <a href="https://github.com/openscope/openscope/issues/1718" target="_blank">#1718</a> - Sync aircraft command map with command definitions
 - <a href="https://github.com/openscope/openscope/issues/1725" target="_blank">#1725</a> - Convert airport load list to JSON
 - <a href="https://github.com/openscope/openscope/issues/217" target="_blank">#217</a> - Differentiate projected path color for selected vs non-selected aircraft
+- <a href="https://github.com/openscope/openscope/issues/495" target="_blank">#495</a> - Scrolls strip into view when aircraft radar return double clicked
 
 
 # 6.22.0 (January 3, 2021)

--- a/src/assets/scripts/client/InputController.js
+++ b/src/assets/scripts/client/InputController.js
@@ -93,6 +93,7 @@ export default class InputController {
         this.onMouseClickAndDragHandler = this._onMouseClickAndDrag.bind(this);
         this.onMouseUpHandler = this._onMouseUp.bind(this);
         this.onMouseDownHandler = this._onMouseDown.bind(this);
+        this.onMouseDblclickHandler = this._onMouseDblclick.bind(this);
 
         return this;
     }
@@ -115,6 +116,7 @@ export default class InputController {
         this.$canvases.on('mousemove', this.onMouseClickAndDragHandler);
         this.$canvases.on('mouseup', this.onMouseUpHandler);
         this.$canvases.on('mousedown', this.onMouseDownHandler);
+        this.$canvases.on('dblclick', this.onMouseDblclickHandler);
         this.$body.addEventListener('contextmenu', (event) => event.preventDefault());
 
         // TODO: Fix this
@@ -138,6 +140,7 @@ export default class InputController {
         this.$canvases.off('mousemove', this.onMouseClickAndDragHandler);
         this.$canvases.off('mouseup', this.onMouseUpHandler);
         this.$canvases.off('mousedown', this.onMouseDownHandler);
+        this.$canvases.off('dblclick', this.onMouseDblclickHandler);
         this.$body.removeEventListener('contextmenu', event.preventDefault());
 
         this._eventBus.off(EVENT.STRIP_CLICK, this.selectAircraftByCallsign);
@@ -394,6 +397,28 @@ export default class InputController {
             default:
                 break;
         }
+    }
+
+    /**
+     * @for InputController
+     * @method _onMouseDblclick
+     * @param event {jquery Event}
+     */
+    _onMouseDblclick(event) {
+        // HACK: for "when an aircraft's radar return is double clicked"
+        // caveat: double click is series of mousedown-mouseup-mousedown-mouseup events in rapid succession
+        // there is no guarantee that pointer is stationary throughout the process!
+        // event handler is for entire canvas, not for things drawn on it; need to resolve which aircraft
+        // _onLeftMouseButtonPress identifies and selects nearest aircraft within 50px of mousedown events
+        // so we can just piggyback off the aircraft (if any) already selected by the second mousedown
+        if (!this.input.callsign) {
+            return;
+        }
+
+        this._eventBus.trigger(
+            EVENT.SCROLL_TO_AIRCRAFT,
+            this._aircraftController.findAircraftByCallsign(this.input.callsign)
+        );
     }
 
     /**

--- a/src/assets/scripts/client/InputController.js
+++ b/src/assets/scripts/client/InputController.js
@@ -1103,14 +1103,15 @@ export default class InputController {
      */
     _markMousePressed(event, mouseButton) {
         const canvasDragButton = GameController.getGameOption(GAME_OPTION_NAMES.MOUSE_CLICK_DRAG);
-        const mousePositionX = event.pageX - CanvasStageModel._panX;
-        const mousePositionY = event.pageY - CanvasStageModel._panY;
 
         // The mouse button that's been pressed isn't the one
         // that drags the canvas, so we return.
         if (mouseButton !== canvasDragButton) {
             return;
         }
+
+        const mousePositionX = event.pageX - CanvasStageModel._panX;
+        const mousePositionY = event.pageY - CanvasStageModel._panY;
 
         // Record mouse down position for panning
         this._mouseDownScreenPosition = [

--- a/src/assets/scripts/client/aircraft/AircraftController.js
+++ b/src/assets/scripts/client/aircraft/AircraftController.js
@@ -156,7 +156,7 @@ export default class AircraftController {
     enable() {
         this._eventBus.on(EVENT.ADD_AIRCRAFT, this.addItem);
         this._eventBus.on(EVENT.STRIP_DOUBLE_CLICK, this._onStripDoubleClickHandler);
-        this._eventBus.on(EVENT.SELECT_AIRCRAFT, this.onSelectAircraft);
+        this._eventBus.on(EVENT.SELECT_AIRCRAFT, this._onSelectAircraft);
         this._eventBus.on(EVENT.DESELECT_AIRCRAFT, this._onDeselectAircraft);
         this._eventBus.on(EVENT.SCROLL_TO_AIRCRAFT, this._onScrollToAircraft);
         this._eventBus.on(EVENT.REMOVE_AIRCRAFT, this._onRemoveAircraftHandler);
@@ -393,17 +393,6 @@ export default class AircraftController {
      */
     updateAircraftStrips() {
         this._stripViewController.update(this.aircraft.list);
-    }
-
-    /**
-     * Public facade for `._onSelectAircraft`
-     *
-     * @for AircraftController
-     * @method onSelectAircraft
-     * @param aircaftModel {AircraftModel}
-     */
-    onSelectAircraft = (aircraftModel) => {
-        this._onSelectAircraft(aircraftModel);
     }
 
     /**

--- a/src/assets/scripts/client/aircraft/AircraftController.js
+++ b/src/assets/scripts/client/aircraft/AircraftController.js
@@ -158,6 +158,7 @@ export default class AircraftController {
         this._eventBus.on(EVENT.STRIP_DOUBLE_CLICK, this._onStripDoubleClickHandler);
         this._eventBus.on(EVENT.SELECT_AIRCRAFT, this.onSelectAircraft);
         this._eventBus.on(EVENT.DESELECT_AIRCRAFT, this._onDeselectAircraft);
+        this._eventBus.on(EVENT.SCROLL_TO_AIRCRAFT, this._onScrollToAircraft);
         this._eventBus.on(EVENT.REMOVE_AIRCRAFT, this._onRemoveAircraftHandler);
         this._eventBus.on(EVENT.REMOVE_AIRCRAFT_CONFLICT, this.removeConflict);
 
@@ -174,6 +175,7 @@ export default class AircraftController {
         this._eventBus.off(EVENT.STRIP_DOUBLE_CLICK, this._onStripDoubleClickHandler);
         this._eventBus.off(EVENT.SELECT_AIRCRAFT, this._onSelectAircraft);
         this._eventBus.off(EVENT.DESELECT_AIRCRAFT, this._onDeselectAircraft);
+        this._eventBus.off(EVENT.SCROLL_TO_AIRCRAFT, this._onScrollToAircraft);
         this._eventBus.off(EVENT.REMOVE_AIRCRAFT, this._onRemoveAircraftHandler);
         this._eventBus.off(EVENT.REMOVE_AIRCRAFT_CONFLICT, this.removeConflict);
 
@@ -715,6 +717,22 @@ export default class AircraftController {
      */
     _onDeselectAircraft = () => {
         this._stripViewController.findAndDeselectActiveStripView();
+    };
+
+    /**
+     * Scroll a `StripViewModel` into view
+     *
+     * @for AircraftController
+     * @method _onScrollToAircraft
+     * @param  aircraftModel {AircraftModel}
+     * @private
+     */
+    _onScrollToAircraft = (aircraftModel) => {
+        if (!aircraftModel.isControllable) {
+            return;
+        }
+
+        this._stripViewController.scrollToStripView(aircraftModel);
     };
 
     /**

--- a/src/assets/scripts/client/aircraft/StripView/StripViewController.js
+++ b/src/assets/scripts/client/aircraft/StripView/StripViewController.js
@@ -221,6 +221,23 @@ export default class StripViewController {
     }
 
     /**
+     * Find a `StripViewModel` and scroll it into view
+     *
+     * @for StripViewController
+     * @method scrollToStripView
+     * @param  aircraftModel {AircraftModel}
+     */
+    scrollToStripView(aircraftModel) {
+        const stripModel = this._collection.findStripByAircraftId(aircraftModel.id);
+
+        if (!stripModel) {
+            throw Error(`No StripViewModel found for selected Aircraft: ${aircraftModel.callsign}`);
+        }
+
+        stripModel.scrollIntoView();
+    }
+
+    /**
      * Method used to deselect an active `StripViewModel` when
      * the specific model is not known.
      *

--- a/src/assets/scripts/client/aircraft/StripView/StripViewModel.js
+++ b/src/assets/scripts/client/aircraft/StripView/StripViewModel.js
@@ -616,6 +616,16 @@ export default class StripViewModel extends BaseModel {
     }
 
     /**
+     * Scroll into view
+     *
+     * @for StripViewModel
+     * @method scrollIntoView
+     */
+    scrollIntoView() {
+        this.$element[0].scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+
+    /**
      * Return a classname based on whether an aircraft is a `departure` or an `arrival`
      *
      * @for AircraftStripView

--- a/src/assets/scripts/client/constants/eventNames.js
+++ b/src/assets/scripts/client/constants/eventNames.js
@@ -130,7 +130,7 @@ export const EVENT = {
     SCROLL_TO_AIRCRAFT: 'scroll-to-aircraft',
 
     /**
-     * An aircraft data block was clicked and the corresponding
+     * An aircraft radar return was clicked and the corresponding
      * `StripViewModel` must also be selected
      *
      * @memberof EVENT

--- a/src/assets/scripts/client/constants/eventNames.js
+++ b/src/assets/scripts/client/constants/eventNames.js
@@ -120,6 +120,16 @@ export const EVENT = {
     REQUEST_TO_CENTER_POINT_IN_VIEW: 'request-to-center-point-in-view',
 
     /**
+     * An aircraft radar return was double clicked and the corresponding
+     * `StripViewModel` must be scrolled into view
+     *
+     * @memberof EVENT
+     * @property SCROLL_TO_AIRCRAFT
+     * @type {string}
+     */
+    SCROLL_TO_AIRCRAFT: 'scroll-to-aircraft',
+
+    /**
      * An aircraft data block was clicked and the corresponding
      * `StripViewModel` must also be selected
      *


### PR DESCRIPTION
Resolves #495

The purpose of this pull request is so that when the radar return of an aircraft on the scope is double clicked, if its corresponding strip is not visible, the the strip view will scroll automatically until the strip is in view.

[`scrollintoview()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView) with object parameter is used [here](https://github.com/openscope/openscope/blob/0ffbbad26bdbb1ad6117568be15546e8d6cd5452/src/assets/scripts/client/aircraft/StripView/StripViewModel.js#L625). May need to consider browser compatibility, see: [caniuse](https://caniuse.com/scrollintoview).

Re: the options set by the parameter, `behavior: 'smooth'` is merely cosmetic, but `block: 'nearest'` is necessary for correct functioning. Without it, behavior defaults to equivalent of `{block: "start", inline: "nearest"}` and has been observed to shunt the entire app UI vertically in the browser window, leaving a horizontal strip of unoccupied white background.

Small amount of unrelated opportunistic code gardening and optimization was done in the affected files.