### PR TITLE
bugfix/1744 - Fix validation for "X needs to be a non-empty object"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - <a href="https://github.com/openscope/openscope/issues/1705" target="_blank">#1705</a> - Re-fix range ring drawing position
 - <a href="https://github.com/openscope/openscope/issues/1707" target="_blank">#1707</a> - Fix minor keyboard input inconsistencies and correct command documentation
 - <a href="https://github.com/openscope/openscope/issues/1716" target="_blank">#1716</a> - Prevent timewarping by negative values
+- <a href="https://github.com/openscope/openscope/issues/1744" target="_blank">#1744</a> - Fix validation helper method for preventing non-empty objects
 
 ### Enhancements & Refactors
 - <a href="https://github.com/openscope/openscope/issues/1703" target="_blank">#1703</a> - Add more PTL ranges, some including 30sec PTLs

--- a/src/assets/scripts/client/aircraft/AircraftTypeDefinitionModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftTypeDefinitionModel.js
@@ -1,6 +1,6 @@
 import BaseModel from '../base/BaseModel';
 import { INVALID_NUMBER } from '../constants/globalConstants';
-import { isEmptyObject } from '../utilities/validatorUtilities';
+import { isEmptyOrNotObject } from '../utilities/validatorUtilities';
 import { AIRPORT_CONSTANTS } from '../constants/airportConstants';
 
 // TODO: abstract these to an appropriate constants file
@@ -27,8 +27,8 @@ export default class AircraftTypeDefinitionModel extends BaseModel {
     constructor(aircraftTypeDefinition) {
         super();
 
-        if (isEmptyObject(aircraftTypeDefinition)) {
-            throw new TypeError('Invalid parameter. Expected aircraftTypeDefinition to be an object');
+        if (isEmptyOrNotObject(aircraftTypeDefinition)) {
+            throw new TypeError('Invalid parameter. Expected aircraftTypeDefinition to be a non-empty object');
         }
 
         /**

--- a/src/assets/scripts/client/airline/AirlineModel.js
+++ b/src/assets/scripts/client/airline/AirlineModel.js
@@ -9,7 +9,7 @@ import _without from 'lodash/without';
 import BaseModel from '../base/BaseModel';
 import { buildFlightNumber } from './buildFlightNumber';
 import { INVALID_INDEX } from '../constants/globalConstants';
-import { isEmptyObject } from '../utilities/validatorUtilities';
+import { isEmptyOrNotObject } from '../utilities/validatorUtilities';
 import { DEFAULT_CALLSIGN_FORMAT } from '../constants/airlineConstants';
 
 /**
@@ -31,9 +31,9 @@ export default class AirlineModel extends BaseModel {
     constructor(airlineDefinition) {
         super();
 
-        if (isEmptyObject(airlineDefinition)) {
+        if (isEmptyOrNotObject(airlineDefinition)) {
             // eslint-disable-next-line max-len
-            throw new TypeError(`Invalid airlineDefinition received by AirlineModel. Expected an object but received ${typeof airlineDefinition}`);
+            throw new TypeError(`Invalid airlineDefinition received by AirlineModel. Expected a non-empty object but received ${typeof airlineDefinition}`);
         }
 
         /**

--- a/src/assets/scripts/client/trafficGenerator/SpawnPatternCollection.js
+++ b/src/assets/scripts/client/trafficGenerator/SpawnPatternCollection.js
@@ -6,7 +6,7 @@ import BaseCollection from '../base/BaseCollection';
 import SpawnPatternModel from './SpawnPatternModel';
 import { FLIGHT_CATEGORY } from '../constants/aircraftConstants';
 import { TIME } from '../constants/globalConstants';
-import { isEmptyObject } from '../utilities/validatorUtilities';
+import { isEmptyOrNotObject } from '../utilities/validatorUtilities';
 
 /**
  * A collection of `SpawnPatternModel` objects
@@ -47,7 +47,7 @@ class SpawnPatternCollection extends BaseCollection {
      * @param airportJson {object}
      */
     init(airportJson) {
-        if (typeof airportJson === 'undefined' || isEmptyObject(airportJson)) {
+        if (isEmptyOrNotObject(airportJson)) {
             throw new TypeError('Invalid airportJson passed to SpawnPatternCollection');
         }
 
@@ -158,10 +158,6 @@ class SpawnPatternCollection extends BaseCollection {
     _buildSpawnPatternModels(spawnPatterns) {
         _forEach(spawnPatterns, (spawnPattern) => {
             const spawnPatternModel = new SpawnPatternModel(spawnPattern);
-            // const spawnPatternModel = ModelSourceFactory.getModelSourceForType(
-            //     'SpawnPatternModel',
-            //     spawnPattern
-            // );
 
             this.addItem(spawnPatternModel);
         });

--- a/src/assets/scripts/client/trafficGenerator/buildPreSpawnAircraft.js
+++ b/src/assets/scripts/client/trafficGenerator/buildPreSpawnAircraft.js
@@ -7,7 +7,7 @@ import _without from 'lodash/without';
 import RouteModel from '../aircraft/FlightManagementSystem/RouteModel';
 import { TIME } from '../constants/globalConstants';
 import { nm } from '../utilities/unitConverters';
-import { isEmptyObject } from '../utilities/validatorUtilities';
+import { isEmptyOrNotObject } from '../utilities/validatorUtilities';
 import { distance2d } from '../math/distance';
 
 /**
@@ -378,8 +378,9 @@ const _preSpawn = (spawnPatternJson, airport) => {
  * @return {array<object>}
  */
 export const buildPreSpawnAircraft = (spawnPatternJson, currentAirport) => {
-    if (isEmptyObject(spawnPatternJson)) {
-        throw new TypeError('Invalid parameter passed to buildPreSpawnAircraft. Expected spawnPatternJson to be an object');
+    if (isEmptyOrNotObject(spawnPatternJson)) {
+        // eslint-disable-next-line max-len
+        throw new TypeError('Invalid parameter passed to buildPreSpawnAircraft. Expected spawnPatternJson to be a non-empty object');
     }
 
     if (_isNil(currentAirport)) {

--- a/src/assets/scripts/client/utilities/validatorUtilities.js
+++ b/src/assets/scripts/client/utilities/validatorUtilities.js
@@ -3,9 +3,9 @@ import _isEmpty from 'lodash/isEmpty';
 import _isObject from 'lodash/isObject';
 
 /**
- * This will return true if it is not an object or it is empty
+ * This will return true if it is an object and it is empty
  *
- * @funtion isNotObjectOrIsEmpty
+ * @funtion isEmptyObject
  * @param value {*}
  * @return {boolean}
  */
@@ -27,7 +27,7 @@ export const isEmptyOrNotObject = (value) => {
 /**
  * This will return true if it is not an array or it is empty
  *
- * @funtion isNotObjectOrIsEmpty
+ * @funtion isEmptyOrNotArray
  * @param value {*}
  * @return {boolean}
  */

--- a/src/assets/scripts/client/utilities/validatorUtilities.js
+++ b/src/assets/scripts/client/utilities/validatorUtilities.js
@@ -14,6 +14,17 @@ export const isEmptyObject = (value) => {
 };
 
 /**
+ * This will return true if it is not an object or it is empty
+ *
+ * @funtion isEmptyOrNotObject
+ * @param value {*}
+ * @return {boolean}
+ */
+export const isEmptyOrNotObject = (value) => {
+    return !_isObject(value) || _isEmpty(value);
+};
+
+/**
  * This will return true if it is not an array or it is empty
  *
  * @funtion isNotObjectOrIsEmpty

--- a/test/utilities/validatorUtilities.spec.js
+++ b/test/utilities/validatorUtilities.spec.js
@@ -1,8 +1,10 @@
 /* eslint-disable arrow-parens, max-len, import/no-extraneous-dependencies*/
 import ava from 'ava';
-import { isEmptyObject,
-         isEmptyOrNotArray
- } from '../../src/assets/scripts/client/utilities/validatorUtilities';
+import {
+    isEmptyObject,
+    isEmptyOrNotObject,
+    isEmptyOrNotArray
+} from '../../src/assets/scripts/client/utilities/validatorUtilities';
 
 ava('.isEmptyObject() returns false when passed an non object', (t) => {
     t.false(isEmptyObject('threeve'));
@@ -23,6 +25,30 @@ ava('.isEmptyObject() returns false when passed an object with properties', (t) 
 ava('.isEmptyObject() returns true when passed an empty object', (t) => {
     t.true(isEmptyObject({}));
     t.true(isEmptyObject([]));
+});
+
+ava('.isEmptyOrNotObject() returns true when passed an non object', (t) => {
+    t.true(isEmptyOrNotObject('threeve'));
+    t.true(isEmptyOrNotObject(false));
+    t.true(isEmptyOrNotObject(true));
+    t.true(isEmptyOrNotObject(42));
+    t.true(isEmptyOrNotObject(undefined));
+    t.true(isEmptyOrNotObject({}));
+});
+
+ava('.isEmptyOrNotObject returns true when passed an empty object', (t) => {
+    t.true(isEmptyOrNotObject({}));
+    t.true(isEmptyOrNotObject([]));
+    t.true(isEmptyOrNotObject(null));
+});
+
+ava('.isEmptyOrNotObject() returns false when passed a non-empty object', (t) => {
+    t.false(isEmptyOrNotObject([1, 2, 3]));
+    t.false(isEmptyOrNotObject({
+        a: 'threeve',
+        b: 42,
+        c: false
+    }));
 });
 
 ava('.isEmptyOrNotArray() returns true when passed an non Array', (t) => {


### PR DESCRIPTION
Resolves #1744

The purpose of this pull request is to fix a bug in validation helper function.

Check / fix:
- [x] `src/assets/scripts/client/aircraft/AircraftTypeDefinitionModel.js`
- [x] `src/assets/scripts/client/airline/AirlineModel.js`
- [x] `src/assets/scripts/client/trafficGenerator/buildPreSpawnAircraft.js`
- [x] `src/assets/scripts/client/trafficGenerator/SpawnPatternCollection.js`

---

Limiting scope of this PR so it can be expeditiously merged to quick fix broken tests.

For a future follow-up issue (#1749):

- check all validation (`throws new TypeError`) for potential problems
- make tests more robust: require match to specific error message
  - consider possibly making error messages reside in a common constants file or helper class,
    to be shared by both `src` file and corresponding `test` spec
  - tests in `classname.spec.js` should be confined to throws in `classname.js`
    (from a preliminary look, exceptions currently exist)
