### PR TITLE
bugfix/1690 - Clear log upon airport changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - <a href="https://github.com/openscope/openscope/issues/1707" target="_blank">#1707</a> - Fix minor keyboard input inconsistencies and correct command documentation
 - <a href="https://github.com/openscope/openscope/issues/1716" target="_blank">#1716</a> - Prevent timewarping by negative values
 - <a href="https://github.com/openscope/openscope/issues/1744" target="_blank">#1744</a> - Fix validation helper method for preventing non-empty objects
+- <a href="https://github.com/openscope/openscope/issues/1690" target="_blank">#1690</a> - Clear log on airport change
 
 ### Enhancements & Refactors
 - <a href="https://github.com/openscope/openscope/issues/1703" target="_blank">#1703</a> - Add more PTL ranges, some including 30sec PTLs

--- a/src/assets/scripts/client/ui/UiController.js
+++ b/src/assets/scripts/client/ui/UiController.js
@@ -358,6 +358,8 @@ class UiController {
      * @chainable
      */
     setupHandlers() {
+        this.onAirportChangeHandler = this.onAirportChange.bind(this);
+
         return this;
     }
 
@@ -370,6 +372,8 @@ class UiController {
      * @method enable
      */
     enable() {
+        this._eventBus.on(EVENT.AIRPORT_CHANGE, this.onAirportChangeHandler);
+
         // TODO: move these to properly bound handler methods
         this.$fastForwards.on('click', (event) => GameController.game_timewarp_toggle(event));
         this.$githubLinkElement.on('click', (event) => this.onClickGithubLink(event));
@@ -400,6 +404,8 @@ class UiController {
      * @method disable
      */
     disable() {
+        this._eventBus.off(EVENT.AIRPORT_CHANGE, this.onAirportChangeHandler);
+
         this.$fastForwards.off('click', (event) => GameController.game_timewarp_toggle(event));
         this.$githubLinkElement.off('click', (event) => this.onClickGithubLink(event));
         this.$pausedImg.off('click', (event) => GameController.game_unpause(event));
@@ -502,6 +508,14 @@ class UiController {
                 uiLogView.remove();
             }, 10000);
         }, 3, window, html);
+    }
+
+    /**
+     * @for UiController
+     * @method onAirportChange
+     */
+    onAirportChange() {
+        this.$log.empty();
     }
 
     /**


### PR DESCRIPTION
Resolves #1690

The purpose of this pull request is to clear the log upon the airport being changed (or reloaded the same one).

This prevents log lines for the previous airport from getting stuck and never removed.

This also immediately clears log lines that would not have gotten stuck, but are still in the midst of their fadeout
 -- also desirable, there is no point leaving them on screen for up to another 10s, they are no longer relevant.

### Other solutions considered

Given [the cause of the issue](https://github.com/openscope/openscope/issues/1690#issuecomment-770246447) one may be tempted to somehow prevent the timers governing the fadeout of stuck log lines from being purged by `GameController.destroyTimers()` call in `AppController.onAirportChange()`. 

However, considering `game.timeouts` is a utility that could be used for a variety of timers with different callbacks, it's probably not a good idea (brittle, error-prone) to try and filter through it and selectively discard some entries while preserving others.

Anyway, it is better to immediately clear the log of all lines as they are irrelevant after airport switch/reload.