### PR TITLE
documentation/1750 - Fix syntax error in airways example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - <a href="https://github.com/openscope/openscope/issues/495" target="_blank">#495</a> - Expand on command parser testing
 - <a href="https://github.com/openscope/openscope/issues/1739" target="_blank">#1739</a> - General code gardening in UiController.js
 - <a href="https://github.com/openscope/openscope/issues/1700" target="_blank">#1700</a> - Convert tutorial contents to JSON
+- <a href="https://github.com/openscope/openscope/issues/1750" target="_blank">#1750</a> - Fix syntax error in airway documentation
 
 
 # 6.22.0 (January 3, 2021)

--- a/documentation/airport-format.md
+++ b/documentation/airport-format.md
@@ -464,7 +464,7 @@ Runways are defined in pairs because a runway can be used from either direction.
     "J100": ["HEC", "CLARR", "LAS", "NORRA", "BCE"],
     "J146": ["LAS", "NOOTN"],
     "J9": ["HEC", "CLARR", "LAS", "NORRA", "AVERS", "URIAH", "BERYL",  "MLF"],
-    "J92:" ["BTY", "BLD", "KADDY", "PRFUM", "CADDU", "DRK"],
+    "J92": ["BTY", "BLD", "KADDY", "PRFUM", "CADDU", "DRK"],
     "Q15": ["CHILY", "DOVEE", "BIKKR"],
     "V8": ["PHYLI", "MMM", "MEADS", "ACLAM", "WINDS", "LYNSY", "SHUSS", "GFS", "HEC"]
 },


### PR DESCRIPTION
Resolves #1750 

The purpose of this pull request is to fix a simple syntax error in airport-format.md
