### PR TITLE
documentation/1758 - build status badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Enhancements & Refactors
 - <a href="https://github.com/openscope/openscope/issues/1752" target="_blank">#1752</a> - Install browser-env for tests, reclassify dev dependencies and remove unused dependencies
+- <a href="https://github.com/openscope/openscope/issues/1758" target="_blank">#1758</a> - Update GitHub build status badge
 
 
 # 6.23.0 (February 5, 2021)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![openScope Current Release](https://img.shields.io/github/release/openscope/openscope.svg)](https://github.com/openscope/openscope/releases)
-[![Travis Production Build State](https://img.shields.io/travis/openscope/openscope/master.svg)](https://github.com/openscope/openscope/tree/master)
+[![openScope Current Release](https://img.shields.io/github/v/release/openscope/openscope.svg)](https://github.com/openscope/openscope/releases)
+[![Production Build State](https://img.shields.io/github/workflow/status/openscope/openscope/protected-branch-checks/master.svg)](https://github.com/openscope/openscope/tree/master)
 [![Coverage Status](https://coveralls.io/repos/github/openscope/openscope/badge.svg?branch=develop)](https://coveralls.io/github/openscope/openscope?branch=develop)
 [![Slack Status](http://slack.openscope.io/badge.svg)](http://slack.openscope.io)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE.md)


### PR DESCRIPTION
Resolves #1758

The purpose of this pull request is to update the build status badge on `README.md` to get status from github workflow rather than travis ci (defunct)
