### PR TITLE
bugfix/1762 - defensive coding in Fms initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - <a href="https://github.com/openscope/openscope/issues/1756" target="_blank">#1756</a> - Add Contour Airlines (VTE)
 
 ### Bugfixes
-- <a href="https://github.com/openscope/openscope/issues/1762" target="_blank">#1762</a> - FMS initialization based on aircraft category, validates for current airport
+- <a href="https://github.com/openscope/openscope/issues/1762" target="_blank">#1762</a> - FMS initialization checks against current airport
 
 ### Enhancements & Refactors
 - <a href="https://github.com/openscope/openscope/issues/1752" target="_blank">#1752</a> - Install browser-env for tests, reclassify dev dependencies and remove unused dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - <a href="https://github.com/openscope/openscope/issues/1756" target="_blank">#1756</a> - Add Contour Airlines (VTE)
 
 ### Bugfixes
+- <a href="https://github.com/openscope/openscope/issues/1762" target="_blank">#1762</a> - FMS initialization based on aircraft category, validates for current airport
 
 ### Enhancements & Refactors
 - <a href="https://github.com/openscope/openscope/issues/1752" target="_blank">#1752</a> - Install browser-env for tests, reclassify dev dependencies and remove unused dependencies

--- a/src/assets/scripts/client/aircraft/FlightManagementSystem/Fms.js
+++ b/src/assets/scripts/client/aircraft/FlightManagementSystem/Fms.js
@@ -271,9 +271,7 @@ export default class Fms {
 
         this._verifyRouteContainsMultipleWaypoints();
         this._initializeFlightPhaseForCategory(category);
-
-        this._initializeAirportsAndRunways(category, origin, destination);
-
+        this._initializeAirportsAndRunways(origin, destination);
         this._initializeFlightPlanAltitude(altitude, category, model);
         this._initializePositionInRouteToBeginAtFixName(nextFix, category);
 
@@ -305,18 +303,20 @@ export default class Fms {
      *
      * @for Fms
      * @method _initializeAirportsAndRunways
-     * @param category {string} Flight category (arrival, departure, or overflight)
      * @param origin {string} ICAO identifier specified by spawn pattern
      * @param destination {string} ICAO identifier specified by spawn pattern
      * @private
      */
-    _initializeAirportsAndRunways(category, origin, destination) {
-        if (category === FLIGHT_CATEGORY.DEPARTURE) {
+    _initializeAirportsAndRunways(origin, destination) {
+        const originLowerCase = origin.toLowerCase();
+        const destinationLowerCase = destination.toLowerCase();
+
+        if (originLowerCase === AirportController.current.icao) {
             this._initializeDepartureAirport(origin);
             this._initializeDepartureRunway();
         }
 
-        if (category === FLIGHT_CATEGORY.ARRIVAL) {
+        if (destinationLowerCase === AirportController.current.icao) {
             this._initializeArrivalAirport(destination);
             this._initializeArrivalRunway();
         }
@@ -331,12 +331,6 @@ export default class Fms {
      * @private
      */
     _initializeArrivalAirport(destinationIcao) {
-        const destinationIcaoLowerCase = destinationIcao.toLowerCase();
-
-        if (destinationIcaoLowerCase !== AirportController.current.icao) {
-            return;
-        }
-
         this.arrivalAirportModel = AirportController.airport_get(destinationIcao);
     }
 
@@ -374,12 +368,6 @@ export default class Fms {
      * @private
      */
     _initializeDepartureAirport(originIcao) {
-        const originIcaoLowerCase = originIcao.toLowerCase();
-
-        if (originIcaoLowerCase !== AirportController.current.icao) {
-            return;
-        }
-
         this.departureAirportModel = AirportController.airport_get(originIcao);
     }
 

--- a/src/assets/scripts/client/aircraft/FlightManagementSystem/Fms.js
+++ b/src/assets/scripts/client/aircraft/FlightManagementSystem/Fms.js
@@ -320,6 +320,12 @@ export default class Fms {
             return;
         }
 
+        destinationIcao = destinationIcao.toLowerCase();
+
+        if (destinationIcao !== AirportController.current.icao) {
+            return;
+        }
+
         this.arrivalAirportModel = AirportController.airport_get(destinationIcao);
     }
 
@@ -358,6 +364,12 @@ export default class Fms {
      */
     _initializeDepartureAirport(originIcao) {
         if (originIcao === '') {
+            return;
+        }
+
+        originIcao = originIcao.toLowerCase();
+
+        if (originIcao !== AirportController.current.icao) {
             return;
         }
 

--- a/src/assets/scripts/client/aircraft/FlightManagementSystem/Fms.js
+++ b/src/assets/scripts/client/aircraft/FlightManagementSystem/Fms.js
@@ -316,10 +316,6 @@ export default class Fms {
      * @private
      */
     _initializeArrivalAirport(destinationIcao) {
-        if (destinationIcao === '') {
-            return;
-        }
-
         destinationIcao = destinationIcao.toLowerCase();
 
         if (destinationIcao !== AirportController.current.icao) {
@@ -363,10 +359,6 @@ export default class Fms {
      * @private
      */
     _initializeDepartureAirport(originIcao) {
-        if (originIcao === '') {
-            return;
-        }
-
         originIcao = originIcao.toLowerCase();
 
         if (originIcao !== AirportController.current.icao) {

--- a/src/assets/scripts/client/aircraft/FlightManagementSystem/Fms.js
+++ b/src/assets/scripts/client/aircraft/FlightManagementSystem/Fms.js
@@ -272,15 +272,7 @@ export default class Fms {
         this._verifyRouteContainsMultipleWaypoints();
         this._initializeFlightPhaseForCategory(category);
 
-        if (category === FLIGHT_CATEGORY.DEPARTURE) {
-            this._initializeDepartureAirport(origin);
-            this._initializeDepartureRunway();
-        }
-
-        if (category === FLIGHT_CATEGORY.ARRIVAL) {
-            this._initializeArrivalAirport(destination);
-            this._initializeArrivalRunway();
-        }
+        this._initializeAirportsAndRunways(category, origin, destination);
 
         this._initializeFlightPlanAltitude(altitude, category, model);
         this._initializePositionInRouteToBeginAtFixName(nextFix, category);
@@ -308,6 +300,29 @@ export default class Fms {
     }
 
     /**
+     * Initialize `#arrivalAirportModel`+`#arrivalRunwayModel` and/or
+     * `#departureAirportModel`+`#departureRunwayModel` as applicable
+     *
+     * @for Fms
+     * @method _initializeAirportsAndRunways
+     * @param category {string} Flight category (arrival, departure, or overflight)
+     * @param origin {string} ICAO identifier specified by spawn pattern
+     * @param destination {string} ICAO identifier specified by spawn pattern
+     * @private
+     */
+    _initializeAirportsAndRunways(category, origin, destination) {
+        if (category === FLIGHT_CATEGORY.DEPARTURE) {
+            this._initializeDepartureAirport(origin);
+            this._initializeDepartureRunway();
+        }
+
+        if (category === FLIGHT_CATEGORY.ARRIVAL) {
+            this._initializeArrivalAirport(destination);
+            this._initializeArrivalRunway();
+        }
+    }
+
+    /**
      * Initialize `#arrivalAirportModel`
      *
      * @for Fms
@@ -316,9 +331,9 @@ export default class Fms {
      * @private
      */
     _initializeArrivalAirport(destinationIcao) {
-        destinationIcao = destinationIcao.toLowerCase();
+        const destinationIcaoLowerCase = destinationIcao.toLowerCase();
 
-        if (destinationIcao !== AirportController.current.icao) {
+        if (destinationIcaoLowerCase !== AirportController.current.icao) {
             return;
         }
 
@@ -359,9 +374,9 @@ export default class Fms {
      * @private
      */
     _initializeDepartureAirport(originIcao) {
-        originIcao = originIcao.toLowerCase();
+        const originIcaoLowerCase = originIcao.toLowerCase();
 
-        if (originIcao !== AirportController.current.icao) {
+        if (originIcaoLowerCase !== AirportController.current.icao) {
             return;
         }
 

--- a/src/assets/scripts/client/aircraft/FlightManagementSystem/Fms.js
+++ b/src/assets/scripts/client/aircraft/FlightManagementSystem/Fms.js
@@ -271,10 +271,17 @@ export default class Fms {
 
         this._verifyRouteContainsMultipleWaypoints();
         this._initializeFlightPhaseForCategory(category);
-        this._initializeDepartureAirport(origin);
-        this._initializeDepartureRunway();
-        this._initializeArrivalAirport(destination);
-        this._initializeArrivalRunway();
+
+        if (category === FLIGHT_CATEGORY.DEPARTURE) {
+            this._initializeDepartureAirport(origin);
+            this._initializeDepartureRunway();
+        }
+
+        if (category === FLIGHT_CATEGORY.ARRIVAL) {
+            this._initializeArrivalAirport(destination);
+            this._initializeArrivalRunway();
+        }
+
         this._initializeFlightPlanAltitude(altitude, category, model);
         this._initializePositionInRouteToBeginAtFixName(nextFix, category);
 

--- a/src/assets/scripts/client/trafficGenerator/SpawnScheduler.js
+++ b/src/assets/scripts/client/trafficGenerator/SpawnScheduler.js
@@ -39,7 +39,7 @@ class SpawnScheduler {
             throw new TypeError('Invalid parameter. SpawnScheduler requires aircraftController to be defined.');
         }
 
-        this.aircraftController = aircraftController;
+        this._aircraftController = aircraftController;
 
         this.startScheduler();
 
@@ -74,7 +74,7 @@ class SpawnScheduler {
 
             // TODO: abstract this to a class method on the `SpawnPatternModel`
             if (spawnPatternModel.isAirborneAtSpawn() && spawnPatternModel.preSpawnAircraftList.length > 0) {
-                this.aircraftController.createPreSpawnAircraftWithSpawnPatternModel(spawnPatternModel);
+                this._aircraftController.createPreSpawnAircraftWithSpawnPatternModel(spawnPatternModel);
             }
         });
     }
@@ -97,7 +97,7 @@ class SpawnScheduler {
         for (let i = 0; i < departureModelsToPreSpawn.length; i++) {
             const spawnPatternModel = departureModelsToPreSpawn[i];
 
-            this.aircraftController.createAircraftWithSpawnPatternModel(spawnPatternModel);
+            this._aircraftController.createAircraftWithSpawnPatternModel(spawnPatternModel);
         }
     }
 
@@ -143,7 +143,7 @@ class SpawnScheduler {
         if (timePassed < nextDelay) {
             nextDelay -= timePassed;
         } else {
-            this.aircraftController.createAircraftWithSpawnPatternModel(spawnPatternModel);
+            this._aircraftController.createAircraftWithSpawnPatternModel(spawnPatternModel);
         }
 
         spawnPatternModel.scheduleId = this._createTimeout(spawnPatternModel, nextDelay);
@@ -166,7 +166,7 @@ class SpawnScheduler {
             // passing null only to match existing api
             null,
             // arguments sent to callback as it's first parameter. using array so multiple arg can be sent
-            [spawnPatternModel, this.aircraftController]
+            [spawnPatternModel, this._aircraftController]
         );
     }
 

--- a/test/aircraft/FlightManagementSystem/Fms.spec.js
+++ b/test/aircraft/FlightManagementSystem/Fms.spec.js
@@ -233,10 +233,10 @@ ava('._initializeArrivalAirport() returns early when destination ICAO is an empt
 
 ava('._initializeArrivalAirport() sets #arrivalAirportModel to the specified destination airport', (t) => {
     const fms = buildFmsForAircraftInCruisePhaseWithRouteString(fullRouteStringMock);
-    const result = fms.reset()._initializeArrivalAirport('ksea');
+    const result = fms.reset()._initializeArrivalAirport('klas');
 
     t.true(typeof result === 'undefined');
-    t.true(fms.arrivalAirportModel.icao === 'ksea');
+    t.true(fms.arrivalAirportModel.icao === 'klas');
 });
 
 ava('._initializeArrivalRunway() returns early when #arrivalAirportModel is null', (t) => {
@@ -275,10 +275,10 @@ ava('._initializeDepartureAirport() returns early when destination ICAO is an em
 
 ava('._initializeDepartureAirport() sets #departureAirportModel to the specified origin airport', (t) => {
     const fms = buildFmsForAircraftInCruisePhaseWithRouteString(fullRouteStringMock);
-    const result = fms.reset()._initializeDepartureAirport('ksea');
+    const result = fms.reset()._initializeDepartureAirport('klas');
 
     t.true(typeof result === 'undefined');
-    t.true(fms.departureAirportModel.icao === 'ksea');
+    t.true(fms.departureAirportModel.icao === 'klas');
 });
 
 ava('._initializeDepartureRunway() returns early when #departureAirportModel is null', (t) => {

--- a/test/aircraft/FlightManagementSystem/Fms.spec.js
+++ b/test/aircraft/FlightManagementSystem/Fms.spec.js
@@ -223,6 +223,28 @@ ava('.reset() resets all instance properties to appropriate default values', (t)
     t.true(!fms._routeModel);
 });
 
+ava('._initializeAirportsAndRunways() does not make calls to initialize departure airport+runway when origin ICAO is an empty string', (t) => {
+    const fms = buildFmsForAircraftInCruisePhaseWithRouteString(starRouteStringMock);
+    const _initializeDepartureAirportSpy = sinon.spy(fms, '_initializeDepartureAirport');
+    const _initializeDepartureRunwaySpy = sinon.spy(fms, '_initializeDepartureRunway');
+    const result = fms._initializeAirportsAndRunways('','klas');
+
+    t.true(typeof result === 'undefined');
+    t.true(_initializeDepartureAirportSpy.notCalled);
+    t.true(_initializeDepartureRunwaySpy.notCalled);
+});
+
+ava('._initializeAirportsAndRunways() does not make calls to initialize arrival airport+runway when destination ICAO is an empty string', (t) => {
+    const fms = buildFmsForAircraftInCruisePhaseWithRouteString(sidRouteStringMock);
+    const _initializeArrivalAirportSpy = sinon.spy(fms, '_initializeArrivalAirport');
+    const _initializeArrivalRunwaySpy = sinon.spy(fms, '_initializeArrivalRunway');
+    const result = fms._initializeAirportsAndRunways('klas','');
+
+    t.true(typeof result === 'undefined');
+    t.true(_initializeArrivalAirportSpy.notCalled);
+    t.true(_initializeArrivalRunwaySpy.notCalled);
+});
+
 ava('._initializeArrivalAirport() sets #arrivalAirportModel to the specified destination airport', (t) => {
     const fms = buildFmsForAircraftInCruisePhaseWithRouteString(fullRouteStringMock);
     const result = fms.reset()._initializeArrivalAirport('klas');

--- a/test/aircraft/FlightManagementSystem/Fms.spec.js
+++ b/test/aircraft/FlightManagementSystem/Fms.spec.js
@@ -223,14 +223,6 @@ ava('.reset() resets all instance properties to appropriate default values', (t)
     t.true(!fms._routeModel);
 });
 
-ava('._initializeArrivalAirport() returns early when destination ICAO is an empty string', (t) => {
-    const fms = buildFmsForAircraftInCruisePhaseWithRouteString(fullRouteStringMock);
-    const result = fms.reset()._initializeArrivalAirport('');
-
-    t.true(typeof result === 'undefined');
-    t.true(!fms.arrivalAirportModel);
-});
-
 ava('._initializeArrivalAirport() sets #arrivalAirportModel to the specified destination airport', (t) => {
     const fms = buildFmsForAircraftInCruisePhaseWithRouteString(fullRouteStringMock);
     const result = fms.reset()._initializeArrivalAirport('klas');
@@ -262,15 +254,6 @@ ava('._initializeArrivalRunway() sets #arrivalRunwayModel IAW the route model', 
 
     t.true(typeof result === 'undefined');
     t.true(fms.arrivalRunwayModel.name === '07R');
-});
-
-ava('._initializeDepartureAirport() returns early when destination ICAO is an empty string', (t) => {
-    const fms = buildFmsForAircraftInCruisePhaseWithRouteString(fullRouteStringMock);
-
-    const result = fms.reset()._initializeDepartureAirport('');
-
-    t.true(typeof result === 'undefined');
-    t.true(!fms.departureAirportModel);
 });
 
 ava('._initializeDepartureAirport() sets #departureAirportModel to the specified origin airport', (t) => {

--- a/test/aircraft/FlightManagementSystem/Fms.spec.js
+++ b/test/aircraft/FlightManagementSystem/Fms.spec.js
@@ -227,7 +227,7 @@ ava('._initializeAirportsAndRunways() does not make calls to initialize departur
     const fms = buildFmsForAircraftInCruisePhaseWithRouteString(starRouteStringMock);
     const _initializeDepartureAirportSpy = sinon.spy(fms, '_initializeDepartureAirport');
     const _initializeDepartureRunwaySpy = sinon.spy(fms, '_initializeDepartureRunway');
-    const result = fms._initializeAirportsAndRunways('','klas');
+    const result = fms._initializeAirportsAndRunways('', 'klas');
 
     t.true(typeof result === 'undefined');
     t.true(_initializeDepartureAirportSpy.notCalled);
@@ -238,7 +238,7 @@ ava('._initializeAirportsAndRunways() does not make calls to initialize arrival 
     const fms = buildFmsForAircraftInCruisePhaseWithRouteString(sidRouteStringMock);
     const _initializeArrivalAirportSpy = sinon.spy(fms, '_initializeArrivalAirport');
     const _initializeArrivalRunwaySpy = sinon.spy(fms, '_initializeArrivalRunway');
-    const result = fms._initializeAirportsAndRunways('klas','');
+    const result = fms._initializeAirportsAndRunways('klas', '');
 
     t.true(typeof result === 'undefined');
     t.true(_initializeArrivalAirportSpy.notCalled);


### PR DESCRIPTION
Resolves #1762

The purpose of this pull request is to add validation/protection to initialization methods in `Fms`:
- ~initialization of arrival/departure airport+runway gated behind an explicit check of the `category` i.e. arriving or departing flight rather than based on the presence/absence of `destination`/`origin`~
- validate + enforce expectation that `destination`/`origin` airport is the current airport
  - in future (to support #47) needs expanded to airports within tracon
