### PR TITLE
enhancement/1771 - Change Thomas Cook to Sunclass Airlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - <a href="https://github.com/openscope/openscope/issues/1763" target="_blank">#1763</a> - Reflect merging of Singapore Cargo Airlines (SQC) into SIA
 - <a href="https://github.com/openscope/openscope/issues/1778" target="_blank">#1778</a> - Code gardening in StripViewModel.js
 - <a href="https://github.com/openscope/openscope/issues/1780" target="_blank">#1780</a> - Implement constants for wake turbulence category & engine type
+- <a href="https://github.com/openscope/openscope/issues/1771" target="_blank">#1771</a> - Change VKG airline from Thomas Cook to Sunclass
 
 
 # 6.23.0 (February 5, 2021)

--- a/assets/airlines/vkg.json
+++ b/assets/airlines/vkg.json
@@ -1,6 +1,6 @@
 {
     "icao": "vkg",
-    "name": "Thomas Cook Airlines Scandinavia",
+    "name": "Sunclass Airlines",
     "callsign": {
         "name": "Viking",
         "callsignFormats": [


### PR DESCRIPTION
Resolves #1771 

The purpose of this pull request is to change Thomas Cook Scandinavia to Sunclass Airlines.
