### PR TITLE
refactor/1778 - StripViewModel code gardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - <a href="https://github.com/openscope/openscope/issues/1758" target="_blank">#1758</a> - Update GitHub build status badge
 - <a href="https://github.com/openscope/openscope/issues/1749" target="_blank">#1749</a> - Improve user input validation and associated tests
 - <a href="https://github.com/openscope/openscope/issues/1763" target="_blank">#1763</a> - Reflect merging of Singapore Cargo Airlines (SQC) into SIA
+- <a href="https://github.com/openscope/openscope/issues/1778" target="_blank">#1778</a> - Code gardening in StripViewModel.js
 
 
 # 6.23.0 (February 5, 2021)

--- a/src/assets/scripts/client/aircraft/StripView/StripViewModel.js
+++ b/src/assets/scripts/client/aircraft/StripView/StripViewModel.js
@@ -491,7 +491,7 @@ export default class StripViewModel extends BaseModel {
     }
 
     /**
-     * Update teh view with new data
+     * Update the view with new data
      *
      * This method will be run on instantiation to initialize the view with data,
      * and will be run again any time updatable data has changed.

--- a/src/assets/scripts/client/aircraft/StripView/StripViewModel.js
+++ b/src/assets/scripts/client/aircraft/StripView/StripViewModel.js
@@ -389,12 +389,12 @@ export default class StripViewModel extends BaseModel {
         const {
             insideCenter,
             callsign,
-            icaoWithWeightClass,
             transponderCode,
+            icaoWithWeightClass,
             assignedAltitude,
+            flightPlanAltitude,
             arrivalAirportId,
             departureAirportId,
-            flightPlanAltitude,
             flightPlan
         } = aircraftModel.getViewModel();
 
@@ -754,9 +754,9 @@ export default class StripViewModel extends BaseModel {
             insideCenter,
             transponderCode,
             assignedAltitude,
+            flightPlanAltitude,
             arrivalAirportId,
             departureAirportId,
-            flightPlanAltitude,
             flightPlan
         } = aircraftModel.getViewModel();
 

--- a/src/assets/scripts/client/aircraft/StripView/StripViewModel.js
+++ b/src/assets/scripts/client/aircraft/StripView/StripViewModel.js
@@ -724,16 +724,24 @@ export default class StripViewModel extends BaseModel {
      * @private
      */
     _shouldUpdate(aircraftModel) {
-        const viewModel = aircraftModel.getViewModel();
+        const {
+            insideCenter,
+            transponderCode,
+            assignedAltitude,
+            flightPlanAltitude,
+            arrivalAirportId,
+            departureAirportId,
+            flightPlan
+        } = aircraftModel.getViewModel();
         const runwayInfo = this._buildRunwayInformation(aircraftModel);
 
-        return this.insideCenter !== viewModel.insideCenter ||
-            this._transponder !== viewModel.transponderCode ||
-            this._assignedAltitude !== viewModel.assignedAltitude ||
-            this._flightPlanAltitude !== viewModel.flightPlanAltitude ||
-            this._arrivalAirport !== viewModel.arrivalAirportId ||
-            this._departureAirport !== viewModel.departureAirportId ||
-            this._flightPlan !== viewModel.flightPlan ||
+        return this.insideCenter !== insideCenter ||
+            this._transponder !== transponderCode ||
+            this._assignedAltitude !== assignedAltitude ||
+            this._flightPlanAltitude !== flightPlanAltitude ||
+            this._arrivalAirport !== arrivalAirportId ||
+            this._departureAirport !== departureAirportId ||
+            this._flightPlan !== flightPlan ||
             this._runwayInformation.hasRunwayAssigned !== runwayInfo.hasRunwayAssigned ||
             this._runwayInformation.name !== runwayInfo.name;
     }


### PR DESCRIPTION
Resolves #1778

The purpose of this pull request is to commit small refactors in `StripViewModel.js`

* in `_init()` and `_updateStripView()`:
  - make order of variables in object destructuring assignments consistent with:
    + order that they are used in code that follows
    + order as per `aircraftModel.getViewModel()` where they come from

* in `_shouldUpdate()`:
  - use object destructring to be consistent with `_init()` and `_updateStripView()`

* minor typo in docbolck