### PR TITLE
bugfix/1845 - Fix Safari browser compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - <a href="https://github.com/openscope/openscope/issues/1848" target="_blank">#1848</a> - Allow user to toggle individual video maps on/off
 
 ### Bugfixes
+- <a href="https://github.com/openscope/openscope/issues/1845" target="_blank">#1845</a> - Fix Safari compatibility issue
 
 ### Enhancements & Refactors
 

--- a/src/assets/scripts/client/constants/globalConstants.js
+++ b/src/assets/scripts/client/constants/globalConstants.js
@@ -31,7 +31,7 @@ export const REGEX = {
     ALTITUDE_RESTRICTION: /^A([0-9]{1,3})([+-]?)$/,
     COMPASS_DIRECTION: /^[NESW]/,
     DOUBLE_DOT: /\.\./g,
-    HOLD_DISTANCE: /^((?:0(?=\.)|[1-9]|[1-4][0-9])(?:(?<!^0)\.0|\.[1-9])?)(nm|min)$/i,
+    HOLD_DISTANCE: /^((?:0(?=\.[1-9])|[1-9]|[1-4][0-9])(?:\.[0-9])?)(nm|min)$/i,
     LAT_LONG: /^([NESW])(\d+(\.\d+)?)([d °](\d+(\.\d+)?))?([m '](\d+(\.\d+)?))?$/,
     SPEED_RESTRICTION: /^S([1-9][0-9]{2})([+-]?)$/,
     SW: /[SW]/,


### PR DESCRIPTION
Resolves #1845 

The purpose of this pull request is to fix Safari browser compatibility.

Safari (and some other browsers) doesn't support a [lookbehind regular expressions](https://caniuse.com/?search=lookbehind), but those are used in command regular expressions. 

So this fix replaced those with compatible regular expressions.