### PR TITLE
Add E175 Varient

### DIFF
--- a/assets/aircraft/e170.json
+++ b/assets/aircraft/e170.json
@@ -1,5 +1,5 @@
 {
-    "name": "Embraer 170/175",
+    "name": "Embraer 170",
     "icao": "E170",
     "engines": {
         "number": 2,

--- a/assets/aircraft/e175.json
+++ b/assets/aircraft/e175.json
@@ -1,0 +1,37 @@
+{
+    "name": "Embraer 175",
+    "icao": "E175",
+    "engines": {
+        "number": 2,
+        "type": "J"
+    },
+    "weightClass": "L",
+    "category": {
+        "srs": 3,
+        "lahso": 7,
+        "recat": "E"
+    },
+    "ceiling": 41000,
+    "rate": {
+        "climb":      3400,
+        "descent":    2600,
+        "accelerate": 7,
+        "decelerate": 4
+    },
+    "runway": {
+        "takeoff": 1.700,
+        "landing": 1.200
+    },
+    "speed":{
+        "min":     110,
+        "landing": 120,
+        "cruise":  475,
+        "cruiseM": null,
+        "max":     481,
+        "maxM":    0.82
+    },
+    "capability": {
+        "ils": true,
+        "fix": true
+    }
+}


### PR DESCRIPTION
Removed E170 in the Aircraft name and change ICAO to E175

Resolves #1884

The purpose of this pull request is to add the E175 varient of aircraft.
