### PR TITLE
Enhancement/1702 Adjust HHOOD4.JKNOX arrival restrictions

### DIFF
--- a/assets/airports/kpdx.json
+++ b/assets/airports/kpdx.json
@@ -426,7 +426,7 @@
             "entryPoints": {
                 "BAYYR": [["BAYYR", "A130+|S270"]],
                 "DUFUR": ["DUFUR", ["RABBI", "A130+|S270"]],
-                "JKNOX": [["JKNOX", "A240+"], ["MYTOE", "A170+"], ["BAYYR", "A130+|S270"]],
+                "JKNOX": [["JKNOX", "A240+"], ["MYTOE", "A170+"], ["BAYYR", "A130+|S270"], ["HHOOD", "A90+|A150-|S250"], ["SHAFR", "A67|S210"]],
                 "JORAD": [["JORAD", "A240+"], ["LUUND", "A170+"], ["YENTL", "A130+|S270"]],
                 "JOTBA": [["JOTBA", "A240+"], ["SODDA", "A170+"], "DUFUR", ["RABBI", "A130+|S270"]],
                 "RABBI": [["RABBI", "A130+|S270"]],


### PR DESCRIPTION
Added HHOOD and SHAFR waypoints along with their speed and altitude restrictions. They were missing prior, most likely causing the aircraft to be high above 6,700ft at SHAFR.

Resolves #1702

The purpose of this pull request is to fix KPDX's HHOOD4 arrivals often flying too high and not meeting speed or altitude restrictions.
