### PR TITLE
Enhancement/1345 Add reset buttons to traffic config dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - <a href="https://github.com/openscope/openscope/issues/1772" target="_blank">#1772</a> - Add/Update some Scandinavian airlines
 - <a href="https://github.com/openscope/openscope/issues/1878" target="_blank">#1878</a> - Update ASA/SWA airlines
 - <a href="https://github.com/openscope/openscope/issues/1878" target="_blank">#1878</a> - Add Embraer 175
-
+- <a href="https://github.com/openscope/openscope/issues/1345" target="_blank">#1345</a> - Add reset buttons to traffic config dialog
 
 # 6.26.0 (December 1, 2021)
 ### New Features

--- a/src/assets/scripts/client/AppController.js
+++ b/src/assets/scripts/client/AppController.js
@@ -313,7 +313,7 @@ export default class AppController {
         this.aircraftController.aircraft_remove_all();
         this.scopeModel.radarTargetCollection.reset();
         SpawnScheduler.createPreSpawnDepartures();
-        SpawnPatternCollection.resetAirborneTraffic(this.aircraftController);
+        SpawnScheduler.resetAirborneTraffic();
     }
 
     // TODO: this should live in a view class somewhere. temporary inclusion here to prevent tests from failing

--- a/src/assets/scripts/client/AppController.js
+++ b/src/assets/scripts/client/AppController.js
@@ -23,7 +23,6 @@ import { speech_init } from './speech';
 import { EVENT } from './constants/eventNames';
 import { SELECTORS } from './constants/selectors';
 import { TRACKABLE_EVENT } from './constants/trackableEvents';
-import _forEach from "lodash/forEach";
 
 /**
  * Root controller class
@@ -313,13 +312,8 @@ export default class AppController {
         EventTracker.recordEvent(TRACKABLE_EVENT.AIRPORTS, 'traffic-reset', AirportController.current.icao);
         this.aircraftController.aircraft_remove_all();
         this.scopeModel.radarTargetCollection.reset();
-        SpawnScheduler.createPreSpawnDepartures()
-
-        _forEach(SpawnPatternCollection.spawnPatternModels, (spawnPattern) => {
-            spawnPattern.preSpawnAircraftList = []
-            spawnPattern.createPreSpawnAircraft(this.aircraftController)
-            SpawnScheduler.resetTimer(spawnPattern)
-        });
+        SpawnScheduler.createPreSpawnDepartures();
+        SpawnPatternCollection.resetAirborneTraffic(this.aircraftController);
     }
 
     // TODO: this should live in a view class somewhere. temporary inclusion here to prevent tests from failing

--- a/src/assets/scripts/client/AppController.js
+++ b/src/assets/scripts/client/AppController.js
@@ -312,7 +312,7 @@ export default class AppController {
         EventTracker.recordEvent(TRACKABLE_EVENT.AIRPORTS, 'traffic-reset', AirportController.current.icao);
         this.aircraftController.aircraft_remove_all();
         this.scopeModel.radarTargetCollection.reset();
-        AirportController.current.departureRunwayModel.reset();
+        AirportController.current.resetAllRunwayQueues();
         SpawnScheduler.createPreSpawnDepartures();
         SpawnScheduler.resetAirborneTraffic();
     }

--- a/src/assets/scripts/client/AppController.js
+++ b/src/assets/scripts/client/AppController.js
@@ -312,6 +312,7 @@ export default class AppController {
         EventTracker.recordEvent(TRACKABLE_EVENT.AIRPORTS, 'traffic-reset', AirportController.current.icao);
         this.aircraftController.aircraft_remove_all();
         this.scopeModel.radarTargetCollection.reset();
+        AirportController.current.departureRunwayModel.reset();
         SpawnScheduler.createPreSpawnDepartures();
         SpawnScheduler.resetAirborneTraffic();
     }

--- a/src/assets/scripts/client/airport/AirportModel.js
+++ b/src/assets/scripts/client/airport/AirportModel.js
@@ -733,6 +733,17 @@ export default class AirportModel {
     }
 
     /**
+     * Reset the queues for ALL runways at once
+     *
+     * @for AirportModel
+     * @method resetAllRunwayQueues
+     * @returns undefined
+     */
+    resetAllRunwayQueues() {
+        this._runwayCollection.runways.forEach((runwayModel) => runwayModel.resetQueue());
+    }
+
+    /**
      * @for AirportModel
      * @method parseTerrain
      * @param  data {object}

--- a/src/assets/scripts/client/airport/AirportModel.js
+++ b/src/assets/scripts/client/airport/AirportModel.js
@@ -207,7 +207,7 @@ export default class AirportModel {
         };
 
         /**
-         * default wind settings for an airport
+         * current wind settings for an airport
          *
          * @property wind
          * @type {object}
@@ -216,6 +216,20 @@ export default class AirportModel {
             speed: 10,
             angle: 0
         };
+
+        /**
+         * default wind settings for an airport
+         * to preserve initial configuration
+         *
+         * @property wind
+         * @type {object}
+         */
+        this.defaultWind = {
+            speed: 10,
+            angle: 0
+        };
+
+
 
         /**
          * @for AirportModel
@@ -362,6 +376,8 @@ export default class AirportModel {
         this.initial_alt = _get(data, 'initial_alt', DEFAULT_INITIAL_ALTITUDE_FT);
         this._runwayCollection = new RunwayCollection(data.runways, this._positionModel);
         this.mapCollection = new MapCollection(data.maps, data.defaultMaps, this.positionModel, this.magneticNorth);
+        this.defaultWind.speed = data.wind.speed;
+        this.defaultWind.angle = degreesToRadians(data.wind.angle);
 
         this._initRangeRings(data.rangeRings);
         this.loadTerrain();

--- a/src/assets/scripts/client/airport/AirportModel.js
+++ b/src/assets/scripts/client/airport/AirportModel.js
@@ -229,8 +229,6 @@ export default class AirportModel {
             angle: 0
         };
 
-
-
         /**
          * @for AirportModel
          * @property ctr_radius

--- a/src/assets/scripts/client/airport/runway/RunwayModel.js
+++ b/src/assets/scripts/client/airport/runway/RunwayModel.js
@@ -132,6 +132,17 @@ export default class RunwayModel extends BaseModel {
     }
 
     /**
+     *  Reset the aircraft-related state of this model, used for resetting departure traffic
+     *
+     *  @for RunwayModel
+     *  @method reset
+     */
+    reset() {
+        this.queue = [];
+        this.lastDepartedAircraftModel = null;
+    }
+
+    /**
      * Fascade to access relative position
      *
      * @for RunwayModel

--- a/src/assets/scripts/client/airport/runway/RunwayModel.js
+++ b/src/assets/scripts/client/airport/runway/RunwayModel.js
@@ -132,12 +132,13 @@ export default class RunwayModel extends BaseModel {
     }
 
     /**
-     *  Reset the aircraft-related state of this model, used for resetting departure traffic
+     * Reset the runway queue
      *
-     *  @for RunwayModel
-     *  @method reset
+     * @for RunwayModel
+     * @method resetQueue
+     * @returns undefined
      */
-    reset() {
+    resetQueue() {
         this.queue = [];
         this.lastDepartedAircraftModel = null;
     }

--- a/src/assets/scripts/client/constants/eventNames.js
+++ b/src/assets/scripts/client/constants/eventNames.js
@@ -183,6 +183,15 @@ export const EVENT = {
     TIMEWARP_TOGGLE: 'timewarp-toggle',
 
     /**
+     * An request has been made to clear and respawn traffic at the current airport
+     *
+     * @memberof EVENT
+     * @property TRAFFIC_RESET
+     * @type {string}
+     */
+    TRAFFIC_RESET: 'traffic-reset',
+
+    /**
      * @memberof EVENT
      * @property TOGGLE_AIRPORT_GUIDE
      * @type {string}

--- a/src/assets/scripts/client/constants/selectors.js
+++ b/src/assets/scripts/client/constants/selectors.js
@@ -48,6 +48,8 @@ export const CLASSNAMES = {
     OPEN: 'open',
     OPTIONS_DIALOG: 'option-dialog',
     TRAFFIC_DIALOG: 'traffic-dialog',
+    TRAFFIC_DEFAULT_BUTTON: 'js-trafficDefaultButton',
+    TRAFFIC_RESTART_BUTTON: 'js-trafficRestartButton',
     OVERFLIGHT: 'overflight',
     PAUSED: 'paused',
     PREV: 'prev',

--- a/src/assets/scripts/client/math/core.js
+++ b/src/assets/scripts/client/math/core.js
@@ -19,6 +19,15 @@ export function abs(n) {
 }
 
 /**
+ * @function avg
+ * @param n {Number[]}
+ * @return {number}
+ */
+export function avg(n) {
+    return n.reduce((a, b) => a + b) / n.length;
+}
+
+/**
  * @function sin
  * @return {number}
  */

--- a/src/assets/scripts/client/trafficGenerator/SpawnPatternCollection.js
+++ b/src/assets/scripts/client/trafficGenerator/SpawnPatternCollection.js
@@ -4,7 +4,6 @@ import _isNaN from 'lodash/isNaN';
 import _random from 'lodash/random';
 import BaseCollection from '../base/BaseCollection';
 import SpawnPatternModel from './SpawnPatternModel';
-import SpawnScheduler from './SpawnScheduler';
 import { FLIGHT_CATEGORY } from '../constants/aircraftConstants';
 import { isEmptyOrNotObject } from '../utilities/validatorUtilities';
 
@@ -84,23 +83,6 @@ class SpawnPatternCollection extends BaseCollection {
     resetRates() {
         this._items.forEach((spawnPatternModel) => {
             spawnPatternModel.resetRate();
-        });
-    }
-
-    /**
-     * Loop through each item in the collection and reset the spawned and preSpawned traffic.
-     *
-     * Used when resetting the traffic in the traffic settings panel.
-     *
-     * @for SpawnPatternCollection
-     * @method resetTraffic
-     * @param aircraftController {AircraftController}
-     */
-    resetAirborneTraffic(aircraftController) {
-        this._items.filter((s) => s.isAirborneAtSpawn()).forEach((spawnPatternModel) => {
-            spawnPatternModel.preSpawnAircraftList = [];
-            spawnPatternModel.createPreSpawnAircraft(aircraftController);
-            SpawnScheduler.resetTimer(spawnPatternModel);
         });
     }
 

--- a/src/assets/scripts/client/trafficGenerator/SpawnPatternCollection.js
+++ b/src/assets/scripts/client/trafficGenerator/SpawnPatternCollection.js
@@ -4,6 +4,7 @@ import _isNaN from 'lodash/isNaN';
 import _random from 'lodash/random';
 import BaseCollection from '../base/BaseCollection';
 import SpawnPatternModel from './SpawnPatternModel';
+import SpawnScheduler from "./SpawnScheduler";
 import { FLIGHT_CATEGORY } from '../constants/aircraftConstants';
 import { isEmptyOrNotObject } from '../utilities/validatorUtilities';
 
@@ -55,7 +56,7 @@ class SpawnPatternCollection extends BaseCollection {
     }
 
     /**
-     * Loop through each item in the collection andd call `.destroy()` on that model.
+     * Loop through each item in the collection and call `.destroy()` on that model.
      *
      * Used when resetting the collection, like onAirportChange.
      *
@@ -70,6 +71,37 @@ class SpawnPatternCollection extends BaseCollection {
         });
 
         this._items = [];
+    }
+
+    /**
+     * Loop through each item in the collection and reset the spaen rate.
+     *
+     * Used when resetting the rate in the traffic settings panel.
+     *
+     * @for SpawnPatternCollection
+     * @method resetRates
+     */
+    resetRates() {
+        this._items.forEach(spawnPatternModel => {
+            spawnPatternModel.resetRate();
+        });
+    }
+
+    /**
+     * Loop through each item in the collection and reset the spaend and preSpawned traffic.
+     *
+     * Used when resetting the traffic in the traffic settings panel.
+     *
+     * @for SpawnPatternCollection
+     * @method resetTraffic
+     * @param aircraftController {AircraftController}
+     */
+    resetAirborneTraffic(aircraftController) {
+        this._items.filter(s => s.isAirborneAtSpawn()).forEach(spawnPatternModel => {
+            spawnPatternModel.preSpawnAircraftList = []
+            spawnPatternModel.createPreSpawnAircraft(aircraftController)
+            SpawnScheduler.resetTimer(spawnPatternModel)
+        });
     }
 
     /**

--- a/src/assets/scripts/client/trafficGenerator/SpawnPatternCollection.js
+++ b/src/assets/scripts/client/trafficGenerator/SpawnPatternCollection.js
@@ -173,7 +173,7 @@ class SpawnPatternCollection extends BaseCollection {
             }
 
             // randomly choose a spawn pattern for this runway to prespawn
-            const spawnPatterns = spawnPatternsByDepartureRunway[runway];
+            const spawnPatterns = spawnPatternsByDepartureRunway[runway].filter(p => p.rate > 0);
             const rateMap = spawnPatterns.map((pattern) => pattern.rate);
             const rateTotal = spawnPatterns.reduce((sum, pattern) => sum + pattern.rate, 0);
             const randomPosition = _random(rateTotal, true);

--- a/src/assets/scripts/client/trafficGenerator/SpawnPatternCollection.js
+++ b/src/assets/scripts/client/trafficGenerator/SpawnPatternCollection.js
@@ -4,7 +4,7 @@ import _isNaN from 'lodash/isNaN';
 import _random from 'lodash/random';
 import BaseCollection from '../base/BaseCollection';
 import SpawnPatternModel from './SpawnPatternModel';
-import SpawnScheduler from "./SpawnScheduler";
+import SpawnScheduler from './SpawnScheduler';
 import { FLIGHT_CATEGORY } from '../constants/aircraftConstants';
 import { isEmptyOrNotObject } from '../utilities/validatorUtilities';
 
@@ -82,7 +82,7 @@ class SpawnPatternCollection extends BaseCollection {
      * @method resetRates
      */
     resetRates() {
-        this._items.forEach(spawnPatternModel => {
+        this._items.forEach((spawnPatternModel) => {
             spawnPatternModel.resetRate();
         });
     }
@@ -97,10 +97,10 @@ class SpawnPatternCollection extends BaseCollection {
      * @param aircraftController {AircraftController}
      */
     resetAirborneTraffic(aircraftController) {
-        this._items.filter(s => s.isAirborneAtSpawn()).forEach(spawnPatternModel => {
-            spawnPatternModel.preSpawnAircraftList = []
-            spawnPatternModel.createPreSpawnAircraft(aircraftController)
-            SpawnScheduler.resetTimer(spawnPatternModel)
+        this._items.filter((s) => s.isAirborneAtSpawn()).forEach((spawnPatternModel) => {
+            spawnPatternModel.preSpawnAircraftList = [];
+            spawnPatternModel.createPreSpawnAircraft(aircraftController);
+            SpawnScheduler.resetTimer(spawnPatternModel);
         });
     }
 

--- a/src/assets/scripts/client/trafficGenerator/SpawnPatternCollection.js
+++ b/src/assets/scripts/client/trafficGenerator/SpawnPatternCollection.js
@@ -173,7 +173,7 @@ class SpawnPatternCollection extends BaseCollection {
             }
 
             // randomly choose a spawn pattern for this runway to prespawn
-            const spawnPatterns = spawnPatternsByDepartureRunway[runway].filter(p => p.rate > 0);
+            const spawnPatterns = spawnPatternsByDepartureRunway[runway].filter((p) => p.rate > 0);
             const rateMap = spawnPatterns.map((pattern) => pattern.rate);
             const rateTotal = spawnPatterns.reduce((sum, pattern) => sum + pattern.rate, 0);
             const randomPosition = _random(rateTotal, true);

--- a/src/assets/scripts/client/trafficGenerator/SpawnPatternCollection.js
+++ b/src/assets/scripts/client/trafficGenerator/SpawnPatternCollection.js
@@ -88,7 +88,7 @@ class SpawnPatternCollection extends BaseCollection {
     }
 
     /**
-     * Loop through each item in the collection and reset the spaend and preSpawned traffic.
+     * Loop through each item in the collection and reset the spawned and preSpawned traffic.
      *
      * Used when resetting the traffic in the traffic settings panel.
      *

--- a/src/assets/scripts/client/trafficGenerator/SpawnPatternModel.js
+++ b/src/assets/scripts/client/trafficGenerator/SpawnPatternModel.js
@@ -297,6 +297,16 @@ export default class SpawnPatternModel extends BaseModel {
         this.rate = INVALID_NUMBER;
 
         /**
+         * Rate at which aircaft spawn, express in aircraft per hour
+         * Used to preserve initial configuration
+         *
+         * @property defaultRate
+         * @type {number}
+         * @default INVALID_NUMBER
+         */
+        this.defaultRate = INVALID_NUMBER;
+
+        /**
          * GameTime when a specific spawn pattern started
          *
          * Used only for cycle, surge and wave patterns
@@ -498,6 +508,7 @@ export default class SpawnPatternModel extends BaseModel {
         this.speed = this._extractSpeedFromJson(spawnPatternJson);
         this.method = spawnPatternJson.method;
         this.rate = parseFloat(spawnPatternJson.rate);
+        this.defaultRate = this.rate;
         this.entrail = _get(spawnPatternJson, 'entrail', this.entrail);
 
         this._routeModel = new RouteModel(spawnPatternJson.route);
@@ -545,6 +556,16 @@ export default class SpawnPatternModel extends BaseModel {
         this.airlines = [];
         this._weightedAirlineList = [];
         this.preSpawnAircraftList = [];
+    }
+
+    /**
+     * Reset to the spawn rate to the value found in the Airport Json
+     *
+     * @for SpawnPatternModel
+     * @method resetRate
+     */
+    resetRate() {
+        this.rate = this.defaultRate;
     }
 
     /**

--- a/src/assets/scripts/client/trafficGenerator/SpawnPatternModel.js
+++ b/src/assets/scripts/client/trafficGenerator/SpawnPatternModel.js
@@ -681,7 +681,7 @@ export default class SpawnPatternModel extends BaseModel {
      * @param aircraftController {AircraftController}
      */
     createPreSpawnAircraft(aircraftController) {
-        if(this.preSpawnAircraftList.length == 0) {
+        if (this.preSpawnAircraftList.length === 0) {
             this.preSpawnAircraftList = this._buildPreSpawnAircraft(this);
         }
 

--- a/src/assets/scripts/client/trafficGenerator/SpawnPatternModel.js
+++ b/src/assets/scripts/client/trafficGenerator/SpawnPatternModel.js
@@ -559,7 +559,7 @@ export default class SpawnPatternModel extends BaseModel {
     }
 
     /**
-     * Reset to the spawn rate to the value found in the Airport Json
+     * Reset the spawn rate to the value found in the Airport Json
      *
      * @for SpawnPatternModel
      * @method resetRate
@@ -671,6 +671,23 @@ export default class SpawnPatternModel extends BaseModel {
      */
     isOverflight() {
         return this.category === FLIGHT_CATEGORY.OVERFLIGHT;
+    }
+
+    /**
+     * Use the supplied aircraft controller to generate prespawned aircraft using this model
+     *
+     * @for SpawnPatternModel
+     * @method createPreSpawnAircraft
+     * @param aircraftController {AircraftController}
+     */
+    createPreSpawnAircraft(aircraftController) {
+        if(this.preSpawnAircraftList.length == 0) {
+            this.preSpawnAircraftList = this._buildPreSpawnAircraft(this);
+        }
+
+        if (this.isAirborneAtSpawn() && this.preSpawnAircraftList.length > 0) {
+            aircraftController.createPreSpawnAircraftWithSpawnPatternModel(this);
+        }
     }
 
     /**

--- a/src/assets/scripts/client/trafficGenerator/SpawnScheduler.js
+++ b/src/assets/scripts/client/trafficGenerator/SpawnScheduler.js
@@ -71,11 +71,7 @@ class SpawnScheduler {
             // set the #cycleStartTime for this `spawnPatternModel` with current game time
             spawnPatternModel.cycleStart(TimeKeeper.accumulatedDeltaTime);
             spawnPatternModel.scheduleId = this.createNextSchedule(spawnPatternModel);
-
-            // TODO: abstract this to a class method on the `SpawnPatternModel`
-            if (spawnPatternModel.isAirborneAtSpawn() && spawnPatternModel.preSpawnAircraftList.length > 0) {
-                this._aircraftController.createPreSpawnAircraftWithSpawnPatternModel(spawnPatternModel);
-            }
+            spawnPatternModel.createPreSpawnAircraft(this._aircraftController)
         });
     }
 

--- a/src/assets/scripts/client/trafficGenerator/SpawnScheduler.js
+++ b/src/assets/scripts/client/trafficGenerator/SpawnScheduler.js
@@ -71,7 +71,7 @@ class SpawnScheduler {
             // set the #cycleStartTime for this `spawnPatternModel` with current game time
             spawnPatternModel.cycleStart(TimeKeeper.accumulatedDeltaTime);
             spawnPatternModel.scheduleId = this.createNextSchedule(spawnPatternModel);
-            spawnPatternModel.createPreSpawnAircraft(this._aircraftController)
+            spawnPatternModel.createPreSpawnAircraft(this._aircraftController);
         });
     }
 

--- a/src/assets/scripts/client/trafficGenerator/SpawnScheduler.js
+++ b/src/assets/scripts/client/trafficGenerator/SpawnScheduler.js
@@ -76,6 +76,22 @@ class SpawnScheduler {
     }
 
     /**
+     * Loop through each airborne `SpawnPatternModel` and reset the spawned and preSpawned traffic.
+     *
+     * Used when resetting the traffic in the traffic settings panel.
+     *
+     * @for SpawnScheduler
+     * @method resetAirborneTraffic
+     */
+    resetAirborneTraffic() {
+        SpawnPatternCollection.spawnPatternModels.filter((s) => s.isAirborneAtSpawn()).forEach((spawnPatternModel) => {
+            spawnPatternModel.preSpawnAircraftList = [];
+            spawnPatternModel.createPreSpawnAircraft(this._aircraftController);
+            this.resetTimer(spawnPatternModel);
+        });
+    }
+
+    /**
      * Send `SpawnPatternModel` objects off the the `AircraftController` to create
      * new aircraft onLoad or onAirportChange.
      *

--- a/src/assets/scripts/client/trafficGenerator/buildPreSpawnAircraft.js
+++ b/src/assets/scripts/client/trafficGenerator/buildPreSpawnAircraft.js
@@ -341,7 +341,7 @@ const _calculateTotalDistanceAlongRoute = (waypointModelList, airport) => {
 const _preSpawn = (spawnPatternJson, airport) => {
     const spawnRate = spawnPatternJson.rate;
 
-    if(spawnRate == 0) {
+    if (spawnRate == 0) {
         return [];
     }
 

--- a/src/assets/scripts/client/trafficGenerator/buildPreSpawnAircraft.js
+++ b/src/assets/scripts/client/trafficGenerator/buildPreSpawnAircraft.js
@@ -10,7 +10,7 @@ import { TIME } from '../constants/globalConstants';
 import { nm } from '../utilities/unitConverters';
 import { isEmptyOrNotObject } from '../utilities/validatorUtilities';
 import { distance2d } from '../math/distance';
-import {ENVIRONMENT} from "../constants/environmentConstants";
+import { ENVIRONMENT } from '../constants/environmentConstants';
 
 /**
  * Return an array whose indices directly mirror those of `waypointModelList`, except it
@@ -251,17 +251,18 @@ function _calculateSpawnPositionsAndAltitudes(
  */
 const _assembleSpawnOffsets = (entrailDistance, totalDistance = 0) => {
     const offsetClosestToAirspace = totalDistance - 3;
-    //dont spawn aircraft closer than 10 MIT
+    // dont spawn aircraft closer than 10 MIT
     const clampedEntrailDistance = Math.max(10, entrailDistance);
     let smallestIntervalNm = 15;
-    //do not allow prespawned aircraft to have a spacing less than `minimumInTrailNm`
-    const largestIntervalNm = Math.max(clampedEntrailDistance, clampedEntrailDistance + (clampedEntrailDistance - smallestIntervalNm));
+    // do not allow prespawned aircraft to have a spacing less than `minimumInTrailNm`
+    const largestIntervalNm = Math.max(clampedEntrailDistance, clampedEntrailDistance
+        + (clampedEntrailDistance - smallestIntervalNm));
 
     // if requesting less than `smallestIntervalNm`, spawn all AT `entrailDistance`
     if (smallestIntervalNm > largestIntervalNm) {
         smallestIntervalNm = largestIntervalNm;
     }
-    
+
     const spawnOffsets = [offsetClosestToAirspace];
     let distanceAlongRoute = offsetClosestToAirspace;
 

--- a/src/assets/scripts/client/trafficGenerator/buildPreSpawnAircraft.js
+++ b/src/assets/scripts/client/trafficGenerator/buildPreSpawnAircraft.js
@@ -255,8 +255,8 @@ const _assembleSpawnOffsets = (entrailDistance, totalDistance = 0) => {
     const clampedEntrailDistance = Math.max(10, entrailDistance);
     let smallestIntervalNm = 15;
     // do not allow prespawned aircraft to have a spacing less than `minimumInTrailNm`
-    const largestIntervalNm = Math.max(clampedEntrailDistance, clampedEntrailDistance
-        + (clampedEntrailDistance - smallestIntervalNm));
+    const largestIntervalNm = Math.max(clampedEntrailDistance, clampedEntrailDistance +
+        (clampedEntrailDistance - smallestIntervalNm));
 
     // if requesting less than `smallestIntervalNm`, spawn all AT `entrailDistance`
     if (smallestIntervalNm > largestIntervalNm) {

--- a/src/assets/scripts/client/trafficGenerator/buildPreSpawnAircraft.js
+++ b/src/assets/scripts/client/trafficGenerator/buildPreSpawnAircraft.js
@@ -11,6 +11,7 @@ import { nm } from '../utilities/unitConverters';
 import { isEmptyOrNotObject } from '../utilities/validatorUtilities';
 import { distance2d } from '../math/distance';
 import { ENVIRONMENT } from '../constants/environmentConstants';
+import { avg } from '../math/core';
 
 /**
  * Return an array whose indices directly mirror those of `waypointModelList`, except it
@@ -357,8 +358,9 @@ const _preSpawn = (spawnPatternJson, airport) => {
     const airspaceCeiling = airport.maxAssignableAltitude;
     const spawnSpeed = spawnPatternJson.speed;
     const spawnAltitude = spawnPatternJson.altitude;
+    const spawnAvgAltitude = Array.isArray(spawnAltitude) ? avg(spawnAltitude) : spawnAltitude;
     // convert IAS to TAS for better estimate
-    const trueAirspeedIncreaseFactor = spawnAltitude * ENVIRONMENT.DENSITY_ALT_INCREASE_FACTOR_PER_FT;
+    const trueAirspeedIncreaseFactor = spawnAvgAltitude * ENVIRONMENT.DENSITY_ALT_INCREASE_FACTOR_PER_FT;
     const spawnEstTrueAirspeed = spawnSpeed * (1 + trueAirspeedIncreaseFactor);
     // distance between each arriving aircraft, in nm.
     const entrailDistance = spawnEstTrueAirspeed / spawnRate;

--- a/src/assets/scripts/client/trafficGenerator/buildPreSpawnAircraft.js
+++ b/src/assets/scripts/client/trafficGenerator/buildPreSpawnAircraft.js
@@ -251,12 +251,16 @@ function _calculateSpawnPositionsAndAltitudes(
  */
 const _assembleSpawnOffsets = (entrailDistance, totalDistance = 0) => {
     const offsetClosestToAirspace = totalDistance - 3;
-    // dont spawn aircraft closer than 10 MIT
-    const clampedEntrailDistance = Math.max(10, entrailDistance);
+    // dont spawn aircraft closer than 6 MIT
+    const clampedEntrailDistance = Math.max(6, entrailDistance);
     let smallestIntervalNm = 15;
     // do not allow prespawned aircraft to have a spacing less than `minimumInTrailNm`
     const largestIntervalNm = Math.max(clampedEntrailDistance, clampedEntrailDistance +
         (clampedEntrailDistance - smallestIntervalNm));
+
+    if (clampedEntrailDistance < 8) {
+        console.error(`Too many aircraft requested, calculated MIT is ${entrailDistance}, limiting MIT to ${clampedEntrailDistance}`);
+    }
 
     // if requesting less than `smallestIntervalNm`, spawn all AT `entrailDistance`
     if (smallestIntervalNm > largestIntervalNm) {

--- a/src/assets/scripts/client/trafficGenerator/buildPreSpawnAircraft.js
+++ b/src/assets/scripts/client/trafficGenerator/buildPreSpawnAircraft.js
@@ -334,17 +334,23 @@ const _calculateTotalDistanceAlongRoute = (waypointModelList, airport) => {
  * `AircraftModel` along a route.
  *
  * @function _preSpawn
- * @param spawnPatternJson {object}
+ * @param spawnPatternJson {object|SpawnPatternModel}
  * @param airport {AirportModel}
  * @return {array<object>}
  */
 const _preSpawn = (spawnPatternJson, airport) => {
-    // distance between each arriving aircraft, in nm
+    const spawnRate = spawnPatternJson.rate;
+
+    if(spawnRate == 0) {
+        return [];
+    }
+
     const airspaceCeiling = airport.maxAssignableAltitude;
     const spawnSpeed = spawnPatternJson.speed;
     const spawnAltitude = spawnPatternJson.altitude;
-    const entrailDistance = spawnSpeed / spawnPatternJson.rate;
-    const routeModel = new RouteModel(spawnPatternJson.route);
+    // distance between each arriving aircraft, in nm
+    const entrailDistance = spawnSpeed / spawnRate;
+    const routeModel = spawnPatternJson._routeModel ? spawnPatternJson._routeModel : new RouteModel(spawnPatternJson.route);
     const waypointModelList = routeModel.waypoints;
     const totalDistance = _calculateTotalDistanceAlongRoute(waypointModelList, airport);
     // calculate number of offsets
@@ -374,7 +380,7 @@ const _preSpawn = (spawnPatternJson, airport) => {
  * for their first arrival aircraft.
  *
  * @function buildPreSpawnAircraft
- * @param spawnPatternJson {object}
+ * @param spawnPatternJson {object|SpawnPatternModel}
  * @param currentAirport {AirportModel}
  * @return {array<object>}
  */

--- a/src/assets/scripts/client/trafficGenerator/buildPreSpawnAircraft.js
+++ b/src/assets/scripts/client/trafficGenerator/buildPreSpawnAircraft.js
@@ -341,7 +341,7 @@ const _calculateTotalDistanceAlongRoute = (waypointModelList, airport) => {
 const _preSpawn = (spawnPatternJson, airport) => {
     const spawnRate = spawnPatternJson.rate;
 
-    if (spawnRate == 0) {
+    if (spawnRate === 0) {
         return [];
     }
 

--- a/src/assets/scripts/client/trafficGenerator/buildPreSpawnAircraft.js
+++ b/src/assets/scripts/client/trafficGenerator/buildPreSpawnAircraft.js
@@ -341,7 +341,7 @@ const _calculateTotalDistanceAlongRoute = (waypointModelList, airport) => {
 const _preSpawn = (spawnPatternJson, airport) => {
     const spawnRate = spawnPatternJson.rate;
 
-    if (spawnRate === 0) {
+    if (spawnRate <= 0) {
         return [];
     }
 

--- a/src/assets/scripts/client/ui/TrafficRateController.js
+++ b/src/assets/scripts/client/ui/TrafficRateController.js
@@ -102,7 +102,8 @@ export default class TrafficRateController {
 
         this._buildDialogBody();
         this.$element.append(this.$dialog);
-        this.$dialog.find('#reset-button').click(this._onFormReset)
+        this.$dialog.find('#reset-button').click(this._onFormReset);
+        this.$dialog.find('#restart-button').click(this._onTrafficReset);
 
         return this;
     }
@@ -121,6 +122,7 @@ export default class TrafficRateController {
         this._onChangeWindDirection = this.onChangeWindDirection.bind(this);
         this._onChangeWindSpeed = this.onChangeWindSpeed.bind(this);
         this._onFormReset = this.onFormReset.bind(this);
+        this._onTrafficReset = this.onTrafficReset.bind(this);
 
         return this;
     }
@@ -186,7 +188,7 @@ export default class TrafficRateController {
      * Resets the traffic dialog and spawn rates to default values
      *
      * @for TrafficRateController
-     * @method onRateReset
+     * @method onFormReset
      */
     onFormReset() {
         const airport = AirportController.airport_get();
@@ -197,6 +199,16 @@ export default class TrafficRateController {
             spawnPattern.resetRate();
         });
         this._buildDialogBody();
+    }
+
+    /**
+     * Resets the generated traffic using the current traffic values
+     *
+     * @for TrafficRateController
+     * @method onTrafficReset
+     */
+    onTrafficReset() {
+        this._eventBus.trigger(EVENT.TRAFFIC_RESET);
     }
 
     /**

--- a/src/assets/scripts/client/ui/TrafficRateController.js
+++ b/src/assets/scripts/client/ui/TrafficRateController.js
@@ -22,8 +22,8 @@ const UI_TRAFFIC_MODAL_TEMPLATE = `
         <p class="dialog-title">Traffic rate</p>
         <div class="dialog-body nice-scrollbar"></div>
         <div class="dialog-footer form-element">
-            <button id="reset-button" class="button">Default</button>
-            <button id="restart-button" class="button">Restart</button>
+            <button id="reset-button" class="js-trafficDefaultButton button">Default</button>
+            <button id="restart-button" class="js-trafficRestartButton button">Restart</button>
         </div>
     </div>`;
 
@@ -102,8 +102,8 @@ export default class TrafficRateController {
 
         this._buildDialogBody();
         this.$element.append(this.$dialog);
-        this.$dialog.find('#reset-button').click(this._onFormResetHandler);
-        this.$dialog.find('#restart-button').click(this._onTrafficResetHandler);
+        this.$dialog.find(SELECTORS.DOM_SELECTORS.TRAFFIC_DEFAULT_BUTTON).click(this._onFormResetHandler);
+        this.$dialog.find(SELECTORS.DOM_SELECTORS.TRAFFIC_RESTART_BUTTON).click(this._onTrafficResetHandler);
 
         return this;
     }

--- a/src/assets/scripts/client/ui/TrafficRateController.js
+++ b/src/assets/scripts/client/ui/TrafficRateController.js
@@ -21,6 +21,10 @@ const UI_TRAFFIC_MODAL_TEMPLATE = `
     <div class="traffic-dialog dialog notSelectable">
         <p class="dialog-title">Traffic rate</p>
         <div class="dialog-body nice-scrollbar"></div>
+        <div class="dialog-footer form-element">
+            <button id="reset-button" class="button">Default</button>
+            <button id="restart-button" class="button">Restart</button>
+        </div>
     </div>`;
 
 /**
@@ -98,6 +102,7 @@ export default class TrafficRateController {
 
         this._buildDialogBody();
         this.$element.append(this.$dialog);
+        this.$dialog.find('#reset-button').click(this._onFormReset)
 
         return this;
     }
@@ -115,6 +120,7 @@ export default class TrafficRateController {
         this._onAirportChangeHandler = this.onAirportChange.bind(this);
         this._onChangeWindDirection = this.onChangeWindDirection.bind(this);
         this._onChangeWindSpeed = this.onChangeWindSpeed.bind(this);
+        this._onFormReset = this.onFormReset.bind(this);
 
         return this;
     }
@@ -177,6 +183,23 @@ export default class TrafficRateController {
     }
 
     /**
+     * Resets the traffic dialog and spawn rates to default values
+     *
+     * @for TrafficRateController
+     * @method onRateReset
+     */
+    onFormReset() {
+        const airport = AirportController.airport_get();
+        this._wind = { speed: airport.defaultWind.speed, angle: Math.round(radiansToDegrees(airport.defaultWind.angle)) };
+
+        this._eventBus.trigger(EVENT.WIND_CHANGE, this._wind);
+        _forEach(SpawnPatternCollection.spawnPatternModels, (spawnPattern) => {
+            spawnPattern.resetRate();
+        });
+        this._buildDialogBody();
+    }
+
+    /**
      * Builds the dialog body
      *
      * @for TrafficRateController
@@ -227,7 +250,7 @@ export default class TrafficRateController {
      * Build form element
      *
      * @for TrafficRateController
-     * @method _buildFormElement
+     * @method _buildSlider
      * @param key {string}
      * @param data {string|object} passed to the change handler
      * @param onChangeMethod {function}

--- a/src/assets/scripts/client/ui/TrafficRateController.js
+++ b/src/assets/scripts/client/ui/TrafficRateController.js
@@ -102,8 +102,8 @@ export default class TrafficRateController {
 
         this._buildDialogBody();
         this.$element.append(this.$dialog);
-        this.$dialog.find('#reset-button').click(this._onFormReset);
-        this.$dialog.find('#restart-button').click(this._onTrafficReset);
+        this.$dialog.find('#reset-button').click(this._onFormResetHandler);
+        this.$dialog.find('#restart-button').click(this._onTrafficResetHandler);
 
         return this;
     }
@@ -119,10 +119,10 @@ export default class TrafficRateController {
      */
     _setupHandlers() {
         this._onAirportChangeHandler = this.onAirportChange.bind(this);
-        this._onChangeWindDirection = this.onChangeWindDirection.bind(this);
-        this._onChangeWindSpeed = this.onChangeWindSpeed.bind(this);
-        this._onFormReset = this.onFormReset.bind(this);
-        this._onTrafficReset = this.onTrafficReset.bind(this);
+        this._onChangeWindDirectionHandler = this.onChangeWindDirection.bind(this);
+        this._onChangeWindSpeedHandler = this.onChangeWindSpeed.bind(this);
+        this._onFormResetHandler = this.onFormReset.bind(this);
+        this._onTrafficResetHandler = this.onTrafficReset.bind(this);
 
         return this;
     }
@@ -195,9 +195,7 @@ export default class TrafficRateController {
         this._wind = { speed: airport.defaultWind.speed, angle: Math.round(radiansToDegrees(airport.defaultWind.angle)) };
 
         this._eventBus.trigger(EVENT.WIND_CHANGE, this._wind);
-        _forEach(SpawnPatternCollection.spawnPatternModels, (spawnPattern) => {
-            spawnPattern.resetRate();
-        });
+        SpawnPatternCollection.resetRates();
         this._buildDialogBody();
     }
 
@@ -302,7 +300,7 @@ export default class TrafficRateController {
             </div>`;
         const $element = $(template);
 
-        $element.on('change', this._onChangeWindDirection);
+        $element.on('change', this._onChangeWindDirectionHandler);
 
         return $element;
     }
@@ -327,7 +325,7 @@ export default class TrafficRateController {
             </div>`;
         const $element = $(template);
 
-        $element.on('change', this._onChangeWindSpeed);
+        $element.on('change', this._onChangeWindSpeedHandler);
 
         return $element;
     }

--- a/src/assets/style/module/dialog/_dialog.less
+++ b/src/assets/style/module/dialog/_dialog.less
@@ -84,6 +84,13 @@
     flex-grow: 1;
 }
 
+.form-element button {
+    display: block;
+    flex-grow: 1;
+    margin-left: 5px;
+    margin-right: 5px;
+}
+
 .form-element + .form-element {
     margin-top: 2px;
 }

--- a/src/assets/style/module/dialog/_dialog.less
+++ b/src/assets/style/module/dialog/_dialog.less
@@ -84,7 +84,7 @@
     flex-grow: 1;
 }
 
-.form-element button {
+.form-element .button {
     display: block;
     flex-grow: 1;
     margin-left: 5px;

--- a/test/airport/AirportModel.spec.js
+++ b/test/airport/AirportModel.spec.js
@@ -185,3 +185,26 @@ ava.skip('.removeAircraftFromAllRunwayQueues()', (t) => {
 
     t.true(removeAircraftFromAllRunwayQueuesSpy.calledOnce);
 });
+
+ava('.resetAllRunwayQueues() calls .resetQueue() for all runways', (t) => {
+    const model = new AirportModel(AIRPORT_JSON_KLAS_MOCK);
+    const resetQueueSpy07L = sinon.spy(model._runwayCollection.findRunwayModelByName('07L'), 'resetQueue');
+    const resetQueueSpy25R = sinon.spy(model._runwayCollection.findRunwayModelByName('25R'), 'resetQueue');
+    const resetQueueSpy07R = sinon.spy(model._runwayCollection.findRunwayModelByName('07R'), 'resetQueue');
+    const resetQueueSpy25L = sinon.spy(model._runwayCollection.findRunwayModelByName('25L'), 'resetQueue');
+    const resetQueueSpy01L = sinon.spy(model._runwayCollection.findRunwayModelByName('01L'), 'resetQueue');
+    const resetQueueSpy19R = sinon.spy(model._runwayCollection.findRunwayModelByName('19R'), 'resetQueue');
+    const resetQueueSpy01R = sinon.spy(model._runwayCollection.findRunwayModelByName('01R'), 'resetQueue');
+    const resetQueueSpy19L = sinon.spy(model._runwayCollection.findRunwayModelByName('19L'), 'resetQueue');
+
+    model.resetAllRunwayQueues();
+
+    t.true(resetQueueSpy07L.calledWithExactly());
+    t.true(resetQueueSpy25R.calledWithExactly());
+    t.true(resetQueueSpy07R.calledWithExactly());
+    t.true(resetQueueSpy25L.calledWithExactly());
+    t.true(resetQueueSpy01L.calledWithExactly());
+    t.true(resetQueueSpy19R.calledWithExactly());
+    t.true(resetQueueSpy01R.calledWithExactly());
+    t.true(resetQueueSpy19L.calledWithExactly());
+});

--- a/test/airport/runway/RunwayModel.spec.js
+++ b/test/airport/runway/RunwayModel.spec.js
@@ -131,3 +131,14 @@ ava('.removeAircraftFromQueue() removes an aircraft#id from the queue', (t) => {
     t.true(model.queue.length === 3);
     t.true(model.queue.indexOf(aircraftIdMock) === -1);
 });
+
+ava('.resetQueue() removes all aircraft from the queue and clears #lastDepartedAircraftModel', (t) => {
+    const model = new RunwayModel(runway07L25R, 0, airportPositionFixtureKLAS);
+    model.queue = ['aircraft1', 'aircraft2', 'aircraft3'];
+    model.lastDepartedAircraftModel = { callsign: 'aircraft2' };
+
+    model.resetQueue();
+
+    t.true(model.queue.length === 0);
+    t.true(model.lastDepartedAircraftModel === null);
+});


### PR DESCRIPTION
Resolves #1345 

The purpose of this pull request is to add two buttons to the traffic dialog. 1 to reset the traffic settings to the "default" config in the airport file. Another to reset\restart the generated traffic based on the new settings in the dialog.
