### PR TITLE
bugfix/1900 - Raise descent rate of all jets to at least 3000fpm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - <a href="https://github.com/openscope/openscope/issues/1870" target="_blank">#1870</a> - Add Nashville Int'l (KEWR)
 
 ### Bugfixes
+- <a href="https://github.com/openscope/openscope/issues/1900" target="_blank">#1900</a> - Raise descent rates of all jets to at least 3000fpm
 
 ### Enhancements & Refactors
 - <a href="https://github.com/openscope/openscope/issues/1782" target="_blank">#1782</a> - Update UAE airline

--- a/assets/aircraft/a124.json
+++ b/assets/aircraft/a124.json
@@ -14,7 +14,7 @@
     "ceiling": 40000,
     "rate": {
         "climb":      1200,
-        "descent":    2000,
+        "descent":    3000,
         "accelerate": 4,
         "decelerate": 2
     },

--- a/assets/aircraft/a306.json
+++ b/assets/aircraft/a306.json
@@ -14,7 +14,7 @@
     "ceiling": 41000,
     "rate": {
         "climb":      3200,
-        "descent":    2000,
+        "descent":    3000,
         "accelerate": 8,
         "decelerate": 4
     },

--- a/assets/aircraft/a30b.json
+++ b/assets/aircraft/a30b.json
@@ -14,7 +14,7 @@
     "ceiling": 41000,
     "rate": {
         "climb":      3200,
-        "descent":    2000,
+        "descent":    3000,
         "accelerate": 8,
         "decelerate": 4
     },

--- a/assets/aircraft/a310.json
+++ b/assets/aircraft/a310.json
@@ -14,7 +14,7 @@
     "ceiling": 41000,
     "rate": {
         "climb":      3000,
-        "descent":    2000,
+        "descent":    3000,
         "accelerate": 4,
         "decelerate": 3
     },

--- a/assets/aircraft/a321.json
+++ b/assets/aircraft/a321.json
@@ -14,7 +14,7 @@
     "ceiling": 43000,
     "rate": {
         "climb":      2500,
-        "descent":    2500,
+        "descent":    3000,
         "accelerate": 6,
         "decelerate": 4
     },

--- a/assets/aircraft/a343.json
+++ b/assets/aircraft/a343.json
@@ -14,7 +14,7 @@
     "ceiling": 41000,
     "rate": {
         "climb":      1500,
-        "descent":    2000,
+        "descent":    3000,
         "accelerate": 4,
         "decelerate": 3
     },

--- a/assets/aircraft/a345.json
+++ b/assets/aircraft/a345.json
@@ -14,7 +14,7 @@
     "ceiling": 41000,
     "rate": {
         "climb": 3500,
-        "descent": 2000,
+        "descent": 3000,
         "accelerate": 4,
         "decelerate": 3
     },

--- a/assets/aircraft/a346.json
+++ b/assets/aircraft/a346.json
@@ -14,7 +14,7 @@
     "ceiling": 41000,
     "rate": {
         "climb":      1500,
-        "descent":    2000,
+        "descent":    3000,
         "accelerate": 6,
         "decelerate": 4
     },

--- a/assets/aircraft/a35k.json
+++ b/assets/aircraft/a35k.json
@@ -14,7 +14,7 @@
     "ceiling": 41000,
     "rate": {
         "climb":      3500,
-        "descent":    2000,
+        "descent":    3000,
         "accelerate": 6,
         "decelerate": 4
     },

--- a/assets/aircraft/a388.json
+++ b/assets/aircraft/a388.json
@@ -14,7 +14,7 @@
     "ceiling": 43000,
     "rate": {
         "climb":      2500,
-        "descent":    2000,
+        "descent":    3000,
         "accelerate": 6,
         "decelerate": 4
     },

--- a/assets/aircraft/an72.json
+++ b/assets/aircraft/an72.json
@@ -14,7 +14,7 @@
     "ceiling": 35000,
     "rate": {
         "climb":      2500,
-        "descent":    1500,
+        "descent":    3000,
         "accelerate": 8,
         "decelerate": 4
     },

--- a/assets/aircraft/b743.json
+++ b/assets/aircraft/b743.json
@@ -14,7 +14,7 @@
     "ceiling": 45000,
     "rate": {
         "climb":      2000,
-        "descent":    2900,
+        "descent":    3000,
         "accelerate": 4,
         "decelerate": 2
     },

--- a/assets/aircraft/b762.json
+++ b/assets/aircraft/b762.json
@@ -14,7 +14,7 @@
     "ceiling": 41000,
     "rate": {
         "climb":      2500,
-        "descent":    2000,
+        "descent":    3000,
         "accelerate": 7,
         "decelerate": 4
     },

--- a/assets/aircraft/b788.json
+++ b/assets/aircraft/b788.json
@@ -14,7 +14,7 @@
     "ceiling": 43000,
     "rate": {
         "climb":      2700,
-        "descent":    2800,
+        "descent":    3000,
         "accelerate": 7,
         "decelerate": 4
     },

--- a/assets/aircraft/b789.json
+++ b/assets/aircraft/b789.json
@@ -14,7 +14,7 @@
     "ceiling": 43000,
     "rate": {
         "climb":      2700,
-        "descent":    2800,
+        "descent":    3000,
         "accelerate": 7,
         "decelerate": 4
     },

--- a/assets/aircraft/b78x.json
+++ b/assets/aircraft/b78x.json
@@ -14,7 +14,7 @@
     "ceiling": 43000,
     "rate": {
         "climb": 2700,
-        "descent": 2800,
+        "descent": 3000,
         "accelerate": 7,
         "decelerate": 4
     },

--- a/assets/aircraft/be40.json
+++ b/assets/aircraft/be40.json
@@ -14,7 +14,7 @@
     "ceiling": 45000,
     "rate": {
         "climb":      4020,
-        "descent":    2000,
+        "descent":    3000,
         "accelerate": 9,
         "decelerate": 3
     },

--- a/assets/aircraft/c510.json
+++ b/assets/aircraft/c510.json
@@ -14,7 +14,7 @@
     "ceiling": 41000,
     "rate": {
         "climb":      4000,
-        "descent":    2000,
+        "descent":    3000,
         "accelerate": 10,
         "decelerate": 5
     },

--- a/assets/aircraft/c750.json
+++ b/assets/aircraft/c750.json
@@ -14,7 +14,7 @@
     "ceiling": 51000,
     "rate": {
         "climb":      3500,
-        "descent":    2500,
+        "descent":    3000,
         "accelerate": 10,
         "decelerate": 5
     },

--- a/assets/aircraft/crjx.json
+++ b/assets/aircraft/crjx.json
@@ -14,7 +14,7 @@
     "ceiling": 41000,
     "rate": {
         "climb":      3000,
-        "descent":    2100,
+        "descent":    3000,
         "accelerate": 9,
         "decelerate": 5
     },

--- a/assets/aircraft/dc10.json
+++ b/assets/aircraft/dc10.json
@@ -14,7 +14,7 @@
     "ceiling": 41000,
     "rate": {
         "climb":      2000,
-        "descent":    1500,
+        "descent":    3000,
         "accelerate": 7,
         "decelerate": 4
     },

--- a/assets/aircraft/dc87.json
+++ b/assets/aircraft/dc87.json
@@ -14,7 +14,7 @@
     "ceiling": 41000,
     "rate": {
         "climb":      2200,
-        "descent":    2500,
+        "descent":    3000,
         "accelerate": 4,
         "decelerate": 2
     },

--- a/assets/aircraft/e135.json
+++ b/assets/aircraft/e135.json
@@ -14,7 +14,7 @@
     "ceiling": 37000,
     "rate": {
         "climb":      3500,
-        "descent":    1500,
+        "descent":    3000,
         "accelerate": 10,
         "decelerate": 6
     },

--- a/assets/aircraft/e145.json
+++ b/assets/aircraft/e145.json
@@ -14,7 +14,7 @@
     "ceiling": 37000,
     "rate": {
         "climb":      2500,
-        "descent":    2500,
+        "descent":    3000,
         "accelerate": 10,
         "decelerate": 6
     },

--- a/assets/aircraft/e170.json
+++ b/assets/aircraft/e170.json
@@ -14,7 +14,7 @@
     "ceiling": 41000,
     "rate": {
         "climb":      3400,
-        "descent":    2600,
+        "descent":    3000,
         "accelerate": 7,
         "decelerate": 4
     },

--- a/assets/aircraft/e190.json
+++ b/assets/aircraft/e190.json
@@ -14,7 +14,7 @@
     "ceiling": 41000,
     "rate": {
         "climb":      3400,
-        "descent":    2200,
+        "descent":    3000,
         "accelerate": 7,
         "decelerate": 4
     },

--- a/assets/aircraft/e290.json
+++ b/assets/aircraft/e290.json
@@ -14,7 +14,7 @@
     "ceiling": 41000,
     "rate": {
         "climb":      3400,
-        "descent":    2200,
+        "descent":    3000,
         "accelerate": 7,
         "decelerate": 4
     },

--- a/assets/aircraft/e35l.json
+++ b/assets/aircraft/e35l.json
@@ -14,7 +14,7 @@
     "ceiling": 37000,
     "rate": {
         "climb":      3500,
-        "descent":    1500,
+        "descent":    3000,
         "accelerate": 10,
         "decelerate": 6
     },

--- a/assets/aircraft/e50p.json
+++ b/assets/aircraft/e50p.json
@@ -14,7 +14,7 @@
     "ceiling": 41000,
     "rate": {
         "climb":      3500,
-        "descent":    2500,
+        "descent":    3000,
         "accelerate": 10,
         "decelerate": 5
     },

--- a/assets/aircraft/e545.json
+++ b/assets/aircraft/e545.json
@@ -14,7 +14,7 @@
     "ceiling": 37000,
     "rate": {
         "climb":      1500,
-        "descent":    1500,
+        "descent":    3000,
         "accelerate": 10,
         "decelerate": 6
     },

--- a/assets/aircraft/e550.json
+++ b/assets/aircraft/e550.json
@@ -14,7 +14,7 @@
     "ceiling": 45000,
     "rate": {
         "climb":      1500,
-        "descent":    1500,
+        "descent":    3000,
         "accelerate": 10,
         "decelerate": 6
     },

--- a/assets/aircraft/e55p.json
+++ b/assets/aircraft/e55p.json
@@ -14,7 +14,7 @@
     "ceiling": 45000,
     "rate": {
         "climb":      4000,
-        "descent":    2500,
+        "descent":    3000,
         "accelerate": 10,
         "decelerate": 5
     },

--- a/assets/aircraft/e75l.json
+++ b/assets/aircraft/e75l.json
@@ -14,7 +14,7 @@
     "ceiling": 41000,
     "rate": {
         "climb":      3400,
-        "descent":    2600,
+        "descent":    3000,
         "accelerate": 7,
         "decelerate": 4
     },

--- a/assets/aircraft/e75s.json
+++ b/assets/aircraft/e75s.json
@@ -14,7 +14,7 @@
     "ceiling": 41000,
     "rate": {
         "climb":      3400,
-        "descent":    2600,
+        "descent":    3000,
         "accelerate": 7,
         "decelerate": 4
     },

--- a/assets/aircraft/gl5t.json
+++ b/assets/aircraft/gl5t.json
@@ -14,7 +14,7 @@
     "ceiling": 51000,
     "rate": {
         "climb": 3000,
-        "descent": 2300,
+        "descent": 3000,
         "accelerate": 6,
         "decelerate": 5
     },

--- a/assets/aircraft/glf4.json
+++ b/assets/aircraft/glf4.json
@@ -14,7 +14,7 @@
     "ceiling": 45000,
     "rate": {
         "climb": 4000,
-        "descent": 2500,
+        "descent": 3000,
         "accelerate": 6,
         "decelerate": 5
     },

--- a/assets/aircraft/glf5.json
+++ b/assets/aircraft/glf5.json
@@ -14,7 +14,7 @@
     "ceiling": 51000,
     "rate": {
         "climb": 4000,
-        "descent": 2500,
+        "descent": 3000,
         "accelerate": 6,
         "decelerate": 5
     },

--- a/assets/aircraft/h25b.json
+++ b/assets/aircraft/h25b.json
@@ -14,7 +14,7 @@
     "ceiling": 41000,
     "rate": {
         "climb": 3000,
-        "descent": 2500,
+        "descent": 3000,
         "accelerate": 4,
         "decelerate": 4
     },

--- a/assets/aircraft/hdjt.json
+++ b/assets/aircraft/hdjt.json
@@ -14,7 +14,7 @@
     "ceiling": 41000,
     "rate": {
         "climb":      2500,
-        "descent":    2000,
+        "descent":    3000,
         "accelerate": 4,
         "decelerate": 3
     },

--- a/assets/aircraft/il62.json
+++ b/assets/aircraft/il62.json
@@ -14,7 +14,7 @@
     "ceiling": 39000,
     "rate": {
         "climb":      1000,
-        "descent":    1500,
+        "descent":    3000,
         "accelerate": 6,
         "decelerate": 3
     },

--- a/assets/aircraft/il76.json
+++ b/assets/aircraft/il76.json
@@ -14,7 +14,7 @@
     "ceiling": 39500,
     "rate": {
         "climb":      1000,
-        "descent":    1500,
+        "descent":    3000,
         "accelerate": 5,
         "decelerate": 2
     },

--- a/assets/aircraft/il96.json
+++ b/assets/aircraft/il96.json
@@ -14,7 +14,7 @@
     "ceiling": 41000,
     "rate": {
         "climb":      2000,
-        "descent":    2500,
+        "descent":    3000,
         "accelerate": 5,
         "decelerate": 2
     },

--- a/assets/aircraft/j328.json
+++ b/assets/aircraft/j328.json
@@ -14,7 +14,7 @@
     "ceiling": 35000,
     "rate": {
         "climb":      2500,
-        "descent":    2500,
+        "descent":    3000,
         "accelerate": 10,
         "decelerate": 6
     },

--- a/assets/aircraft/l101.json
+++ b/assets/aircraft/l101.json
@@ -14,7 +14,7 @@
     "ceiling": 41000,
     "rate": {
         "climb":      2000,
-        "descent":    2500,
+        "descent":    3000,
         "accelerate": 7,
         "decelerate": 5
     },

--- a/assets/aircraft/lj40.json
+++ b/assets/aircraft/lj40.json
@@ -14,7 +14,7 @@
     "ceiling": 51000,
     "rate": {
         "climb":      2820,
-        "descent":    2200,
+        "descent":    3000,
         "accelerate": 10,
         "decelerate": 5
     },

--- a/assets/aircraft/lj45.json
+++ b/assets/aircraft/lj45.json
@@ -14,7 +14,7 @@
     "ceiling": 51000,
     "rate": {
         "climb":      2820,
-        "descent":    2200,
+        "descent":    3000,
         "accelerate": 10,
         "decelerate": 5
     },

--- a/assets/aircraft/lj60.json
+++ b/assets/aircraft/lj60.json
@@ -14,7 +14,7 @@
     "ceiling": 51000,
     "rate": {
         "climb":      4500,
-        "descent":    2500,
+        "descent":    3000,
         "accelerate": 10,
         "decelerate": 5
     },

--- a/assets/aircraft/lj75.json
+++ b/assets/aircraft/lj75.json
@@ -14,7 +14,7 @@
     "ceiling": 51000,
     "rate": {
         "climb":      4000,
-        "descent":    2500,
+        "descent":    3000,
         "accelerate": 10,
         "decelerate": 5
     },

--- a/assets/aircraft/md81.json
+++ b/assets/aircraft/md81.json
@@ -14,7 +14,7 @@
     "ceiling": 37000,
     "rate": {
         "climb":      3000,
-        "descent":    2300,
+        "descent":    3000,
         "accelerate": 7,
         "decelerate": 5
     },

--- a/assets/aircraft/md82.json
+++ b/assets/aircraft/md82.json
@@ -14,7 +14,7 @@
     "ceiling": 37000,
     "rate": {
         "climb":      2800,
-        "descent":    1500,
+        "descent":    3000,
         "accelerate": 7,
         "decelerate": 5
     },

--- a/assets/aircraft/md83.json
+++ b/assets/aircraft/md83.json
@@ -14,7 +14,7 @@
     "ceiling": 37000,
     "rate": {
         "climb":      2800,
-        "descent":    1500,
+        "descent":    3000,
         "accelerate": 7,
         "decelerate": 3
     },

--- a/assets/aircraft/md88.json
+++ b/assets/aircraft/md88.json
@@ -14,7 +14,7 @@
     "ceiling": 37000,
     "rate": {
         "climb":      2800,
-        "descent":    2300,
+        "descent":    3000,
         "accelerate": 7,
         "decelerate": 5
     },

--- a/assets/aircraft/su9.json
+++ b/assets/aircraft/su9.json
@@ -14,7 +14,7 @@
     "ceiling": 41000,
     "rate": {
         "climb":      1800,
-        "descent":    1800,
+        "descent":    3000,
         "accelerate": 7,
         "decelerate": 4
     },

--- a/assets/aircraft/su95.json
+++ b/assets/aircraft/su95.json
@@ -14,7 +14,7 @@
     "ceiling": 40000,
     "rate": {
         "climb":      2500,
-        "descent":    2800,
+        "descent":    3000,
         "accelerate": 4,
         "decelerate": 4
     },


### PR DESCRIPTION
Resolves #1900.

Should fix issues of aircraft like E135 being unable to meet their crossing restrictions because they are limited to 1500fpm in the descent (source from [EuroControl Aircraft Performance Database](https://contentzone.eurocontrol.int/aircraftperformance/details.aspx?ICAO=E135&ICAOFilter=e135), which is far too low).

Any aircraft with descent rates of less than 3000fpm were increased to 3000--- no others were changed.