### PR TITLE
documentation/1754 - Add distance measurement tool to docs

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -1,0 +1,93 @@
+daemon off;
+worker_processes auto;
+
+events {
+  use epoll;
+  accept_mutex on;
+  worker_connections 512;
+}
+
+http {
+  gzip on;
+  gzip_comp_level 6;
+  gzip_min_length 512;
+  gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+  gzip_vary on;
+  gzip_proxied any;
+
+  server_tokens off;
+
+
+  access_log logs/access.log;
+
+
+
+  error_log stderr error;
+
+
+  include mime.types;
+  default_type application/octet-stream;
+  sendfile on;
+
+  #Must read the body in 5 seconds.
+  client_body_timeout 5;
+
+  server {
+    listen 10273 reuseport;
+    charset UTF-8;
+    port_in_redirect off;
+    keepalive_timeout 5;
+    root public;
+
+
+
+
+
+    mruby_post_read_handler /app/bin/config/lib/ngx_mruby/headers.rb cache;
+
+    location / {
+      mruby_set $fallback /app/bin/config/lib/ngx_mruby/routes_fallback.rb cache;
+
+      try_files $uri $uri/ $fallback;
+
+    }
+
+
+
+
+
+
+
+
+    location ~ ^/assets/[^/]*$ {
+      set $route /assets/[^/]*;
+      mruby_set $path /app/bin/config/lib/ngx_mruby/routes_path.rb cache;
+      mruby_set $fallback /app/bin/config/lib/ngx_mruby/routes_fallback.rb cache;
+
+      try_files $uri $path $fallback;
+
+    }
+
+    location ~ ^/.*$ {
+      set $route /.*;
+      mruby_set $path /app/bin/config/lib/ngx_mruby/routes_path.rb cache;
+      mruby_set $fallback /app/bin/config/lib/ngx_mruby/routes_fallback.rb cache;
+
+      try_files $uri $path $fallback;
+
+    }
+
+
+  # need this b/c setting $fallback to =404 will try #{root}=404 instead of returning a 404
+  location @404 {
+    return 404;
+  }
+
+  # fallback proxy named match
+
+
+  # fallback redirects named match
+
+
+  }
+}

--- a/documentation/scope-commands.md
+++ b/documentation/scope-commands.md
@@ -98,3 +98,16 @@ _Shortcut -_ `[F7] [callsign]` or `[F7] [radius] [callsign]`
 _Description -_ This toggles a circle around the center of the radar target, with a radius you can specify in the command. If the radius is not specified, the default halo size will be used (generally 3nm for terminal, or 5nm for en route).
 
 _More Info -_ Note that if a resized halo exists, entering `[F7] [callsign]` will actually be interpreted by the system as `[F7] 3 [callsign]`-- meaning the halo will be resized to 3nm, not removed. With the halo back to 3nm, entering `[F7] [callsign]` again will remove the halo. If you add a 10nm halo with `[F7] 10 [callsign]`, it can be removed instead of resized by specifying `[F7] 10 [callsign]`, or use the above method of entering `[F7] [callsign]` twice.
+
+### Range/Bearing Measurement Tool
+
+_Syntax -_ N/A
+
+_Shortcut -_ N/A
+
+_Description -_ To easily determine the heading/distance between two points/fixes/aircraft, simply hold the \"Ctrl\" button and left click two points. Pressing Shift+Ctrl will cause the click to snap to the nearest aircraft or fix. If snapped to an aircraft, a time will also be displayed, based on the aircraft's current speed. To clear all range/bearing lines, press the ESC key.
+
+_More Info -_ If the measurement starts with an aircraft, the setting in "Settings" -> "Measure path style" affects the way the distance is calculated:
+- **Straight lines only**: The direct bearing and distance between the aircraft the the referenced point/fix/aircraft (e.g. as if the aircraft _instantly_ turned in the measured direction).
+- **Arc to next fix, then straight**: A simulated line, as though the aircraft continued to its next assigned fix, _and then_ turned to the measured point/fix/aircraft.
+- **All Lines Arced**: A simulted line, as though the aircraft turned towared the measured point/fix/aircraft at a standard turn rate, at its current speed.


### PR DESCRIPTION
Resolves #1754 

Adds range/bearing tool instruction to `scope-commands.md`.

All I did was copy-paste the instructions from the tutorial, and added a blurb about the relevant settings.
