### PR TITLE
Bugfix/2022 - "fly present heading" while still on ground

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ### New Features
 
 ### Bugfixes
-- <a href="https://github.com/openscope/openscope/issues/2022" target="_blank">#2022</a> - "Fly present heading" treated by departures as "fly runway heading" prior to take off; invalid while on apron and during taxi
+- <a href="https://github.com/openscope/openscope/issues/2022" target="_blank">#2022</a> - Improve handling of "fph" while still on ground
 
 ### Enhancements & Refactors
 - <a href="https://github.com/openscope/openscope/issues/1977" target="_blank">#1977</a> - Update scoring documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### New Features
 
 ### Bugfixes
+- <a href="https://github.com/openscope/openscope/issues/2022" target="_blank">#2022</a> - "Fly present heading" treated by departures as "fly runway heading" prior to take off; invalid while on apron and during taxi
 
 ### Enhancements & Refactors
 - <a href="https://github.com/openscope/openscope/issues/1977" target="_blank">#1977</a> - Update scoring documentation

--- a/assets/autocomplete/commandAutocompleteConfig.json
+++ b/assets/autocomplete/commandAutocompleteConfig.json
@@ -483,6 +483,9 @@
           "altkeys": [
             "fly present heading",
             "maintain heading",
+            "fly runway heading",
+            "maintain runway heading",
+            "runway heading",
             "straight ahead"
           ],
           "explain": "<b>f</b>ly <b>p</b>resent <b>h</b>eading"

--- a/documentation/aircraft-commands.md
+++ b/documentation/aircraft-commands.md
@@ -328,6 +328,12 @@ _Aliases -_ `fph`
 
 _Information -_ This command has the aircraft fly straight ahead, regardless of assigned routing. 
 
+For departure aircraft prior to take off, this command is interpreted as "fly
+runway heading". The aircraft will ignore any assigned routing and will instead
+maintain runway heading upon take off, until otherwise instructed.
+
+The command is invalid for aircraft that are at the gate, or still in the process of taxiing.
+
 _Syntax -_ `AAL123 fph`
 
 ### Heading

--- a/src/assets/scripts/client/aircraft/AircraftCommander.js
+++ b/src/assets/scripts/client/aircraft/AircraftCommander.js
@@ -411,6 +411,19 @@ export default class AircraftCommander {
      * @param aircraft {AircraftModel}
      */
     runFlyPresentHeading(aircraft) {
+        if (aircraft.flightPhase === FLIGHT_PHASE.APRON) {
+            return [false, 'we\'re still at the gate'];
+        }
+
+        if (aircraft.flightPhase === FLIGHT_PHASE.TAXI) {
+            const runway = aircraft.fms.departureRunwayModel;
+            const readback = {};
+            readback.log = `we're still taxiing to Runway ${runway.name}`;
+            readback.say = `we're still taxiing to Runway ${radio_runway(runway.name)}`;
+
+            return [false, readback];
+        }
+
         return aircraft.pilot.maintainPresentHeading(aircraft);
     }
 

--- a/src/assets/scripts/client/aircraft/Pilot/Pilot.js
+++ b/src/assets/scripts/client/aircraft/Pilot/Pilot.js
@@ -228,8 +228,8 @@ export default class Pilot {
 
         const readback = {};
         const runwayOrPresent = (
-                aircraftModel.flightPhase === FLIGHT_PHASE.WAITING || aircraftModel.flightPhase === FLIGHT_PHASE.TAKEOFF
-            ) ? 'runway' : 'present';
+            aircraftModel.flightPhase === FLIGHT_PHASE.WAITING || aircraftModel.flightPhase === FLIGHT_PHASE.TAKEOFF
+        ) ? 'runway' : 'present';
         readback.log = `fly ${runwayOrPresent} heading`;
         readback.say = `fly ${runwayOrPresent} heading`;
 

--- a/src/assets/scripts/client/aircraft/Pilot/Pilot.js
+++ b/src/assets/scripts/client/aircraft/Pilot/Pilot.js
@@ -227,8 +227,9 @@ export default class Pilot {
         this._mcp.setHeadingHold();
 
         const readback = {};
-        readback.log = 'fly present heading';
-        readback.say = 'fly present heading';
+        const runwayOrPresent = aircraftModel.flightPhase === FLIGHT_PHASE.WAITING ? 'runway' : 'present';
+        readback.log = `fly ${runwayOrPresent} heading`;
+        readback.say = `fly ${runwayOrPresent} heading`;
 
         return [true, readback];
     }

--- a/src/assets/scripts/client/aircraft/Pilot/Pilot.js
+++ b/src/assets/scripts/client/aircraft/Pilot/Pilot.js
@@ -227,7 +227,9 @@ export default class Pilot {
         this._mcp.setHeadingHold();
 
         const readback = {};
-        const runwayOrPresent = aircraftModel.flightPhase === FLIGHT_PHASE.WAITING ? 'runway' : 'present';
+        const runwayOrPresent = (
+                aircraftModel.flightPhase === FLIGHT_PHASE.WAITING || aircraftModel.flightPhase === FLIGHT_PHASE.TAKEOFF
+            ) ? 'runway' : 'present';
         readback.log = `fly ${runwayOrPresent} heading`;
         readback.say = `fly ${runwayOrPresent} heading`;
 

--- a/test/aircraft/Pilot/Pilot.spec.js
+++ b/test/aircraft/Pilot/Pilot.spec.js
@@ -16,6 +16,7 @@ import {
 } from '../../fixtures/aircraftFixtures';
 import { airportModelFixture } from '../../fixtures/airportFixtures';
 import { createNavigationLibraryFixture } from '../../fixtures/navigationLibraryFixtures';
+import { FLIGHT_PHASE } from '../../../src/assets/scripts/client/constants/aircraftConstants';
 import { INVALID_NUMBER } from '../../../src/assets/scripts/client/constants/globalConstants';
 
 // mocks
@@ -1126,7 +1127,7 @@ ava('.maintainPresentHeading() sets the #mcp with the correct modes and values',
     t.true(aircraftModel.pilot._mcp.heading === aircraftModel.heading);
 });
 
-ava('.maintainPresentHeading() returns a success message when finished', (t) => {
+ava('.maintainPresentHeading() returns a success message when finished (general case)', (t) => {
     const expectedResult = [
         true,
         {
@@ -1135,6 +1136,21 @@ ava('.maintainPresentHeading() returns a success message when finished', (t) => 
         }
     ];
     const aircraftModel = new AircraftModel(ARRIVAL_AIRCRAFT_INIT_PROPS_MOCK);
+    const result = aircraftModel.pilot.maintainPresentHeading(aircraftModel);
+
+    t.deepEqual(result, expectedResult);
+});
+
+ava('.maintainPresentHeading() returns a success message when finished (pre-departure)', (t) => {
+    const expectedResult = [
+        true,
+        {
+            log: 'fly runway heading',
+            say: 'fly runway heading'
+        }
+    ];
+    const aircraftModel = new AircraftModel(DEPARTURE_AIRCRAFT_INIT_PROPS_MOCK);
+    aircraftModel.setFlightPhase(FLIGHT_PHASE.WAITING);
     const result = aircraftModel.pilot.maintainPresentHeading(aircraftModel);
 
     t.deepEqual(result, expectedResult);

--- a/test/aircraft/Pilot/Pilot.spec.js
+++ b/test/aircraft/Pilot/Pilot.spec.js
@@ -1118,6 +1118,21 @@ ava('.maintainHeading() calls .cancelApproachClearance()', (t) => {
     t.true(cancelApproachClearanceSpy.called);
 });
 
+ava('.maintainPresentHeading() calls .cancelApproachClearance()', (t) => {
+    const approachTypeMock = 'ils';
+    const runwayModelMock = airportModelFixture.getRunway('19L');
+    const aircraftModel = new AircraftModel(ARRIVAL_AIRCRAFT_INIT_PROPS_MOCK);
+    const cancelApproachClearanceSpy = sinon.spy(aircraftModel.pilot, 'cancelApproachClearance');
+
+    aircraftModel.pilot.conductInstrumentApproach(aircraftModel, approachTypeMock, runwayModelMock);
+
+    t.true(aircraftModel.pilot.hasApproachClearance);
+
+    aircraftModel.pilot.maintainPresentHeading(aircraftModel);
+
+    t.true(cancelApproachClearanceSpy.called);
+});
+
 ava('.maintainPresentHeading() sets the #mcp with the correct modes and values', (t) => {
     const aircraftModel = new AircraftModel(ARRIVAL_AIRCRAFT_INIT_PROPS_MOCK);
 
@@ -1154,21 +1169,6 @@ ava('.maintainPresentHeading() returns a success message when finished (pre-depa
     const result = aircraftModel.pilot.maintainPresentHeading(aircraftModel);
 
     t.deepEqual(result, expectedResult);
-});
-
-ava('.maintainPresentHeading() calls .cancelApproachClearance()', (t) => {
-    const approachTypeMock = 'ils';
-    const runwayModelMock = airportModelFixture.getRunway('19L');
-    const aircraftModel = new AircraftModel(ARRIVAL_AIRCRAFT_INIT_PROPS_MOCK);
-    const cancelApproachClearanceSpy = sinon.spy(aircraftModel.pilot, 'cancelApproachClearance');
-
-    aircraftModel.pilot.conductInstrumentApproach(aircraftModel, approachTypeMock, runwayModelMock);
-
-    t.true(aircraftModel.pilot.hasApproachClearance);
-
-    aircraftModel.pilot.maintainPresentHeading(aircraftModel);
-
-    t.true(cancelApproachClearanceSpy.called);
 });
 
 ava('.maintainSpeed() sets the correct Mcp mode and value', (t) => {


### PR DESCRIPTION
Resolves #2022

The purpose of this pull request is to

- prevent nonsense outcomes to `fph` command for departing aircraft still on the ground
- treat `fph` as "fly runway heading" in appropriate context

#### todo list

- [x] reject `fph` when in phases `APRON` and `TAXI`
- [x] change readback to "fly runway heading" for `WAITING`
- [x] consider whether to change readback for `TAKEOFF`
- [x] update documentation
- [x] update tests
- [x] changelog