### PR TITLE
refactor/2026 - reorder checks for invalid conditions for issuing "takeoff"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bugfixes
 - <a href="https://github.com/openscope/openscope/issues/2022" target="_blank">#2022</a> - Improve handling of "fph" while still on ground
+- <a href="https://github.com/openscope/openscope/issues/2026" target="_blank">#2026</a> - Improve error messages from invalid takeoff commands
 
 ### Enhancements & Refactors
 - <a href="https://github.com/openscope/openscope/issues/1977" target="_blank">#1977</a> - Update scoring documentation

--- a/src/assets/scripts/client/aircraft/AircraftCommander.js
+++ b/src/assets/scripts/client/aircraft/AircraftCommander.js
@@ -681,10 +681,6 @@ export default class AircraftCommander {
         const roundedWindSpeed = round(wind.speed);
         const readback = {};
 
-        if (!isInQueue) {
-            return [false, 'unable to take off, we\'re not at any runway'];
-        }
-
         if (aircraft.isAirborne()) {
             return [false, 'unable to take off, we\'re already airborne'];
         }
@@ -702,6 +698,10 @@ export default class AircraftCommander {
 
         if (aircraft.flightPhase === FLIGHT_PHASE.TAKEOFF) {
             return [false, 'already taking off'];
+        }
+
+        if (!isInQueue) {
+            return [false, 'unable to take off, we\'re not at any runway'];
         }
 
         if (spotInQueue > 0) {


### PR DESCRIPTION
Resolves #2026

The purpose of this pull request is to change the order in which invalid conditions for issuing `takeoff` command are checked, so that more specific and informative error message readbacks are returned instead of generic "unable to take off, we're not at any runway".