### PR TITLE
Enhancement/2030 - add support for system command aliases, implement 'tw' alias for 'timewarp'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - <a href="https://github.com/openscope/openscope/issues/1991" target="_blank">#1991</a> - Update KPHL magnetic variation
 - <a href="https://github.com/openscope/openscope/issues/1787" target="_blank">#1787</a> - Standardize JSON schemas
 - <a href="https://github.com/openscope/openscope/issues/1912" target="_blank">#1912</a> - Update tutorial for auto-departure feature
+- <a href="https://github.com/openscope/openscope/issues/2030" target="_blank">#2030</a> - Implement 'tw' alias for 'timewarp' command
 
 
 # 6.28.0 (July 3, 2022)

--- a/assets/autocomplete/commandAutocompleteConfig.json
+++ b/assets/autocomplete/commandAutocompleteConfig.json
@@ -781,10 +781,10 @@
       "variants": [
         {
           "aliases": [
+            "tw",
             "timewarp"
           ],
           "altkeys": [
-            "tw",
             "time warp"
           ],
           "explain": "set time warp <u>rate</u>"

--- a/documentation/aircraft-commands.md
+++ b/documentation/aircraft-commands.md
@@ -481,7 +481,7 @@ _Syntax -_ `pause`
 
 ### Timewarp
 
-~~_Aliases -_ `tw`~~
+_Aliases -_ `tw`
 
 _Information -_ Sets the rate at which time passes, normal is `1`. While the time warp button can only set the rate to `1`, `2`, or `5`, the timewarp command accepts any value greater than or equal to 1.
 

--- a/documentation/aircraft-commands.md
+++ b/documentation/aircraft-commands.md
@@ -485,7 +485,7 @@ _Aliases -_ `tw`
 
 _Information -_ Sets the rate at which time passes, normal is `1`. While the time warp button can only set the rate to `1`, `2`, or `5`, the timewarp command accepts any value greater than or equal to 1.
 
-_Parameters -_ A number to multiply the rate at which time passes. `1` resets to normal time.
+_Parameters -_ A number to multiply the rate at which time passes. Omitting the parameter, or setting it to `1`, resets to normal time.
 
 _Syntax -_ `timewarp [rate]`
 

--- a/src/assets/scripts/client/commands/parsers/CommandParser.js
+++ b/src/assets/scripts/client/commands/parsers/CommandParser.js
@@ -300,6 +300,6 @@ export default class CommandParser {
             return false;
         }
 
-        return command.isSystemCommand && callsignOrSystemCommandName !== PARSED_COMMAND_NAME.TRANSMIT;
+        return command.isSystemCommand;
     }
 }

--- a/src/assets/scripts/client/commands/parsers/CommandParser.js
+++ b/src/assets/scripts/client/commands/parsers/CommandParser.js
@@ -152,7 +152,7 @@ export default class CommandParser {
     _buildSystemCommandModel(commandArgSegments) {
         const commandIndex = 0;
         const argIndex = 1;
-        const commandName = commandArgSegments[commandIndex];
+        const commandName = findCommandNameWithAlias(commandArgSegments[commandIndex]);
         const commandArgs = commandArgSegments[argIndex];
         const aircraftCommandModel = new AircraftCommandModel(commandName);
 
@@ -294,12 +294,12 @@ export default class CommandParser {
      * @return {boolean}
      */
     _isSystemCommand(callsignOrSystemCommandName) {
-        const command = AIRCRAFT_COMMAND_MAP[callsignOrSystemCommandName];
+        const commandName = findCommandNameWithAlias(callsignOrSystemCommandName);
 
-        if (typeof command === 'undefined') {
+        if (typeof commandName === 'undefined') {
             return false;
         }
 
-        return command.isSystemCommand;
+        return AIRCRAFT_COMMAND_MAP[commandName].isSystemCommand;
     }
 }

--- a/test/commands/parsers/CommandParser.spec.js
+++ b/test/commands/parsers/CommandParser.spec.js
@@ -7,7 +7,14 @@ import CommandParser from '../../../src/assets/scripts/client/commands/parsers/C
 import AircraftCommandModel from '../../../src/assets/scripts/client/commands/aircraftCommand/AircraftCommandModel';
 import { PARSED_COMMAND_NAME } from '../../../src/assets/scripts/client/constants/inputConstants';
 
+const COMMAND_ARGS_SEPARATOR = ' ';
+
+const AIRPORT_MOCK = 'airport ksea';
+const PAUSE_MOCK = 'pause';
 const TIMEWARP_50_MOCK = 'timewarp 50';
+const TW_50_MOCK = 'tw 50';
+const TUTORIAL_MOCK = 'tutorial';
+
 const CALLSIGN_MOCK = 'AAL777';
 const CAF_MOCK = 'caf';
 const CVS_MOCK = 'cvs';
@@ -44,11 +51,16 @@ ava('does not throw when called without parameters', t => {
     t.notThrows(() => new CommandParser());
 });
 
-
 ava('sets #command with the correct name when provided a system command', t => {
-    const model = new CommandParser(TIMEWARP_50_MOCK);
+    const airportModel = new CommandParser(AIRPORT_MOCK);
+    const pauseModel = new CommandParser(PAUSE_MOCK);
+    const timewarpModel = new CommandParser(TIMEWARP_50_MOCK);
+    const tutorialModel = new CommandParser(TUTORIAL_MOCK);
 
-    t.true(model.command === 'timewarp');
+    t.true(airportModel.command === PARSED_COMMAND_NAME.AIRPORT);
+    t.true(pauseModel.command === PARSED_COMMAND_NAME.PAUSE);
+    t.true(timewarpModel.command === PARSED_COMMAND_NAME.TIMEWARP);
+    t.true(tutorialModel.command === PARSED_COMMAND_NAME.TUTORIAL);
 });
 
 ava('sets #command with the correct name when provided a transmit command', t => {
@@ -107,9 +119,14 @@ ava('._validateAndParseCommandArguments() calls ._validateCommandArguments()', t
     t.true(_validateCommandArgumentsSpy.called);
 });
 
-ava('._isSystemCommand() returns true if callsignOrTopLevelCommandName exists within SYSTEM_COMMANDS and is not transmit', t => {
-    const systemCommandMock = 'timewarp';
-    const model = new CommandParser(systemCommandMock);
+ava('._isSystemCommand() returns true if callsignOrSystemCommandName exists within AIRCRAFT_COMMAND_MAP and is marked as a system command there', t => {
+    const airportModel = new CommandParser(AIRPORT_MOCK);
+    const pauseModel = new CommandParser(PAUSE_MOCK);
+    const timewarpModel = new CommandParser(TIMEWARP_50_MOCK);
+    const tutorialModel = new CommandParser(TUTORIAL_MOCK);
 
-    t.true(model._isSystemCommand(systemCommandMock));
+    t.true(airportModel._isSystemCommand(AIRPORT_MOCK.split(COMMAND_ARGS_SEPARATOR)[0]));
+    t.true(pauseModel._isSystemCommand(PAUSE_MOCK.split(COMMAND_ARGS_SEPARATOR)[0]));
+    t.true(timewarpModel._isSystemCommand(TIMEWARP_50_MOCK.split(COMMAND_ARGS_SEPARATOR)[0]));
+    t.true(tutorialModel._isSystemCommand(TUTORIAL_MOCK.split(COMMAND_ARGS_SEPARATOR)[0]));
 });

--- a/test/commands/parsers/CommandParser.spec.js
+++ b/test/commands/parsers/CommandParser.spec.js
@@ -63,6 +63,13 @@ ava('sets #command with the correct name when provided a system command', t => {
     t.true(tutorialModel.command === PARSED_COMMAND_NAME.TUTORIAL);
 });
 
+ava('sets #command with identical name when provided an alias of a system command', t => {
+    const twModel = new CommandParser(TW_50_MOCK);
+    const timewarpModel = new CommandParser(TIMEWARP_50_MOCK);
+
+    t.is(twModel.command, timewarpModel.command);
+});
+
 ava('sets #command with the correct name when provided a transmit command', t => {
     const commandStringMock = buildCommandString(CAF_MOCK, CVS_MOCK, TAKEOFF_MOCK);
     const model = new CommandParser(commandStringMock);
@@ -129,4 +136,14 @@ ava('._isSystemCommand() returns true if callsignOrSystemCommandName exists with
     t.true(pauseModel._isSystemCommand(PAUSE_MOCK.split(COMMAND_ARGS_SEPARATOR)[0]));
     t.true(timewarpModel._isSystemCommand(TIMEWARP_50_MOCK.split(COMMAND_ARGS_SEPARATOR)[0]));
     t.true(tutorialModel._isSystemCommand(TUTORIAL_MOCK.split(COMMAND_ARGS_SEPARATOR)[0]));
+});
+
+ava('._isSystemCommand() returns identical outcome for alias of a system command', t => {
+    const twModel = new CommandParser(TW_50_MOCK);
+    const timewarpModel = new CommandParser(TIMEWARP_50_MOCK);
+
+    t.is(
+        twModel._isSystemCommand(TW_50_MOCK.split(COMMAND_ARGS_SEPARATOR)[0]),
+        timewarpModel._isSystemCommand(TIMEWARP_50_MOCK.split(COMMAND_ARGS_SEPARATOR)[0])
+    );
 });


### PR DESCRIPTION
Resolves #2030

The purpose of this pull request is to add support for system command aliases so that the alias `tw` for `timewarp` actually works.
