### PR TITLE
bugfix/1249 - command parser: discard empty tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugfixes
 - <a href="https://github.com/openscope/openscope/issues/2022" target="_blank">#2022</a> - Improve handling of "fph" while still on ground
 - <a href="https://github.com/openscope/openscope/issues/2026" target="_blank">#2026</a> - Improve error messages from invalid takeoff commands
+- <a href="https://github.com/openscope/openscope/issues/1249" target="_blank">#1249</a> - Fix handling of consecutive spaces in commands
 
 ### Enhancements & Refactors
 - <a href="https://github.com/openscope/openscope/issues/1977" target="_blank">#1977</a> - Update scoring documentation

--- a/src/assets/scripts/client/commands/parsers/CommandParser.js
+++ b/src/assets/scripts/client/commands/parsers/CommandParser.js
@@ -128,7 +128,7 @@ export default class CommandParser {
      */
     _extractCommandsAndArgs(rawCommandWithArgs) {
         const commandOrCallsignIndex = 0;
-        const commandArgSegmentsWithCallsign = rawCommandWithArgs.split(COMMAND_ARGS_SEPARATOR);
+        const commandArgSegmentsWithCallsign = rawCommandWithArgs.split(COMMAND_ARGS_SEPARATOR).filter((t) => t);
         const callsignOrSystemCommandName = commandArgSegmentsWithCallsign[commandOrCallsignIndex];
         // effectively a slice of the array that returns everything but the first item
         const commandArgSegments = _tail(commandArgSegmentsWithCallsign);

--- a/src/assets/scripts/client/commands/parsers/CommandParser.js
+++ b/src/assets/scripts/client/commands/parsers/CommandParser.js
@@ -206,11 +206,6 @@ export default class CommandParser {
 
         for (let i = 0; i < commandArgSegments.length; i++) {
             const commandOrArg = commandArgSegments[i];
-
-            if (commandOrArg === '') {
-                continue;
-            }
-
             const commandName = findCommandNameWithAlias(commandOrArg);
 
             if (typeof aircraftCommandModel === 'undefined') {

--- a/test/commands/parsers/CommandParser.spec.js
+++ b/test/commands/parsers/CommandParser.spec.js
@@ -1,6 +1,7 @@
 import ava from 'ava';
 import sinon from 'sinon';
 import _map from 'lodash/map';
+import _some from 'lodash/some';
 import _tail from 'lodash/tail';
 
 import CommandParser from '../../../src/assets/scripts/client/commands/parsers/CommandParser';
@@ -93,6 +94,17 @@ ava('sets #commandList with AircraftCommandModel objects when it receives transm
     _map(model.commandList, (command) => {
         t.true(command instanceof AircraftCommandModel);
     });
+});
+
+ava('._extractCommandsAndArgs() discards empty tokens caused by multiple spaces', t => {
+    const extraSpacesMock = 'timewarp  50';
+    const model = new CommandParser(extraSpacesMock);
+    const _buildSystemCommandModelSpy = sinon.spy(model, '_buildSystemCommandModel');
+
+    model._extractCommandsAndArgs(extraSpacesMock);
+
+    t.true(_buildSystemCommandModelSpy.calledOnce);
+    t.false(_some(_buildSystemCommandModelSpy.lastCall.args[0], { length: 0 }));
 });
 
 ava('._extractCommandsAndArgs() calls _buildCommandList() when provided transmit commands', t => {


### PR DESCRIPTION
Resolves #1249

The purpose of this pull request is to make the command parser robust against typos of consecutive spaces. Previously, this would result in empty tokens when the command string is split using space as a delimiter. Some commands broke when empty strings were ingested in place of expected arguments. Such empty tokens are now discarded.
