### PR TITLE
enhancement/2020 - Add chat log duration setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 6.29.0 (October 1, 2022)
 ### New Features
 - <a href="https://github.com/openscope/openscope/issues/2000" target="_blank">#2000</a> - Add popup info for score changes
+- <a href="https://github.com/openscope/openscope/issues/2033" target="_blank">#2033</a> - Add duration setting for log messages
 
 ### Bugfixes
 - <a href="https://github.com/openscope/openscope/issues/2022" target="_blank">#2022</a> - Improve handling of "fph" while still on ground

--- a/src/assets/scripts/client/constants/eventNames.js
+++ b/src/assets/scripts/client/constants/eventNames.js
@@ -28,10 +28,10 @@ export const EVENT = {
 
     /**
      * @memberof EVENT
-     * @property WIND_CHANGE
+     * @property CHAT_LOG_DURATION_CHANGE
      * @type {string}
      */
-    WIND_CHANGE: 'wind-change',
+    CHAT_LOG_DURATION_CHANGE: 'chat-log-duration-change',
 
     /**
      * A click was registered outside of a specific `StripViewModel`
@@ -55,6 +55,13 @@ export const EVENT = {
      * @type {string}
      */
     MARK_SHALLOW_RENDER: 'mark-shallow-render',
+
+    /**
+     * @memberof EVENT
+     * @property MEASURE_TOOL_STYLE_CHANGE
+     * @type {string}
+     */
+    MEASURE_TOOL_STYLE_CHANGE: 'measure-tool-style-change',
 
     /**
      * A pan event has been detected necessitating an entire redraw of each canvas
@@ -287,13 +294,6 @@ export const EVENT = {
     RANGE_RINGS_CHANGE: 'range-rings-change',
 
     /**
-     * @memberof EVENT
-     * @property MEASURE_TOOL_STYLE_CHANGE
-     * @type {string}
-     */
-    MEASURE_TOOL_STYLE_CHANGE: 'measure-tool-style-change',
-
-    /**
      * A click has been registered in the unpause button shown within the
      * screen overlay whil the app is paused
      *
@@ -304,20 +304,20 @@ export const EVENT = {
     UNPAUSE: 'unpause',
 
     /**
+     * @memberof EVENT
+     * @property WIND_CHANGE
+     * @type {string}
+     */
+    WIND_CHANGE: 'wind-change',
+
+    /**
      * The zoom level has changed necessitating an entire redraw of each canvas
      *
      * @memberof EVENT
      * @property ZOOM_VIEWPORT
      * @type {string}
      */
-    ZOOM_VIEWPORT: 'zoom-viewport',
-
-    /**
-     * @memberof EVENT
-     * @property CHAT_LOG_DURATION_CHANGE
-     * @type {string}
-     */
-    CHAT_LOG_DURATION_CHANGE: 'chat-log-duration-change'
+    ZOOM_VIEWPORT: 'zoom-viewport'
 };
 
 export const AIRCRAFT_EVENT = {

--- a/src/assets/scripts/client/constants/eventNames.js
+++ b/src/assets/scripts/client/constants/eventNames.js
@@ -310,7 +310,14 @@ export const EVENT = {
      * @property ZOOM_VIEWPORT
      * @type {string}
      */
-    ZOOM_VIEWPORT: 'zoom-viewport'
+    ZOOM_VIEWPORT: 'zoom-viewport',
+
+    /**
+     * @memberof EVENT
+     * @property CHAT_LOG_DURATION_CHANGE
+     * @type {string}
+     */
+    CHAT_LOG_DURATION_CHANGE: 'chat-log-duration-change'
 };
 
 export const AIRCRAFT_EVENT = {

--- a/src/assets/scripts/client/constants/gameOptionConstants.js
+++ b/src/assets/scripts/client/constants/gameOptionConstants.js
@@ -270,10 +270,8 @@ export const GAME_OPTION_VALUES = [
         unit: 'sec',
         validationHandler(newVal) {
             const output = parseFloat(newVal);
-            if (Number.isNaN(output) || output <= 0) {
-                return false;
-            }
-            return true;
+
+            return !Number.isNaN(output) && output > 0;
         }
     }
 ];

--- a/src/assets/scripts/client/constants/gameOptionConstants.js
+++ b/src/assets/scripts/client/constants/gameOptionConstants.js
@@ -11,6 +11,7 @@ import { MEASURE_TOOL_STYLE } from './inputConstants';
  */
 export const GAME_OPTION_NAMES = {
     CONTROL_METHOD: 'controlMethod',
+    CHAT_LOG_DURATION: 'chatLogDuration',
     DRAW_PROJECTED_PATHS: 'drawProjectedPaths',
     DRAW_ILS_DISTANCE_SEPARATOR: 'drawIlsDistanceSeparator',
     MEASURE_TOOL_PATH: 'measureToolPath',
@@ -258,5 +259,21 @@ export const GAME_OPTION_VALUES = [
                 value: MEASURE_TOOL_STYLE.ALL_ARCED
             }
         ]
+    },
+    {
+        name: GAME_OPTION_NAMES.CHAT_LOG_DURATION,
+        defaultValue: '3',
+        description: 'Chat Log Duration',
+        help: 'How long chat transmissions will remain visible before fading out',
+        type: 'number',
+        onChangeEventHandler: EVENT.CHAT_LOG_DURATION_CHANGE,
+        unit: 'sec',
+        validationHandler(newVal) {
+            const output = parseFloat(newVal);
+            if (Number.isNaN(output) || output <= 0) {
+                return false;
+            }
+            return true;
+        }
     }
 ];

--- a/src/assets/scripts/client/ui/SettingsController.js
+++ b/src/assets/scripts/client/ui/SettingsController.js
@@ -98,13 +98,13 @@ export default class SettingsController {
         const descriptions = GameController.game.option.getDescriptions();
 
         _forEach(descriptions, (opt) => {
+            let $container = this._buildTextInputTemplate(opt);
+
             if (opt.type === 'select') {
-                const $container = this._buildSelectInputTemplate(opt);
-                this.$dialogBody.append($container);
-            } else {
-                const $container = this._buildTextInputTemplate(opt);
-                this.$dialogBody.append($container);
+                $container = this._buildSelectInputTemplate(opt);
             }
+
+            this.$dialogBody.append($container);
         });
 
         const $version = this._buildVersionTemplate();
@@ -150,8 +150,8 @@ export default class SettingsController {
         const $selector = $(`<select name="${option.name}"></select>`);
         const selectedOption = GameController.game.option.getOptionByName(option.name);
 
-        $container.append($label);
         $label.text(option.description);
+        $container.append($label);
 
         // this could me done with a _map(), but verbosity here makes the code easier to read
         for (let i = 0; i < option.optionList.length; i++) {
@@ -209,25 +209,27 @@ export default class SettingsController {
                                     value="${currentValue}">`);
         const $unit = $(`<span class="form-value">${option.unit}</span>`);
 
-        $container.append($label);
         $label.text(option.description);
+        $container.append($label);
 
         // TODO: this should be moved to proper event handler method and only assigned here.
         $selector.change((event) => {
             const $currentTarget = $(event.currentTarget);
+            const currentValue = $currentTarget.val();
 
-            if (!option.validationHandler($currentTarget.val())) {
+            if (!option.validationHandler(currentValue)) {
                 // User didn't enter a valid value, revert to the old value
                 $selector.val(currentValue);
+
                 return;
             }
 
-            let value = $currentTarget.val();
+            let nextValue = currentValue;
             if (option.type === 'number') {
-                value = parseFloat(value);
+                nextValue = parseFloat(nextValue);
             }
 
-            GameController.game.option.setOptionByName($currentTarget.attr('name'), value);
+            GameController.game.option.setOptionByName($currentTarget.attr('name'), nextValue);
         });
 
         $container.append($selector);

--- a/src/assets/scripts/client/ui/UiController.js
+++ b/src/assets/scripts/client/ui/UiController.js
@@ -157,14 +157,14 @@ class UiController {
         this.$log = null;
 
         /**
-         * Duration for chat log transmissions to remain visible
+         * Duration for chat log transmissions to remain visible in seconds
          *
          * @for UiController
-         * @property $chatLogDuration
+         * @property chatLogDuration
          * @type number
          * @default null
          */
-        this.$chatLogDuration = null;
+        this.chatLogDuration = null;
 
         /**
          * Element in center of screen to unpause when paused
@@ -379,8 +379,7 @@ class UiController {
         this.$toggleTutorial = this.$element.find(SELECTORS.DOM_SELECTORS.TOGGLE_TUTORIAL);
         this.$toggleVideoMap = this.$element.find(SELECTORS.DOM_SELECTORS.TOGGLE_VIDEO_MAP);
         this.$tutorialDialog = this.$element.find(SELECTORS.DOM_SELECTORS.TUTORIAL);
-
-        this.$chatLogDuration = GameController.game.option.getOptionByName('chatLogDuration');
+        this.chatLogDuration = GameController.game.option.getOptionByName('chatLogDuration');
 
         return this.setupHandlers()
             .enable();
@@ -491,7 +490,7 @@ class UiController {
         this.$fastForwards = null;
         this.$githubLinkElement = null;
         this.$log = null;
-        this.$chatLogDuration = null;
+        this.chatLogDuration = null;
         this.$pausedImg = null;
         this.$switchAirport = null;
         this.$toggleAirportGuide = null;
@@ -551,7 +550,7 @@ class UiController {
             setTimeout(() => {
                 uiLogView.remove();
             }, 10000);
-        }, this.$chatLogDuration, window, html);
+        }, this.chatLogDuration, window, html);
     }
 
     /**
@@ -567,7 +566,7 @@ class UiController {
      * @method onAirportChange
      */
     onChatLogDurationChange() {
-        this.$chatLogDuration = GameController.game.option.getOptionByName('chatLogDuration');
+        this.chatLogDuration = GameController.game.option.getOptionByName('chatLogDuration');
     }
 
     /**

--- a/src/assets/scripts/client/ui/UiController.js
+++ b/src/assets/scripts/client/ui/UiController.js
@@ -157,6 +157,16 @@ class UiController {
         this.$log = null;
 
         /**
+         * Duration for chat log transmissions to remain visible
+         *
+         * @for UiController
+         * @property $chatLogDuration
+         * @type number
+         * @default null
+         */
+        this.$chatLogDuration = null;
+
+        /**
          * Element in center of screen to unpause when paused
          *
          * @for UiController
@@ -370,6 +380,8 @@ class UiController {
         this.$toggleVideoMap = this.$element.find(SELECTORS.DOM_SELECTORS.TOGGLE_VIDEO_MAP);
         this.$tutorialDialog = this.$element.find(SELECTORS.DOM_SELECTORS.TUTORIAL);
 
+        this.$chatLogDuration = GameController.game.option.getOptionByName('chatLogDuration');
+
         return this.setupHandlers()
             .enable();
     }
@@ -381,6 +393,7 @@ class UiController {
      */
     setupHandlers() {
         this.onAirportChangeHandler = this.onAirportChange.bind(this);
+        this.onChatLogDurationChangeHandler = this.onChatLogDurationChange.bind(this);
 
         return this;
     }
@@ -394,6 +407,7 @@ class UiController {
      */
     enable() {
         this._eventBus.on(EVENT.AIRPORT_CHANGE, this.onAirportChangeHandler);
+        this._eventBus.on(EVENT.CHAT_LOG_DURATION_CHANGE, this.onChatLogDurationChangeHandler);
 
         // TODO: move these to properly bound handler methods
 
@@ -430,6 +444,7 @@ class UiController {
      */
     disable() {
         this._eventBus.off(EVENT.AIRPORT_CHANGE, this.onAirportChangeHandler);
+        this._eventBus.off(EVENT.CHAT_LOG_DURATION_CHANGE, this.onChatLogDurationChangeHandler);
         this.$airportSearch.off('keyup', (event) => this._onInitiateAirportSearch(event));
         this.$fastForwards.off('click', (event) => GameController.game_timewarp_toggle(event));
         this.$githubLinkElement.off('click', (event) => this.onClickGithubLink(event));
@@ -476,6 +491,7 @@ class UiController {
         this.$fastForwards = null;
         this.$githubLinkElement = null;
         this.$log = null;
+        this.$chatLogDuration = null;
         this.$pausedImg = null;
         this.$switchAirport = null;
         this.$toggleAirportGuide = null;
@@ -535,7 +551,7 @@ class UiController {
             setTimeout(() => {
                 uiLogView.remove();
             }, 10000);
-        }, 3, window, html);
+        }, this.$chatLogDuration, window, html);
     }
 
     /**
@@ -544,6 +560,14 @@ class UiController {
      */
     onAirportChange() {
         this.$log.empty();
+    }
+
+    /**
+     * @for UiController
+     * @method onAirportChange
+     */
+    onChatLogDurationChange() {
+        this.$chatLogDuration = GameController.game.option.getOptionByName('chatLogDuration');
     }
 
     /**

--- a/test/game/GameOptions.spec.js
+++ b/test/game/GameOptions.spec.js
@@ -20,7 +20,8 @@ ava('sets #_options on instantiation', (t) => {
         'softCeiling',
         'mouseClickDrag',
         'rangeRings',
-        'measureToolPath'
+        'measureToolPath',
+        'chatLogDuration'
     ];
 
     const model = new GameOptions();


### PR DESCRIPTION
Resolves #2020

The purpose of this change is to allow users to adjust how long a chat message will remain visible before fading out. Currently messages are shown for 3 seconds (the new default value for the setting) but users can now change the delay to any valid number greater than 0

_Note: The link to join slack doesn't work so I can't request access to the repo. Hence why this PR is from a fork_
