### PR TITLE
enhancement/1821 - add aliases cm, dm, tl, tr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Enhancements & Refactors
 - <a href="https://github.com/openscope/openscope/issues/1977" target="_blank">#1977</a> - Update scoring documentation
 - <a href="https://github.com/openscope/openscope/issues/1991" target="_blank">#1991</a> - Update KPHL magnetic variation
+- <a href="https://github.com/openscope/openscope/issues/1821" target="_blank">#1821</a> - Add aliases cm, dm for altitude, tl, tr for turn
 
 
 # 6.28.0 (July 3, 2022)

--- a/assets/autocomplete/commandAutocompleteConfig.json
+++ b/assets/autocomplete/commandAutocompleteConfig.json
@@ -553,6 +553,64 @@
       ]
     },
     {
+      "id": "tl",
+      "variants": [
+        {
+          "aliases": [
+            "tl"
+          ],
+          "altkeys": [
+            "turn left",
+            "left turn"
+          ],
+          "explain": "<b>t</b>urn left to <u>heading</u>, or by given <u>number of degrees</u>"
+        }
+      ],
+      "paramsets": [
+        {
+          "example": "060",
+          "explain": "turn left to fly <u>heading</u>",
+          "candidate": "^(?:|[0-3]|[0-2][0-9]|3[0-6]|00[1-9]|0[1-9][0-9]|[1-2][0-9]{2}|3[0-5][0-9]|360)$",
+          "validate": "^(00[1-9]|0[1-9][0-9]|[1-2][0-9]{2}|3[0-5][0-9]|360)$"
+        },
+        {
+          "example": "30",
+          "explain": "turn left by <u>number of degrees</u>",
+          "candidate": "^(?:[1-9][0-9]?)?$",
+          "validate": "^([1-9][0-9]?)$"
+        }
+      ]
+    },
+    {
+      "id": "tr",
+      "variants": [
+        {
+          "aliases": [
+            "tr"
+          ],
+          "altkeys": [
+            "turn right",
+            "right turn"
+          ],
+          "explain": "<b>t</b>urn right to <u>heading</u>, or by given <u>number of degrees</u>"
+        }
+      ],
+      "paramsets": [
+        {
+          "example": "060",
+          "explain": "turn right to fly <u>heading</u>",
+          "candidate": "^(?:|[0-3]|[0-2][0-9]|3[0-6]|00[1-9]|0[1-9][0-9]|[1-2][0-9]{2}|3[0-5][0-9]|360)$",
+          "validate": "^(00[1-9]|0[1-9][0-9]|[1-2][0-9]{2}|3[0-5][0-9]|360)$"
+        },
+        {
+          "example": "30",
+          "explain": "turn right by <u>number of degrees</u>",
+          "candidate": "^(?:[1-9][0-9]?)?$",
+          "validate": "^([1-9][0-9]?)$"
+        }
+      ]
+    },
+    {
       "id": "speed",
       "variants": [
         {

--- a/assets/autocomplete/commandAutocompleteConfig.json
+++ b/assets/autocomplete/commandAutocompleteConfig.json
@@ -440,6 +440,7 @@
         {
           "aliases": [
             "c",
+            "cm",
             "climb"
           ],
           "altkeys": [
@@ -450,6 +451,7 @@
         {
           "aliases": [
             "d",
+            "dm",
             "descend"
           ],
           "altkeys": [

--- a/documentation/aircraft-commands.md
+++ b/documentation/aircraft-commands.md
@@ -307,7 +307,7 @@ These commands control the three most basic ways we can control aircraft, collec
 
 ### Altitude
 
-_Aliases -_ `climb`, `c`, `descend`, `d`, `altitude`, `a`
+_Aliases -_ `climb`, `c`, `cm`, `descend`, `d`, `dm`, `altitude`, `a`
 
 _Hotkeys -_ `up arrow`, `down arrow` (if "Control Method" setting = "Arrow Keys")
 
@@ -332,7 +332,7 @@ _Syntax -_ `AAL123 fph`
 
 ### Heading
 
-_Aliases -_ `heading`, `h`, `turn`, `t`, `fh`
+_Aliases -_ `heading`, `h`, `turn`, `t`, `fh`; `tl` and `tr` to force direction of turn
 
 _Hotkeys -_ `left arrow`, `right arrow` (if "Control Method" setting = "Arrow Keys")
 

--- a/src/assets/scripts/client/commands/aircraftCommand/aircraftCommandMap.js
+++ b/src/assets/scripts/client/commands/aircraftCommand/aircraftCommandMap.js
@@ -100,7 +100,7 @@ export const AIRCRAFT_COMMAND_MAP = {
         isSystemCommand: false
     },
     heading: {
-        aliases: ['fh', 'h', 'heading', 't', 'turn'],
+        aliases: ['fh', 'h', 'heading', 't', 'tl', 'tr', 'turn'],
         functionName: 'runHeading',
         isSystemCommand: false
     },

--- a/src/assets/scripts/client/commands/aircraftCommand/aircraftCommandMap.js
+++ b/src/assets/scripts/client/commands/aircraftCommand/aircraftCommandMap.js
@@ -35,7 +35,7 @@ export const AIRCRAFT_COMMAND_MAP = {
         isSystemCommand: true
     },
     altitude: {
-        aliases: ['a', 'altitude', 'c', 'climb', 'd', 'descend'],
+        aliases: ['a', 'altitude', 'c', 'cm', 'climb', 'd', 'dm', 'descend'],
         functionName: 'runAltitude',
         isSystemCommand: false
     },

--- a/src/assets/scripts/client/commands/parsers/CommandParser.js
+++ b/src/assets/scripts/client/commands/parsers/CommandParser.js
@@ -219,6 +219,14 @@ export default class CommandParser {
                 }
 
                 aircraftCommandModel = new AircraftCommandModel(commandName);
+                // hack for #1821
+                if (commandName === 'heading') {
+                    if (commandOrArg === 'tl') {
+                        aircraftCommandModel.args.push('l');
+                    } else if (commandOrArg === 'tr') {
+                        aircraftCommandModel.args.push('r');
+                    }
+                }
             } else {
                 if (typeof commandName === 'undefined') {
                     aircraftCommandModel.args.push(commandOrArg);
@@ -229,6 +237,14 @@ export default class CommandParser {
                 commandList.push(aircraftCommandModel);
 
                 aircraftCommandModel = new AircraftCommandModel(commandName);
+                // hack for #1821
+                if (commandName === 'heading') {
+                    if (commandOrArg === 'tl') {
+                        aircraftCommandModel.args.push('l');
+                    } else if (commandOrArg === 'tr') {
+                        aircraftCommandModel.args.push('r');
+                    }
+                }
             }
         }
 

--- a/test/commands/definitions/aircraftCommandMap.spec.js
+++ b/test/commands/definitions/aircraftCommandMap.spec.js
@@ -218,7 +218,7 @@ ava('aliases, heading parser and heading validator used by heading', t => {
     const p = headingParser;
     const v = headingValidator;
     t.true(parse === p.toString() && validate === v.toString());
-    test_aliases(t, AIRCRAFT_COMMAND_MAP, 'heading', ['fh', 'h', 'heading', 't', 'turn']);
+    test_aliases(t, AIRCRAFT_COMMAND_MAP, 'heading', ['fh', 'h', 'heading', 't', 'tl', 'tr', 'turn']);
 });
 
 ava('aliases, hold parser and hold validator used by hold', t => {

--- a/test/commands/definitions/aircraftCommandMap.spec.js
+++ b/test/commands/definitions/aircraftCommandMap.spec.js
@@ -195,7 +195,7 @@ ava('aliases, altitude parser and altitude validator used by altitude', t => {
     const p = altitudeParser;
     const v = altitudeValidator;
     t.true(parse === p.toString() && validate === v.toString());
-    test_aliases(t, AIRCRAFT_COMMAND_MAP, 'altitude', ['a', 'altitude', 'c', 'climb', 'd', 'descend']);
+    test_aliases(t, AIRCRAFT_COMMAND_MAP, 'altitude', ['a', 'altitude', 'c', 'cm', 'climb', 'd', 'dm', 'descend']);
 });
 
 ava('aliases, crossing parser and crossing validator used by cross', t => {


### PR DESCRIPTION
Resolves #1821.
Blocks #2041.

The purpose of this pull request is to add `cm`, `dm` aliases for descend/climb, `tr`, `tl` for `t l`/`t r`.

`cm`, `dm` are straightforward additions, but `tl` and `tr` required hacky special case handling because the alias system only supports an alias serving as shorthand or substitute for a command, and not command plus some argument(s). Likewise in the autocomplete config, they have to be treated as separate commands with their own entries rather than as a variation of the existing `heading`.

It's not exactly pretty, so I'll let you guys decide if you want to tolerate the hacky solution or if you'd rather forgo having `tl` and `tr`.

- [x] implement aliases
- [x] update tests
- [x] update autocomplete config
- [x] update documentation
- [x] changelog