### PR TITLE
bugfix/1795 - fix aircraft strip scrollIntoView when strip view drawer starts closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - <a href="https://github.com/openscope/openscope/issues/2022" target="_blank">#2022</a> - Improve handling of "fph" while still on ground
 - <a href="https://github.com/openscope/openscope/issues/2026" target="_blank">#2026</a> - Improve error messages from invalid takeoff commands
 - <a href="https://github.com/openscope/openscope/issues/1249" target="_blank">#1249</a> - Fix handling of consecutive spaces in commands
+- <a href="https://github.com/openscope/openscope/issues/1795" target="_blank">#1795</a> - Fix strip bay alignment bug when opening by cliking aircraft
 
 ### Enhancements & Refactors
 - <a href="https://github.com/openscope/openscope/issues/1977" target="_blank">#1977</a> - Update scoring documentation

--- a/src/assets/scripts/client/aircraft/StripView/StripViewController.js
+++ b/src/assets/scripts/client/aircraft/StripView/StripViewController.js
@@ -237,7 +237,15 @@ export default class StripViewController {
             throw Error(`No StripViewModel found for selected Aircraft: ${aircraftModel.callsign}`);
         }
 
-        stripModel.scrollIntoView();
+        if (this.$stripView.hasClass(SELECTORS.CLASSNAMES.STRIP_VIEW_IS_HIDDEN)) {
+            this.$stripView.removeClass(SELECTORS.CLASSNAMES.STRIP_VIEW_IS_HIDDEN);
+            // wait 0.3s for strip view drawer slide out transition to complete
+            setTimeout(() => {
+                stripModel.scrollIntoView();
+            }, 300);
+        } else {
+            stripModel.scrollIntoView();
+        }
     }
 
     /**
@@ -311,7 +319,7 @@ export default class StripViewController {
     }
 
     /**
-     * Event handler for when a `StripViewModel` instance is clicked
+     * Event handler for when a the strip view drawer toggle is clicked
      *
      * @for StripViewController
      * @method _onStripListToggle


### PR DESCRIPTION
Resolves #1795

Bonus: fixed erroneous JSDoc

---
#### Notes

Re: the 300ms timeout.

First instinct is to simply
```
this.$stripView.removeClass(SELECTORS.CLASSNAMES.STRIP_VIEW_IS_HIDDEN);
stripModel.scrollIntoView();
```
but this isn't good enough.

The strip view drawer open/close has a [0.3s transition](https://github.com/openscope/openscope/blob/ad17e5be592a86ab93bf60b166626a70731a361c/src/assets/style/landmark/_stripView.less#L13) whereas the duration of `scrollIntoView()` is browser-dependent and not within our control. It seems `scrollIntoView()` is much faster, so there would still be the glitch of the entire browser viewport scrolling right for a split second before the strip view reveal transition kicks in and restores the "correct" look. That is why `scrollIntoView()` has to be deferred until the strip view drawer finished sliding out.

An alternative is to consider using [this library](https://github.com/scroll-into-view/scroll-into-view-if-needed) which has a non-standard [`boundary` arg](https://scroll-into-view.dev/#limit-propagation) which would allow us to limit the scrolling to within the sidebar and not scroll the entire viewport. But it's probably not worth the additional dependency just to handle a corner case. The 0.3s delay works well enough and doesn't hurt UI responsiveness much.