### PR TITLE
bugfix/1965 - fix typos in KSLC fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### New Features
 
 ### Bugfixes
+- <a href="https://github.com/openscope/openscope/issues/1965" target="_blank">#1965</a> - Fix typos of fix names in KSLC airport file
 
 ### Enhancements & Refactors
 - <a href="https://github.com/openscope/openscope/issues/1977" target="_blank">#1977</a> - Update scoring documentation

--- a/assets/airports/kslc.json
+++ b/assets/airports/kslc.json
@@ -559,7 +559,7 @@
             },
             "draw": [
                 ["HOPTO", "ZIONZ", "KOOGR", "ROMMN", "KIMMR*"],
-                ["ROMNN", "PLEZZ", "EYELO*"],
+                ["ROMMN", "PLEZZ", "EYELO*"],
                 ["ZIONZ", "GITLN", "LODUY", "KROST*"],
                 ["LODUY", "URNUW", "BCE*"],
                 ["URNUW", "EHK*"]
@@ -779,7 +779,7 @@
                 "EKR": ["EKR", "RACER", "MTU", "THISL"],
                 "HELPR": ["HELPR", "GOSHU"]
             },
-            "body": ["SPANE", "BOAGY", "FFU", "DRYVE", "CCHIP", "#345"],
+            "body": ["SPANE", "BOAGY", "FFU", "DRYVE", "CHHIP", "#345"],
             "rwy": {
                 "KSLC14": [],
                 "KSLC16L": [],
@@ -791,7 +791,7 @@
                 "KSLC35": []
             },
             "draw": [
-                ["EKR", "RACER", "MTU", "THISL", "SPANE", "BOAGY", "FFU", "DRYVE", "CCHIP"],
+                ["EKR", "RACER", "MTU", "THISL", "SPANE", "BOAGY", "FFU", "DRYVE", "CHHIP"],
                 ["HELPR", "GOSHU"]
             ]
         },


### PR DESCRIPTION
Resolves #1965

The purpose of this pull request is to resolve undefined fixes at KSLC caused by typo of fix names in the airport file.
