### PR TITLE
bugfix/1852 - Fix airborne aircraft calling up with "ready to taxi"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - <a href="https://github.com/openscope/openscope/issues/2026" target="_blank">#2026</a> - Improve error messages from invalid takeoff commands
 - <a href="https://github.com/openscope/openscope/issues/1249" target="_blank">#1249</a> - Fix handling of consecutive spaces in commands
 - <a href="https://github.com/openscope/openscope/issues/1795" target="_blank">#1795</a> - Fix strip bay alignment bug when opening by cliking aircraft
+- <a href="https://github.com/openscope/openscope/issues/1852" target="_blank">#1852</a> - Fix bug where airborne aircraft report "ready to taxi"
 
 ### Enhancements & Refactors
 - <a href="https://github.com/openscope/openscope/issues/1977" target="_blank">#1977</a> - Update scoring documentation

--- a/src/assets/scripts/client/aircraft/AircraftModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftModel.js
@@ -2708,7 +2708,7 @@ export default class AircraftModel {
         this.updateFlightPhase();
         this.updateTarget();
         this.updatePhysics();
-        this._updateAircraftVisibility();
+        this._updateAircraftControllability();
     }
 
     /**
@@ -2792,13 +2792,17 @@ export default class AircraftModel {
 
     /**
      * @for AircraftModel
-     * @method _updateAircraftVisibility
+     * @method _updateAircraftControllability
      * @private
      */
-    _updateAircraftVisibility() {
+    _updateAircraftControllability() {
+        if (this.projected) {
+            return;
+        }
+
         const isInsideAirspace = this.isInsideAirspace(AirportController.airport_get());
 
-        if (isInsideAirspace === this.isControllable || this.projected) {
+        if (this.isControllable === isInsideAirspace) {
             return;
         }
 

--- a/src/assets/scripts/client/aircraft/AircraftModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftModel.js
@@ -1246,7 +1246,7 @@ export default class AircraftModel {
         let alt_log;
         let alt_say;
 
-        if (this.isArrival()) {
+        if (this.isAirborne()) {
             const altdiff = this.altitude - this.mcp.altitude;
             const alt = digits_decimal(this.altitude, -2);
 
@@ -1272,9 +1272,7 @@ export default class AircraftModel {
                 ],
                 this.pilotVoice
             );
-        }
-
-        if (this.isDeparture()) {
+        } else {
             UiController.ui_log(`${AirportController.airport_get().radio.twr}, ${this.callsign}, ready to taxi`);
             speech_say(
                 [


### PR DESCRIPTION
Resolves #1852

The purpose of this pull request is to change `AircraftModel.callUp()` so that the call up message that is used is determined by whether acft is airborne or not, rather than whether it is an arrival or departure acft.
