### PR TITLE
Bugfix/2034 - command parser now chokes on unrecognized tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### New Features
 
 ### Bugfixes
+- <a href="https://github.com/openscope/openscope/issues/2034" target="_blank">#2034</a> - Fix parser accepting and silently ignoring unrecognized tokens
 
 ### Enhancements & Refactors
 - <a href="https://github.com/openscope/openscope/issues/1977" target="_blank">#1977</a> - Update scoring documentation

--- a/src/assets/scripts/client/commands/parsers/CommandParser.js
+++ b/src/assets/scripts/client/commands/parsers/CommandParser.js
@@ -250,7 +250,7 @@ export default class CommandParser {
 
         if (validationErrors.length > 0) {
             _forEach(validationErrors, (error) => {
-                throw error;
+                throw new Error(error);
             });
         }
     }

--- a/src/assets/scripts/client/commands/parsers/CommandParser.js
+++ b/src/assets/scripts/client/commands/parsers/CommandParser.js
@@ -10,6 +10,7 @@ import {
 } from '../aircraftCommand/aircraftCommandMap';
 import { PARSED_COMMAND_NAME } from '../../constants/inputConstants';
 import ParsedCommand from '../ParsedCommand';
+import { ERROR_MESSAGE } from './parserMessages';
 
 /**
  * Symbol used to split the command string as it enters the class.
@@ -213,21 +214,20 @@ export default class CommandParser {
 
             const commandName = findCommandNameWithAlias(commandOrArg);
 
-            if (typeof aircraftCommandModel === 'undefined') {
-                if (typeof commandName === 'undefined') {
-                    continue;
+            if (typeof commandName === 'undefined') {
+                // token not recognized as a command
+                if (typeof aircraftCommandModel === 'undefined') {
+                    // token was expected to be a valid command (#2034)
+                    throw new Error(ERROR_MESSAGE.INVALID_CMD);
                 }
-
-                aircraftCommandModel = new AircraftCommandModel(commandName);
+                // it might be an argument
+                aircraftCommandModel.args.push(commandOrArg);
             } else {
-                if (typeof commandName === 'undefined') {
-                    aircraftCommandModel.args.push(commandOrArg);
-
-                    continue;
+                // new command encountered
+                if (typeof aircraftCommandModel !== 'undefined') {
+                    // "flush" prior command first
+                    commandList.push(aircraftCommandModel);
                 }
-
-                commandList.push(aircraftCommandModel);
-
                 aircraftCommandModel = new AircraftCommandModel(commandName);
             }
         }

--- a/src/assets/scripts/client/commands/parsers/parserMessages.js
+++ b/src/assets/scripts/client/commands/parsers/parserMessages.js
@@ -21,6 +21,7 @@ const INVALID_ARG_LENGTH = `${INVALID_ARG} length`;
  * @final
  */
 export const ERROR_MESSAGE = {
+    INVALID_CMD: 'Invalid command',
     ZERO_ARG_LENGTH: `${INVALID_ARG_LENGTH}. Expected exactly zero arguments`,
     SINGLE_ARG_LENGTH: `${INVALID_ARG_LENGTH}. Expected exactly one argument`,
     TWO_ARG_LENGTH: `${INVALID_ARG_LENGTH}. Expected exactly two arguments`,

--- a/test/commands/parsers/CommandParser.spec.js
+++ b/test/commands/parsers/CommandParser.spec.js
@@ -32,12 +32,7 @@ ava('throws when called with invalid arguments', (t) => {
     const expectedResult = 'Invalid argument length. Expected exactly zero arguments';
     const commandStringMock = buildCommandString(TAKEOFF_MOCK, 'threeve');
 
-    try {
-        // eslint-disable-next-line no-unused-vars
-        const model = new CommandParser(commandStringMock);
-    } catch (e) {
-        t.true(e === expectedResult);
-    }
+    t.throws(() => new CommandParser(commandStringMock), null, expectedResult);
 });
 
 ava('does not throw when called without parameters', t => {

--- a/test/commands/parsers/CommandParser.spec.js
+++ b/test/commands/parsers/CommandParser.spec.js
@@ -82,14 +82,21 @@ ava('._extractCommandsAndArgs() calls _buildCommandList() when provided transmit
     t.true(_buildCommandListSpy.calledWithExactly(_tail(expectedArgs)));
 });
 
-ava('._buildCommandList() returns an empty array when adding args to an undefined AircraftCommandModel', t => {
-    const model = new CommandParser('threeve');
+ava('._buildCommandList() returns an empty array when fed with no commands', t => {
+    const model = new CommandParser(CALLSIGN_MOCK);
 
-    t.notThrows(() => model._buildCommandList(['$texas']));
+    t.notThrows(() => model._buildCommandList([]));
 
-    const result = model._buildCommandList(['$texas']);
+    const result = model._buildCommandList([]);
 
     t.deepEqual(result, []);
+});
+
+ava('._buildCommandList() throws if unrecognized token encountered when expecting a valid command', t => {
+    const model = new CommandParser(CALLSIGN_MOCK);
+    const expectedResult = 'Invalid command';
+
+    t.throws(() => model._buildCommandList(['nonsense']), null, expectedResult);
 });
 
 ava('._validateAndParseCommandArguments() calls ._validateCommandArguments()', t => {


### PR DESCRIPTION
Resolves #2034.
Depends on #2035. (rebase this once that is merged)

The purpose of this pull request is to prevent the command parser from silently ignoring any tokens that it does not recognize.

This is expected to cause a merge conflict with #2035 -- if you want, I can rebase this after that gets merged first. In the meantime, this can still be deployed and tested.

Todo
- [ ] rebase after #2035 is merged first
- [x] changelog
