### PR TITLE
bugfix/2040 - Fix spurious "no such aircraft, say again" error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - <a href="https://github.com/openscope/openscope/issues/1249" target="_blank">#1249</a> - Fix handling of consecutive spaces in commands
 - <a href="https://github.com/openscope/openscope/issues/1795" target="_blank">#1795</a> - Fix strip bay alignment bug when opening by cliking aircraft
 - <a href="https://github.com/openscope/openscope/issues/1852" target="_blank">#1852</a> - Fix bug where airborne aircraft report "ready to taxi"
+- <a href="https://github.com/openscope/openscope/issues/2040" target="_blank">#2040</a> - Fix spurious "no such aircraft, say again" error
 
 ### Enhancements & Refactors
 - <a href="https://github.com/openscope/openscope/issues/1977" target="_blank">#1977</a> - Update scoring documentation

--- a/src/assets/scripts/client/InputController.js
+++ b/src/assets/scripts/client/InputController.js
@@ -56,7 +56,6 @@ export default class InputController {
 
         prop.input = input;
         this.input = input;
-        this.input.command = '';
         this.input.callsign = '';
         this.input.data = '';
         this.input.history = [];
@@ -90,7 +89,6 @@ export default class InputController {
     setupHandlers() {
         this.onKeydownHandler = this._onKeydown.bind(this);
         this.onKeyupHandler = this._onKeyup.bind(this);
-        this.onCommandInputChangeHandler = this._onCommandInputChange.bind(this);
         this.onMouseScrollHandler = this._onMouseScroll.bind(this);
         this.onMouseClickAndDragHandler = this._onMouseClickAndDrag.bind(this);
         this.onMouseUpHandler = this._onMouseUp.bind(this);
@@ -109,7 +107,6 @@ export default class InputController {
     enable() {
         this.$window.on('keydown', this.onKeydownHandler);
         this.$window.on('keyup', this.onKeyupHandler);
-        this.$commandInput.on('input', this.onCommandInputChangeHandler);
         // TODO: these are non-standard events and will be deprecated soon. this should be moved
         // over to the `wheel` event. This should also be moved over to `.on()` instead of `.bind()`
         // https://developer.mozilla.org/en-US/docs/Web/Events/wheel
@@ -136,7 +133,6 @@ export default class InputController {
     disable() {
         this.$window.off('keydown', this.onKeydownHandler);
         this.$window.off('keyup', this.onKeyupHandler);
-        this.$commandInput.off('input', this.onCommandInputChangeHandler);
         // uncomment only after `.on()` for this event has been implemented.
         // this.$commandInput.off('DOMMouseScroll mousewheel', this.onMouseScrollHandler);
         this.$canvases.off('mousemove', this.onMouseClickAndDragHandler);
@@ -164,7 +160,6 @@ export default class InputController {
         this._autocompleteController = null;
 
         this.input = input;
-        this.input.command = '';
         this.input.callsign = '';
         // this.input.data = '';
         this.input.history = [];
@@ -184,7 +179,6 @@ export default class InputController {
     input_init_pre() {
         // TODO: these prop properties can be removed except for `this.input`
         this.input = input;
-        this.input.command = '';
         this.input.callsign = '';
         this.input.data = '';
         this.input.history = [];
@@ -212,7 +206,6 @@ export default class InputController {
         prop.input.callsign = '';
         prop.input.command = '';
         this.input.callsign = '';
-        this.input.command = '';
         this.$commandInput.val('');
 
         this._eventBus.trigger(EVENT.DESELECT_AIRCRAFT, {});
@@ -428,15 +421,6 @@ export default class InputController {
 
     /**
      * @for InputController
-     * @method _onCommandInputChange
-     * @private
-     */
-    _onCommandInputChange() {
-        this.input.command = this.$commandInput.val();
-    }
-
-    /**
-     * @for InputController
      * @method selectAircraft
      * @param aircraftModel {AircraftModel}
      */
@@ -453,7 +437,6 @@ export default class InputController {
         prop.input.command = '';
         this.input.callsign = aircraftModel.callsign;
         this.$commandInput.val(`${aircraftModel.callsign} `);
-        this._onCommandInputChange();
 
         if (!this.$commandInput.is(':focus')) {
             this.$commandInput.focus();
@@ -535,7 +518,6 @@ export default class InputController {
                 if (this._isArrowControlMethod() && this.commandBarContext === COMMAND_CONTEXT.AIRCRAFT) {
                     this.$commandInput.val(`${currentCommandInputValue} t l `);
                     event.preventDefault();
-                    this.onCommandInputChangeHandler();
                 }
 
                 break;
@@ -544,7 +526,6 @@ export default class InputController {
                 if (this._isArrowControlMethod() && this.commandBarContext === COMMAND_CONTEXT.AIRCRAFT) {
                     this.$commandInput.val(`${currentCommandInputValue} t r `);
                     event.preventDefault();
-                    this.onCommandInputChangeHandler();
                 }
 
                 break;
@@ -554,7 +535,6 @@ export default class InputController {
                 if (this._isArrowControlMethod() && this.commandBarContext === COMMAND_CONTEXT.AIRCRAFT) {
                     this.$commandInput.val(`${currentCommandInputValue} c `);
                     event.preventDefault();
-                    this.onCommandInputChangeHandler();
                 } else {
                     this.selectPreviousAircraft();
                     event.preventDefault();
@@ -566,7 +546,6 @@ export default class InputController {
                 if (this._isArrowControlMethod() && this.commandBarContext === COMMAND_CONTEXT.AIRCRAFT) {
                     this.$commandInput.val(`${currentCommandInputValue} d `);
                     event.preventDefault();
-                    this.onCommandInputChangeHandler();
                 } else {
                     this.selectNextAircraft();
                     event.preventDefault();
@@ -579,7 +558,6 @@ export default class InputController {
                 if (this.commandBarContext === COMMAND_CONTEXT.AIRCRAFT) {
                     this.$commandInput.val(`${currentCommandInputValue} / `);
                     event.preventDefault();
-                    this.onCommandInputChangeHandler();
                 }
 
                 break;
@@ -588,7 +566,6 @@ export default class InputController {
                 if (this.commandBarContext === COMMAND_CONTEXT.AIRCRAFT) {
                     this.$commandInput.val(`${currentCommandInputValue} * `);
                     event.preventDefault();
-                    this.onCommandInputChangeHandler();
                 }
 
                 break;
@@ -598,7 +575,6 @@ export default class InputController {
                 if (this.commandBarContext === COMMAND_CONTEXT.AIRCRAFT) {
                     this.$commandInput.val(`${currentCommandInputValue} + `);
                     event.preventDefault();
-                    this.onCommandInputChangeHandler();
                 }
 
                 break;
@@ -607,7 +583,6 @@ export default class InputController {
                 if (this.commandBarContext === COMMAND_CONTEXT.AIRCRAFT) {
                     this.$commandInput.val(`${currentCommandInputValue} - `);
                     event.preventDefault();
-                    this.onCommandInputChangeHandler();
                 }
 
                 break;
@@ -631,7 +606,6 @@ export default class InputController {
 
                 this.$commandInput.val('QP_J ');
                 event.preventDefault();
-                this.onCommandInputChangeHandler();
 
                 break;
             case KEY_CODES.BACKQUOTE:
@@ -738,7 +712,7 @@ export default class InputController {
         }
 
         if (this.input.history_item == null) {
-            this.input.history.unshift(this.input.command);
+            this.input.history.unshift(this.$commandInput.val());
             this.input.history_item = 0;
         }
 
@@ -749,7 +723,6 @@ export default class InputController {
         const aircraftModel = this._aircraftController.findAircraftByCallsign(callsign);
 
         this.selectAircraft(aircraftModel);
-        this.onCommandInputChangeHandler();
     }
 
     /**
@@ -766,8 +739,6 @@ export default class InputController {
         if (this.input.history_item <= 0) {
             this.$commandInput.val(this.input.history[0]);
 
-            this.onCommandInputChangeHandler();
-
             this.input.history.splice(0, 1);
             this.input.history_item = null;
 
@@ -780,7 +751,6 @@ export default class InputController {
         const aircraftModel = this._aircraftController.findAircraftByCallsign(callsign);
 
         this.selectAircraft(aircraftModel);
-        this.onCommandInputChangeHandler();
     }
 
     /**
@@ -826,8 +796,7 @@ export default class InputController {
      * @method processAircraftCommand
      */
     processAircraftCommand() {
-        // this could use $commandInput.val() as an alternative
-        const userCommand = this.input.command.trim().toLowerCase();
+        const userCommand = this.$commandInput.val().trim().toLowerCase();
 
         // Using try/catch here very much on purpose. the `CommandParser` will throw when it encounters any kind
         // of error; invalid length, validation, parse, etc. Here we catch those errors, log them to the screen
@@ -880,7 +849,7 @@ export default class InputController {
      */
     processScopeCommand() {
         let scopeCommandModel;
-        const userCommand = this.input.command.trim().toLowerCase();
+        const userCommand = this.$commandInput.val().trim().toLowerCase();
 
         try {
             scopeCommandModel = new ScopeCommandModel(userCommand);
@@ -1141,10 +1110,7 @@ export default class InputController {
             this.deselectAircraft();
             this._markMousePressed(event, MOUSE_BUTTON_NAMES.LEFT);
         } else if (this.commandBarContext === COMMAND_CONTEXT.SCOPE) {
-            const newCommandValue = `${this.$commandInput.val()} ${aircraftModel.callsign}`;
-            this.input.command = newCommandValue;
-            this.$commandInput.val(newCommandValue);
-
+            this.$commandInput.val(`${this.$commandInput.val()} ${aircraftModel.callsign}`);
             this.processCommand();
         } else if (aircraftModel) {
             this.selectAircraft(aircraftModel);

--- a/src/assets/scripts/client/InputController.js
+++ b/src/assets/scripts/client/InputController.js
@@ -57,10 +57,8 @@ export default class InputController {
         prop.input = input;
         this.input = input;
         this.input.callsign = '';
-        this.input.data = '';
         this.input.history = [];
         this.input.history_item = null;
-        this.input.click = [0, 0];
         this._mouseDelta = [0, 0];
         this._mouseDownScreenPosition = [0, 0];
         this.input.isMouseDown = false;
@@ -161,10 +159,8 @@ export default class InputController {
 
         this.input = input;
         this.input.callsign = '';
-        // this.input.data = '';
         this.input.history = [];
         this.input.history_item = null;
-        this.input.click = [0, 0];
         this._mouseDelta = [0, 0];
         this._mouseDownScreenPosition = [0, 0];
         this.input.isMouseDown = false;
@@ -180,10 +176,8 @@ export default class InputController {
         // TODO: these prop properties can be removed except for `this.input`
         this.input = input;
         this.input.callsign = '';
-        this.input.data = '';
         this.input.history = [];
         this.input.history_item = null;
-        this.input.click = [0, 0];
         this._mouseDelta = [0, 0];
         this._mouseDownScreenPosition = [0, 0];
         this.input.isMouseDown = false;
@@ -204,7 +198,6 @@ export default class InputController {
         // TODO: Refactor out the prop
         // using `prop` here so CanvasController knows which aircraft is selected
         prop.input.callsign = '';
-        prop.input.command = '';
         this.input.callsign = '';
         this.$commandInput.val('');
 
@@ -434,7 +427,6 @@ export default class InputController {
         // TODO: Refactor out the prop
         // using `prop` here so CanvasController knows which aircraft is selected
         prop.input.callsign = aircraftModel.callsign;
-        prop.input.command = '';
         this.input.callsign = aircraftModel.callsign;
         this.$commandInput.val(`${aircraftModel.callsign} `);
 

--- a/src/assets/scripts/client/InputController.js
+++ b/src/assets/scripts/client/InputController.js
@@ -452,8 +452,8 @@ export default class InputController {
         prop.input.callsign = aircraftModel.callsign;
         prop.input.command = '';
         this.input.callsign = aircraftModel.callsign;
-        this.input.command = '';
         this.$commandInput.val(`${aircraftModel.callsign} `);
+        this._onCommandInputChange();
 
         if (!this.$commandInput.is(':focus')) {
             this.$commandInput.focus();

--- a/src/assets/scripts/client/InputController.js
+++ b/src/assets/scripts/client/InputController.js
@@ -59,7 +59,6 @@ export default class InputController {
         this.input.callsign = '';
         this.input.history = [];
         this.input.history_item = null;
-        this._mouseDelta = [0, 0];
         this._mouseDownScreenPosition = [0, 0];
         this.input.isMouseDown = false;
         this.commandBarContext = COMMAND_CONTEXT.AIRCRAFT;
@@ -161,7 +160,6 @@ export default class InputController {
         this.input.callsign = '';
         this.input.history = [];
         this.input.history_item = null;
-        this._mouseDelta = [0, 0];
         this._mouseDownScreenPosition = [0, 0];
         this.input.isMouseDown = false;
 
@@ -178,7 +176,6 @@ export default class InputController {
         this.input.callsign = '';
         this.input.history = [];
         this.input.history_item = null;
-        this._mouseDelta = [0, 0];
         this._mouseDownScreenPosition = [0, 0];
         this.input.isMouseDown = false;
     }
@@ -344,13 +341,6 @@ export default class InputController {
 
         const nextXPan = event.pageX - this._mouseDownScreenPosition[0];
         const nextYPan = event.pageY - this._mouseDownScreenPosition[1];
-
-        // TODO: investigate `_mouseDelta` and what exactly it does
-        // this updates the current mouseDelta so the next time through we have correct values
-        this._mouseDelta = [
-            nextXPan,
-            nextYPan
-        ];
 
         CanvasStageModel.updatePan(nextXPan, nextYPan);
     }

--- a/src/assets/scripts/client/ui/autocomplete/AutocompleteController.js
+++ b/src/assets/scripts/client/ui/autocomplete/AutocompleteController.js
@@ -488,7 +488,6 @@ export default class AutocompleteController {
 
         cmdstr = before.concat((before.length > 0) ? ' ' : '', this.params.command, ' ', paramstr);
         this._inputController.$commandInput.val(cmdstr + after);
-        this._inputController.onCommandInputChangeHandler();
         this._inputController.$commandInput.prop('selectionStart', cmdstr.length);
         this._inputController.$commandInput.prop('selectionEnd', cmdstr.length);
         this._inputController.$commandInput.focus();


### PR DESCRIPTION
Resolves #2040

The purpose of this pull request is to fix spurious error message when the command input is automatically populated with aircraft callsign by clicking an aircraft radar return or flight strip, and then transmitted as-is without any modification.