### PR TITLE
Enhancement/2050 - auto tower controllability and behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@
 - <a href="https://github.com/openscope/openscope/issues/2022" target="_blank">#2022</a> - Improve handling of "fph" while still on ground
 - <a href="https://github.com/openscope/openscope/issues/2026" target="_blank">#2026</a> - Improve error messages from invalid takeoff commands
 - <a href="https://github.com/openscope/openscope/issues/1249" target="_blank">#1249</a> - Fix handling of consecutive spaces in commands
-- <a href="https://github.com/openscope/openscope/issues/1795" target="_blank">#1795</a> - Fix strip bay alignment bug when opening by cliking aircraft
+- <a href="https://github.com/openscope/openscope/issues/1795" target="_blank">#1795</a> - Fix strip bay alignment bug when opening by clicking aircraft
 - <a href="https://github.com/openscope/openscope/issues/1852" target="_blank">#1852</a> - Fix bug where airborne aircraft report "ready to taxi"
 - <a href="https://github.com/openscope/openscope/issues/2040" target="_blank">#2040</a> - Fix spurious "no such aircraft, say again" error
+- <a href="https://github.com/openscope/openscope/issues/2049" target="_blank">#2049</a> - Fix missing "ready to taxi" call up from spawning departures 
 
 ### Enhancements & Refactors
 - <a href="https://github.com/openscope/openscope/issues/1977" target="_blank">#1977</a> - Update scoring documentation
@@ -20,6 +21,7 @@
 - <a href="https://github.com/openscope/openscope/issues/2042" target="_blank">#2042</a> - Update readme badges and slack links
 - <a href="https://github.com/openscope/openscope/issues/2052" target="_blank">#2052</a> - Fix script minification issues in build process
 - <a href="https://github.com/openscope/openscope/issues/2045" target="_blank">#2045</a> - Assorted code cleanup and optimizations
+- <a href="https://github.com/openscope/openscope/issues/2050" target="_blank">#2050</a> - System tower control: sim behavior and aircraft controllability
 
 
 # 6.28.0 (July 3, 2022)

--- a/src/assets/scripts/client/aircraft/AircraftController.js
+++ b/src/assets/scripts/client/aircraft/AircraftController.js
@@ -184,6 +184,7 @@ export default class AircraftController {
      */
     _setupHandlers() {
         this._onRemoveAircraftHandler = this.aircraft_remove.bind(this);
+        this._onTowerControllerChangeHandler = this._onTowerControllerChange.bind(this);
 
         return this;
     }
@@ -201,6 +202,7 @@ export default class AircraftController {
         this._eventBus.on(EVENT.SCROLL_TO_AIRCRAFT, this._onScrollToAircraft);
         this._eventBus.on(EVENT.REMOVE_AIRCRAFT, this._onRemoveAircraftHandler);
         this._eventBus.on(EVENT.REMOVE_AIRCRAFT_CONFLICT, this.removeConflict);
+        this._eventBus.on(EVENT.TOWER_CONTROLLER_CHANGE, this._onTowerControllerChangeHandler);
 
         return this;
     }
@@ -218,6 +220,7 @@ export default class AircraftController {
         this._eventBus.off(EVENT.SCROLL_TO_AIRCRAFT, this._onScrollToAircraft);
         this._eventBus.off(EVENT.REMOVE_AIRCRAFT, this._onRemoveAircraftHandler);
         this._eventBus.off(EVENT.REMOVE_AIRCRAFT_CONFLICT, this.removeConflict);
+        this._eventBus.off(EVENT.TOWER_CONTROLLER_CHANGE, this._onTowerControllerChangeHandler);
 
         return this;
     }
@@ -915,6 +918,19 @@ export default class AircraftController {
         // Clean up the screen from aircraft that are too far
         if (!this.isAircraftVisible(aircraftModel, 2) && !aircraftModel.isControllable && aircraftModel.isRemovable) {
             this.aircraft_remove(aircraftModel);
+        }
+    }
+
+    /**
+     * Respond to user changing the tower control (autotower) settings
+     *
+     * @for AircraftController
+     * @private
+     */
+    _onTowerControllerChange() {
+        const isAutoTower = GameController.getGameOption(GAME_OPTION_NAMES.TOWER_CONTROLLER) === 'SYSTEM';
+        for (let i = 0; i < this.aircraft.list.length; i++) {
+            this.aircraft.list[i].onTowerControllerChange(isAutoTower);
         }
     }
 }

--- a/src/assets/scripts/client/aircraft/AircraftController.js
+++ b/src/assets/scripts/client/aircraft/AircraftController.js
@@ -23,7 +23,7 @@ import { speech_say } from '../speech';
 import { generateTransponderCode, isDiscreteTransponderCode, isValidTransponderCode } from '../utilities/transponderUtilities';
 import { km } from '../utilities/unitConverters';
 import { isEmptyOrNotArray } from '../utilities/validatorUtilities';
-import { FLIGHT_CATEGORY, FLIGHT_PHASE } from '../constants/aircraftConstants';
+import { FLIGHT_CATEGORY } from '../constants/aircraftConstants';
 import { EVENT, AIRCRAFT_EVENT } from '../constants/eventNames';
 import { GAME_OPTION_NAMES } from '../constants/gameOptionConstants';
 import { INVALID_INDEX } from '../constants/globalConstants';
@@ -363,11 +363,13 @@ export default class AircraftController {
             return;
         }
 
+        const isAutoTower = GameController.getGameOption(GAME_OPTION_NAMES.TOWER_CONTROLLER) === 'SYSTEM';
+
         // TODO: this is getting better, but still needs more simplification
         for (let i = 0; i < this.aircraft.list.length; i++) {
             const aircraftModel = this.aircraft.list[i];
 
-            aircraftModel.update();
+            aircraftModel.update(isAutoTower);
             aircraftModel.updateWarning();
 
             // TODO: conflict checking eats up a lot of resources when there are more than
@@ -580,14 +582,8 @@ export default class AircraftController {
         }
 
         if (isDeparture && isAutoTower) {
-            // create the StripView immediately for departures; arrival strips are made when controllable
-            this._stripViewController.createStripView(aircraftModel);
             aircraftModel.pilot.clearedAsFiled();
-            aircraftModel.moveToRunway(aircraftModel.fms.departureRunwayModel);
-            aircraftModel.fms.departureRunwayModel.addAircraftToQueue(aircraftModel.id);
-            aircraftModel.setFlightPhase(FLIGHT_PHASE.WAITING);
-
-            aircraftModel.shouldTakeOffWhenRunwayIsClear = true;
+            aircraftModel.taxiToRunway(aircraftModel.fms.departureRunwayModel);
 
             this._runCommandOnPreSpawnAircraft(aircraftModel, runwayCommands, aircraftModel.fms.departureRunwayModel.name);
         }

--- a/src/assets/scripts/client/aircraft/AircraftController.js
+++ b/src/assets/scripts/client/aircraft/AircraftController.js
@@ -366,7 +366,7 @@ export default class AircraftController {
             return;
         }
 
-        const isAutoTower = GameController.getGameOption(GAME_OPTION_NAMES.TOWER_CONTROLLER) === 'SYSTEM';
+        const isAutoTower = GameController.isAutoTower();
 
         // TODO: this is getting better, but still needs more simplification
         for (let i = 0; i < this.aircraft.list.length; i++) {
@@ -573,7 +573,6 @@ export default class AircraftController {
         const aircraftModel = new AircraftModel(initializationProps);
         const isDeparture = initializationProps.category === 'departure';
         const isArrival = initializationProps.category === 'arrival';
-        const isAutoTower = GameController.getGameOption(GAME_OPTION_NAMES.TOWER_CONTROLLER) === 'SYSTEM';
         const runwayCommands = initializationProps.commands;
 
         // triggering event bus rather than calling locally because multiple classes
@@ -584,7 +583,7 @@ export default class AircraftController {
             this._runCommandOnPreSpawnAircraft(aircraftModel, runwayCommands, aircraftModel.fms.arrivalRunwayModel.name);
         }
 
-        if (isDeparture && isAutoTower) {
+        if (isDeparture && GameController.isAutoTower()) {
             aircraftModel.pilot.clearedAsFiled();
             aircraftModel.taxiToRunway(aircraftModel.fms.departureRunwayModel);
 
@@ -928,7 +927,7 @@ export default class AircraftController {
      * @private
      */
     _onTowerControllerChange() {
-        const isAutoTower = GameController.getGameOption(GAME_OPTION_NAMES.TOWER_CONTROLLER) === 'SYSTEM';
+        const isAutoTower = GameController.isAutoTower();
         for (let i = 0; i < this.aircraft.list.length; i++) {
             this.aircraft.list[i].onTowerControllerChange(isAutoTower);
         }

--- a/src/assets/scripts/client/aircraft/AircraftController.js
+++ b/src/assets/scripts/client/aircraft/AircraftController.js
@@ -382,7 +382,7 @@ export default class AircraftController {
             }
 
             this._updateAircraftConflicts(aircraftModel, i);
-            this._updateAircraftVisibility(aircraftModel);
+            this._updateAircraftVisibility(aircraftModel, isAutoTower);
 
             if (!aircraftModel.isControllable) {
                 this.removeStripView(aircraftModel);
@@ -879,21 +879,26 @@ export default class AircraftController {
      *
      * @for AircraftController
      * @param {AircraftModel} aircraftModel
+     * @param {boolean} isAutoTower
      * @private
      */
-    _updateAircraftVisibility(aircraftModel) {
+    _updateAircraftVisibility(aircraftModel, isAutoTower) {
         // TODO: these next 3 logic blocks could use some cleaning/abstraction
         if (aircraftModel.isArrival() && aircraftModel.isStopped() && !aircraftModel.hit) {
+            // trigger this for scoring purposes even if autotower is on, to give credit for a safe arrival
+            // (since there is no separate scoring for TRACON -> TWR handover)
             EventBus.trigger(AIRCRAFT_EVENT.FULLSTOP, aircraftModel, aircraftModel.fms.arrivalRunwayModel);
 
-            UiController.ui_log(`${aircraftModel.callsign} switching to ground, good day`);
-            speech_say(
-                [
-                    { type: 'callsign', content: aircraftModel },
-                    { type: 'text', content: ', switching to ground, good day' }
-                ],
-                aircraftModel.pilotVoice
-            );
+            if (!isAutoTower) {
+                UiController.ui_log(`${aircraftModel.callsign} switching to ground, good day`);
+                speech_say(
+                    [
+                        { type: 'callsign', content: aircraftModel },
+                        { type: 'text', content: ', switching to ground, good day' }
+                    ],
+                    aircraftModel.pilotVoice
+                );
+            }
 
             GameController.events_recordNew(GAME_EVENTS.ARRIVAL);
             this.aircraft_remove(aircraftModel);

--- a/src/assets/scripts/client/aircraft/AircraftModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftModel.js
@@ -2812,6 +2812,20 @@ export default class AircraftModel {
     }
 
     /**
+     * Respond to user changing the tower control (autotower) settings
+     * by adjusting controllability as needed *without* making radio calls
+     *
+     * @for AircraftModel
+     * @method onTowerControllerChange
+     * @param isAutoTower {boolean}
+     */
+    onTowerControllerChange(isAutoTower) {
+        if (this._isUnderTowerControl()) {
+            this.isControllable = !isAutoTower;
+        }
+    }
+
+    /**
      * Returns the distance to another aircraft in nm
      *
      * @for AircraftModel

--- a/src/assets/scripts/client/aircraft/AircraftModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftModel.js
@@ -1317,14 +1317,17 @@ export default class AircraftModel {
      * @for AircraftModel
      * @method takeoff
      * @param runway {RunwayModel} the runway taking off on
+     * @param byAutoTower {boolean}
      */
-    takeoff(runway) {
+    takeoff(runway, byAutoTower = false) {
         const cruiseSpeed = this.model.speed.cruise;
         const initialAltitude = this.fms.getInitialClimbClearance();
 
         this._prepareMcpForTakeoff(initialAltitude, runway.angle, cruiseSpeed);
         this.setFlightPhase(FLIGHT_PHASE.TAKEOFF);
-        EventBus.trigger(AIRCRAFT_EVENT.TAKEOFF, this, runway);
+        if (!byAutoTower) {
+            EventBus.trigger(AIRCRAFT_EVENT.TAKEOFF, this, runway);
+        }
 
         this.takeoffTime = TimeKeeper.accumulatedDeltaTime;
         runway.lastDepartedAircraftModel = this;
@@ -1528,7 +1531,7 @@ export default class AircraftModel {
                     }
 
                     runway.removeAircraftFromQueue(this.id);
-                    this.takeoff(runway);
+                    this.takeoff(runway, true);
                     this.tookOffUnderAutoTowerControl = true;
                 }
 

--- a/src/assets/scripts/client/aircraft/AircraftModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftModel.js
@@ -93,7 +93,8 @@ const AUTOTOWER_FLIGHT_PHASES = [
     FLIGHT_PHASE.APRON,
     FLIGHT_PHASE.TAXI,
     FLIGHT_PHASE.WAITING,
-    FLIGHT_PHASE.TAKEOFF
+    FLIGHT_PHASE.TAKEOFF,
+    FLIGHT_PHASE.LANDING
 ];
 
 /**
@@ -1585,8 +1586,21 @@ export default class AircraftModel {
 
                 this.setFlightPhase(FLIGHT_PHASE.LANDING);
 
-                if (!this.projected) {
-                    EventBus.trigger(AIRCRAFT_EVENT.FINAL_APPROACH, this, this.fms.arrivalRunwayModel);
+                if (this.projected) {
+                    break;
+                }
+
+                EventBus.trigger(AIRCRAFT_EVENT.FINAL_APPROACH, this, this.fms.arrivalRunwayModel);
+
+                if (isAutoTower) {
+                    UiController.ui_log(`${this.callsign} switching to tower, good day`);
+                    speech_say(
+                        [
+                            { type: 'callsign', content: this },
+                            { type: 'text', content: ', switching to tower, good day' }
+                        ],
+                        this.pilotVoice
+                    );
                 }
 
                 break;
@@ -2774,7 +2788,9 @@ export default class AircraftModel {
         }
 
         this.setIsRemovable();
-        EventBus.trigger(AIRCRAFT_EVENT.AIRSPACE_EXIT, this);
+        if (this.flightPhase !== FLIGHT_PHASE.LANDING) {
+            EventBus.trigger(AIRCRAFT_EVENT.AIRSPACE_EXIT, this);
+        }
     }
 
     /**

--- a/src/assets/scripts/client/aircraft/AircraftModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftModel.js
@@ -669,9 +669,6 @@ export default class AircraftModel {
         this.target.altitude = this.altitude;
         this.targetHeading = this.heading;
         this.target.speed = this.speed;
-
-        // This assumes and arrival spawns outside the airspace
-        this.isControllable = data.category === FLIGHT_CATEGORY.DEPARTURE;
     }
 
     /**

--- a/src/assets/scripts/client/aircraft/AircraftModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftModel.js
@@ -1219,6 +1219,8 @@ export default class AircraftModel {
         let alt_say;
 
         if (this.isAirborne()) {
+            const controller = this.isDeparture() ?
+                AirportController.airport_get().radio.dep : AirportController.airport_get().radio.app;
             const altdiff = this.altitude - this.mcp.altitude;
             const alt = digits_decimal(this.altitude, -2);
 
@@ -1235,10 +1237,10 @@ export default class AircraftModel {
                 alt_say = `at ${radio_altitude(alt)}`;
             }
 
-            UiController.ui_log(`${AirportController.airport_get().radio.app}, ${this.callsign} with you ${alt_log}`);
+            UiController.ui_log(`${controller}, ${this.callsign} with you ${alt_log}`);
             speech_say(
                 [
-                    { type: 'text', content: `${AirportController.airport_get().radio.app}, ` },
+                    { type: 'text', content: `${controller}, ` },
                     { type: 'callsign', content: this },
                     { type: 'text', content: `with you ${alt_say}` }
                 ],

--- a/src/assets/scripts/client/aircraft/StripView/StripViewController.js
+++ b/src/assets/scripts/client/aircraft/StripView/StripViewController.js
@@ -157,8 +157,6 @@ export default class StripViewController {
 
             let stripViewModel = this._collection.findStripByAircraftId(aircraftModel.id);
 
-            // Here we create the StripViewModel for ARRIVALS at the moment they become
-            // "controllable". By contrast, departure strips are created immediately.
             if (typeof stripViewModel === 'undefined') {
                 stripViewModel = this.createStripView(aircraftModel);
             }
@@ -181,7 +179,7 @@ export default class StripViewController {
 
         this._collection.addItem(stripViewModel);
 
-        if (aircraftModel.isDeparture() || aircraftModel.isControllable) {
+        if (aircraftModel.isControllable) {
             this._addViewToStripList(stripViewModel);
         }
 

--- a/src/assets/scripts/client/constants/eventNames.js
+++ b/src/assets/scripts/client/constants/eventNames.js
@@ -181,6 +181,15 @@ export const EVENT = {
     SET_THEME: 'set-theme',
 
     /**
+     * Change in tower control setting
+     *
+     * @memberof EVENT
+     * @property TOWER_CONTROLLER_CHANGE
+     * @type {string}
+     */
+    TOWER_CONTROLLER_CHANGE: 'tower-controller-change',
+
+    /**
      * Step through pre-defined timewarp speeds
      *
      * @memberof EVENT

--- a/src/assets/scripts/client/constants/gameOptionConstants.js
+++ b/src/assets/scripts/client/constants/gameOptionConstants.js
@@ -59,7 +59,7 @@ export const GAME_OPTION_VALUES = [
         defaultValue: 'SYSTEM',
         description: 'Tower Control (Experimental)',
         type: 'select',
-        onChangeEventHandler: null,
+        onChangeEventHandler: EVENT.TOWER_CONTROLLER_CHANGE,
         optionList: [
             {
                 displayLabel: 'System Controlled',

--- a/src/assets/scripts/client/game/GameController.js
+++ b/src/assets/scripts/client/game/GameController.js
@@ -562,6 +562,16 @@ class GameController {
     }
 
     /**
+     * Check whether the auto tower game option is activated.
+     * @for GameController
+     * @method isAutoTower
+     * @return {boolean}
+     */
+    isAutoTower() {
+        return this.getGameOption(GAME_OPTION_NAMES.TOWER_CONTROLLER) === 'SYSTEM';
+    }
+
+    /**
      * Check whether or not the trailing distance separator should be drawn.
      *
      * Used by the `CanvasController` to determine whether or not to proceed with

--- a/src/assets/scripts/client/game/ScoreController.js
+++ b/src/assets/scripts/client/game/ScoreController.js
@@ -189,7 +189,7 @@ export default class ScoreController {
         const previousAircraft = runwayModel.lastDepartedAircraftModel;
 
         // do not penalize departures launched automatically; only those launched by the user
-        if (!previousAircraft || previousAircraft.shouldTakeOffWhenRunwayIsClear) {
+        if (!previousAircraft || previousAircraft.tookOffUnderAutoTowerControl) {
             return;
         }
 

--- a/src/assets/scripts/client/game/ScoreController.js
+++ b/src/assets/scripts/client/game/ScoreController.js
@@ -36,6 +36,7 @@ export default class ScoreController {
      * @chainable
      */
     setupHandlers() {
+        this._onTakeoffHandler = this._onTakeoff.bind(this);
         this._onApproachHandler = this._onApproach.bind(this);
         this._onLandingHandler = this._onLanding.bind(this);
         this._onExitAirspaceHandler = this._onExitAirspace.bind(this);
@@ -49,6 +50,7 @@ export default class ScoreController {
      * @chainable
      */
     enable() {
+        EventBus.on(AIRCRAFT_EVENT.TAKEOFF, this._onTakeoffHandler);
         EventBus.on(AIRCRAFT_EVENT.APPROACH, this._onApproachHandler);
         EventBus.on(AIRCRAFT_EVENT.FULLSTOP, this._onLandingHandler);
         EventBus.on(AIRCRAFT_EVENT.AIRSPACE_EXIT, this._onExitAirspaceHandler);
@@ -62,11 +64,23 @@ export default class ScoreController {
      * @chainable
      */
     disable() {
+        EventBus.off(AIRCRAFT_EVENT.TAKEOFF, this._onTakeoffHandler);
         EventBus.off(AIRCRAFT_EVENT.APPROACH, this._onApproachHandler);
         EventBus.off(AIRCRAFT_EVENT.FULLSTOP, this._onLandingHandler);
         EventBus.off(AIRCRAFT_EVENT.AIRSPACE_EXIT, this._onExitAirspaceHandler);
 
         return this;
+    }
+
+    /**
+     * @for ScoreController
+     * @method _onTakeoff
+     * @param aircraftModel {AircraftModel}
+     * @param runwayModel {RunwayModel}
+     */
+    _onTakeoff(aircraftModel, runwayModel) {
+        this._scoreWind(aircraftModel, 'taking off');
+        this._scoreRunwaySeparation(aircraftModel, runwayModel, 'taking off');
     }
 
     /**


### PR DESCRIPTION
Resolves #2050

- When tower control set to system, user (TRACON) does not have control over acft on tower frequency
- Reinstate scoring of takeoffs for when tower control set to user
- Automatic departures: aircraft no longer predestined to automatically take off upon spawning, will instead make the decision when they are at front of queue and runway is clear and tower control is set to system at that point in time.

Resolves #2049

- Fix missing "ready to taxi" call up from spawning departures (when tower control set to user)
